### PR TITLE
Updates through version 7.60

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4.1")]
-[assembly: AssemblyFileVersion("1.0.4.1")]
+[assembly: AssemblyVersion("2.0.1.5")]
+[assembly: AssemblyFileVersion("2.0.1.5")]

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.6")]
+[assembly: AssemblyVersion("1.0.4.1")]
+[assembly: AssemblyFileVersion("1.0.4.1")]

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RC210_DataAssistant_V2")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RC210_DataAssistant_V2")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("30e51741-5905-4e1c-ac37-b057f22865df")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.2.5")]
+[assembly: AssemblyFileVersion("1.0.2.5")]

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("RC210_DataAssistant_V2")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.5")]
-[assembly: AssemblyFileVersion("1.0.2.5")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.6")]

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -85,6 +85,7 @@
 			this.macroDefinitionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.versionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.updateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.xMLFilePathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.reportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.generateReportToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
 			this.viewReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -617,10 +618,10 @@
 			// menuStrip1
 			// 
 			this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem,
-            this.optionsToolStripMenuItem,
-            this.reportToolStripMenuItem,
-            this.aboutToolStripMenuItem});
+            		this.fileToolStripMenuItem,
+            		this.optionsToolStripMenuItem,
+            		this.reportToolStripMenuItem,
+            		this.aboutToolStripMenuItem});
 			this.menuStrip1.Location = new System.Drawing.Point(0, 0);
 			this.menuStrip1.Name = "menuStrip1";
 			this.menuStrip1.Size = new System.Drawing.Size(650, 24);
@@ -630,8 +631,8 @@
 			// fileToolStripMenuItem
 			// 
 			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openToolStripMenuItem,
-            this.closeToolStripMenuItem});
+            		this.openToolStripMenuItem,
+            		this.closeToolStripMenuItem});
 			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
 			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
 			this.fileToolStripMenuItem.Text = "&File";
@@ -653,12 +654,13 @@
 			// optionsToolStripMenuItem
 			// 
 			this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.saveToolStripMenuItem,
-            this.resetToolStripMenuItem,
-            this.recallToolStripMenuItem,
-            this.toolStripMenuItem1,
-            this.portNamesToolStripMenuItem,
-            this.macroDefinitionsToolStripMenuItem});
+            		this.saveToolStripMenuItem,
+            		this.resetToolStripMenuItem,
+            		this.recallToolStripMenuItem,
+            		this.toolStripMenuItem1,
+            		this.portNamesToolStripMenuItem,
+            		this.macroDefinitionsToolStripMenuItem,
+			this.xMLFilePathToolStripMenuItem});
 			this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
 			this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
 			this.optionsToolStripMenuItem.Text = "&Options";
@@ -692,9 +694,9 @@
 			// portNamesToolStripMenuItem
 			// 
 			this.portNamesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.port1ToolStripMenuItem,
-            this.port2ToolStripMenuItem,
-            this.port3ToolStripMenuItem});
+            		this.port1ToolStripMenuItem,
+            		this.port2ToolStripMenuItem,
+            		this.port3ToolStripMenuItem});
 			this.portNamesToolStripMenuItem.Name = "portNamesToolStripMenuItem";
 			this.portNamesToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
 			this.portNamesToolStripMenuItem.Text = "Port Names";
@@ -723,8 +725,8 @@
 			// macroDefinitionsToolStripMenuItem
 			// 
 			this.macroDefinitionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.versionToolStripMenuItem,
-            this.updateToolStripMenuItem});
+            		this.versionToolStripMenuItem,
+            		this.updateToolStripMenuItem});
 			this.macroDefinitionsToolStripMenuItem.Name = "macroDefinitionsToolStripMenuItem";
 			this.macroDefinitionsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
 			this.macroDefinitionsToolStripMenuItem.Text = "Macro Definitions";
@@ -743,12 +745,19 @@
 			this.updateToolStripMenuItem.Text = "Update";
 			this.updateToolStripMenuItem.Click += new System.EventHandler(this.UpdateToolStripMenuItem_Click);
 			// 
+			// xMLFilePathToolStripMenuItem
+			// 
+			this.xMLFilePathToolStripMenuItem.Name = "xMLFilePathToolStripMenuItem";
+			this.xMLFilePathToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+			this.xMLFilePathToolStripMenuItem.Text = "xMLFilePath";
+			this.xMLFilePathToolStripMenuItem.Click += new System.EventHandler(this.UpdateToolStripMenuItem_Click);
+			//
 			// reportToolStripMenuItem
 			// 
 			this.reportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.generateReportToolStripMenuItem1,
-            this.viewReportToolStripMenuItem,
-            this.openReportFolderToolStripMenuItem});
+            		this.generateReportToolStripMenuItem1,
+            		this.viewReportToolStripMenuItem,
+            		this.openReportFolderToolStripMenuItem});
 			this.reportToolStripMenuItem.Name = "reportToolStripMenuItem";
 			this.reportToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
 			this.reportToolStripMenuItem.Text = "&Report";
@@ -844,9 +853,7 @@
 			// 
 			this.checkBox_RTCOption.AutoSize = true;
 			this.checkBox_RTCOption.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RTCOption;
-			this.checkBox_RTCOption.CheckState = System.Windows.Forms.CheckState.Unchecked;
 			this.checkBox_RTCOption.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RTCOption", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_RTCOption.Enabled = true;
 			this.checkBox_RTCOption.Location = new System.Drawing.Point(192, 21);
 			this.checkBox_RTCOption.Name = "checkBox_RTCOption";
 			this.checkBox_RTCOption.Size = new System.Drawing.Size(133, 17);
@@ -981,6 +988,7 @@
 		private System.Windows.Forms.ToolStripMenuItem macroDefinitionsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem versionToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem updateToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem xzMLFilePathToolStripMenuItem;
 	}
 }
 

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -988,7 +988,7 @@
 		private System.Windows.Forms.ToolStripMenuItem macroDefinitionsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem versionToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem updateToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem xzMLFilePathToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem xMLFilePathToolStripMenuItem;
 	}
 }
 

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -28,892 +28,885 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.groupBox_Port1 = new System.Windows.Forms.GroupBox();
-            this.checkBox_P1Switches = new System.Windows.Forms.CheckBox();
-            this.checkBox_P1Timers = new System.Windows.Forms.CheckBox();
-            this.checkBox_P1TailMessages = new System.Windows.Forms.CheckBox();
-            this.checkBox_P1UnlockCode = new System.Windows.Forms.CheckBox();
-            this.checkBox_P1IDs = new System.Windows.Forms.CheckBox();
-            this.groupBox_Port2 = new System.Windows.Forms.GroupBox();
-            this.checkBox_P2Switches = new System.Windows.Forms.CheckBox();
-            this.checkBox_P2Timers = new System.Windows.Forms.CheckBox();
-            this.checkBox_P2TailMessages = new System.Windows.Forms.CheckBox();
-            this.checkBox_P2UnlockCode = new System.Windows.Forms.CheckBox();
-            this.checkBox_P2IDs = new System.Windows.Forms.CheckBox();
-            this.groupBox_Port3 = new System.Windows.Forms.GroupBox();
-            this.checkBox_P3Switches = new System.Windows.Forms.CheckBox();
-            this.checkBox_P3Timers = new System.Windows.Forms.CheckBox();
-            this.checkBox_P3TailMessages = new System.Windows.Forms.CheckBox();
-            this.checkBox_P3UnlockCode = new System.Windows.Forms.CheckBox();
-            this.checkBox_P3IDs = new System.Windows.Forms.CheckBox();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.checkBox_CTMessageMacros = new System.Windows.Forms.CheckBox();
-            this.checkBox_MessageMacros = new System.Windows.Forms.CheckBox();
-            this.checkBox_MacroCodes = new System.Windows.Forms.CheckBox();
-            this.checkBox_Macros = new System.Windows.Forms.CheckBox();
-            this.groupBox6 = new System.Windows.Forms.GroupBox();
-            this.checkBox_PreAccessPrefix = new System.Windows.Forms.CheckBox();
-            this.checkBox_RemoteBaseMemories = new System.Windows.Forms.CheckBox();
-            this.checkBox_GeneralTimers = new System.Windows.Forms.CheckBox();
-            this.checkBox_Alarms = new System.Windows.Forms.CheckBox();
-            this.checkBox_AnalogMeters = new System.Windows.Forms.CheckBox();
-            this.checkBox_SetpointsScheduler = new System.Windows.Forms.CheckBox();
-            this.checkBox_GlobalLockCode = new System.Windows.Forms.CheckBox();
-            this.checkBox_TerminatorDigit = new System.Windows.Forms.CheckBox();
-            this.groupBox7 = new System.Windows.Forms.GroupBox();
-            this.checkBox_DTMFMemories = new System.Windows.Forms.CheckBox();
-            this.checkBox_DTMFTestPadCode = new System.Windows.Forms.CheckBox();
-            this.groupBox8 = new System.Windows.Forms.GroupBox();
-            this.checkBox_APSettings = new System.Windows.Forms.CheckBox();
-            this.checkBox_APMemories = new System.Windows.Forms.CheckBox();
-            this.checkBox_APPrefix = new System.Windows.Forms.CheckBox();
-            this.checkBox_APAnswerCode = new System.Windows.Forms.CheckBox();
-            this.checkBox_APTollRestrictions = new System.Windows.Forms.CheckBox();
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.recallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-            this.portNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.port1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.port2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.port3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.macroDefinitionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.versionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.updateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.xMLFilePathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.reportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateReportToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.viewReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openReportFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.checkBox_CustomHeader = new System.Windows.Forms.CheckBox();
-            this.checkBox_DateHeader = new System.Windows.Forms.CheckBox();
-            this.textBox_CustomHeader = new System.Windows.Forms.TextBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.checkBox_RTCOption = new System.Windows.Forms.CheckBox();
-            this.comboBox_FwVersion = new System.Windows.Forms.ComboBox();
-            this.groupBox_Port1.SuspendLayout();
-            this.groupBox_Port2.SuspendLayout();
-            this.groupBox_Port3.SuspendLayout();
-            this.groupBox4.SuspendLayout();
-            this.groupBox6.SuspendLayout();
-            this.groupBox7.SuspendLayout();
-            this.groupBox8.SuspendLayout();
-            this.menuStrip1.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // groupBox_Port1
-            // 
-            this.groupBox_Port1.Controls.Add(this.checkBox_P1Switches);
-            this.groupBox_Port1.Controls.Add(this.checkBox_P1Timers);
-            this.groupBox_Port1.Controls.Add(this.checkBox_P1TailMessages);
-            this.groupBox_Port1.Controls.Add(this.checkBox_P1UnlockCode);
-            this.groupBox_Port1.Controls.Add(this.checkBox_P1IDs);
-            this.groupBox_Port1.Location = new System.Drawing.Point(12, 27);
-            this.groupBox_Port1.Name = "groupBox_Port1";
-            this.groupBox_Port1.Size = new System.Drawing.Size(331, 44);
-            this.groupBox_Port1.TabIndex = 3;
-            this.groupBox_Port1.TabStop = false;
-            this.groupBox_Port1.Text = "Port 1";
-            // 
-            // checkBox_P1Switches
-            // 
-            this.checkBox_P1Switches.AutoSize = true;
-            this.checkBox_P1Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Switches;
-            this.checkBox_P1Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P1Switches.Location = new System.Drawing.Point(252, 20);
-            this.checkBox_P1Switches.Name = "checkBox_P1Switches";
-            this.checkBox_P1Switches.Size = new System.Drawing.Size(69, 17);
-            this.checkBox_P1Switches.TabIndex = 5;
-            this.checkBox_P1Switches.Text = "Switches";
-            this.checkBox_P1Switches.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P1Timers
-            // 
-            this.checkBox_P1Timers.AutoSize = true;
-            this.checkBox_P1Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Timers;
-            this.checkBox_P1Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P1Timers.Location = new System.Drawing.Point(188, 19);
-            this.checkBox_P1Timers.Name = "checkBox_P1Timers";
-            this.checkBox_P1Timers.Size = new System.Drawing.Size(57, 17);
-            this.checkBox_P1Timers.TabIndex = 4;
-            this.checkBox_P1Timers.Text = "Timers";
-            this.checkBox_P1Timers.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P1TailMessages
-            // 
-            this.checkBox_P1TailMessages.AutoSize = true;
-            this.checkBox_P1TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1TailMsgs;
-            this.checkBox_P1TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P1TailMessages.Location = new System.Drawing.Point(111, 19);
-            this.checkBox_P1TailMessages.Name = "checkBox_P1TailMessages";
-            this.checkBox_P1TailMessages.Size = new System.Drawing.Size(71, 17);
-            this.checkBox_P1TailMessages.TabIndex = 4;
-            this.checkBox_P1TailMessages.Text = "Tail Msgs";
-            this.checkBox_P1TailMessages.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P1UnlockCode
-            // 
-            this.checkBox_P1UnlockCode.AutoSize = true;
-            this.checkBox_P1UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1UnlockCode;
-            this.checkBox_P1UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P1UnlockCode.Location = new System.Drawing.Point(6, 19);
-            this.checkBox_P1UnlockCode.Name = "checkBox_P1UnlockCode";
-            this.checkBox_P1UnlockCode.Size = new System.Drawing.Size(51, 17);
-            this.checkBox_P1UnlockCode.TabIndex = 4;
-            this.checkBox_P1UnlockCode.Text = "Code";
-            this.checkBox_P1UnlockCode.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P1IDs
-            // 
-            this.checkBox_P1IDs.AutoSize = true;
-            this.checkBox_P1IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1IDs;
-            this.checkBox_P1IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P1IDs.Location = new System.Drawing.Point(63, 19);
-            this.checkBox_P1IDs.Name = "checkBox_P1IDs";
-            this.checkBox_P1IDs.Size = new System.Drawing.Size(42, 17);
-            this.checkBox_P1IDs.TabIndex = 4;
-            this.checkBox_P1IDs.Text = "IDs";
-            this.checkBox_P1IDs.UseVisualStyleBackColor = true;
-            // 
-            // groupBox_Port2
-            // 
-            this.groupBox_Port2.Controls.Add(this.checkBox_P2Switches);
-            this.groupBox_Port2.Controls.Add(this.checkBox_P2Timers);
-            this.groupBox_Port2.Controls.Add(this.checkBox_P2TailMessages);
-            this.groupBox_Port2.Controls.Add(this.checkBox_P2UnlockCode);
-            this.groupBox_Port2.Controls.Add(this.checkBox_P2IDs);
-            this.groupBox_Port2.Location = new System.Drawing.Point(12, 77);
-            this.groupBox_Port2.Name = "groupBox_Port2";
-            this.groupBox_Port2.Size = new System.Drawing.Size(331, 44);
-            this.groupBox_Port2.TabIndex = 3;
-            this.groupBox_Port2.TabStop = false;
-            this.groupBox_Port2.Text = "Port 2";
-            // 
-            // checkBox_P2Switches
-            // 
-            this.checkBox_P2Switches.AutoSize = true;
-            this.checkBox_P2Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Switches;
-            this.checkBox_P2Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P2Switches.Location = new System.Drawing.Point(252, 19);
-            this.checkBox_P2Switches.Name = "checkBox_P2Switches";
-            this.checkBox_P2Switches.Size = new System.Drawing.Size(69, 17);
-            this.checkBox_P2Switches.TabIndex = 5;
-            this.checkBox_P2Switches.Text = "Switches";
-            this.checkBox_P2Switches.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P2Timers
-            // 
-            this.checkBox_P2Timers.AutoSize = true;
-            this.checkBox_P2Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Timers;
-            this.checkBox_P2Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P2Timers.Location = new System.Drawing.Point(188, 19);
-            this.checkBox_P2Timers.Name = "checkBox_P2Timers";
-            this.checkBox_P2Timers.Size = new System.Drawing.Size(57, 17);
-            this.checkBox_P2Timers.TabIndex = 4;
-            this.checkBox_P2Timers.Text = "Timers";
-            this.checkBox_P2Timers.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P2TailMessages
-            // 
-            this.checkBox_P2TailMessages.AutoSize = true;
-            this.checkBox_P2TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2TailMsgs;
-            this.checkBox_P2TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P2TailMessages.Location = new System.Drawing.Point(111, 19);
-            this.checkBox_P2TailMessages.Name = "checkBox_P2TailMessages";
-            this.checkBox_P2TailMessages.Size = new System.Drawing.Size(71, 17);
-            this.checkBox_P2TailMessages.TabIndex = 4;
-            this.checkBox_P2TailMessages.Text = "Tail Msgs";
-            this.checkBox_P2TailMessages.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P2UnlockCode
-            // 
-            this.checkBox_P2UnlockCode.AutoSize = true;
-            this.checkBox_P2UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2UnlockCode;
-            this.checkBox_P2UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P2UnlockCode.Location = new System.Drawing.Point(6, 19);
-            this.checkBox_P2UnlockCode.Name = "checkBox_P2UnlockCode";
-            this.checkBox_P2UnlockCode.Size = new System.Drawing.Size(51, 17);
-            this.checkBox_P2UnlockCode.TabIndex = 4;
-            this.checkBox_P2UnlockCode.Text = "Code";
-            this.checkBox_P2UnlockCode.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P2IDs
-            // 
-            this.checkBox_P2IDs.AutoSize = true;
-            this.checkBox_P2IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2IDs;
-            this.checkBox_P2IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P2IDs.Location = new System.Drawing.Point(63, 19);
-            this.checkBox_P2IDs.Name = "checkBox_P2IDs";
-            this.checkBox_P2IDs.Size = new System.Drawing.Size(42, 17);
-            this.checkBox_P2IDs.TabIndex = 4;
-            this.checkBox_P2IDs.Text = "IDs";
-            this.checkBox_P2IDs.UseVisualStyleBackColor = true;
-            // 
-            // groupBox_Port3
-            // 
-            this.groupBox_Port3.Controls.Add(this.checkBox_P3Switches);
-            this.groupBox_Port3.Controls.Add(this.checkBox_P3Timers);
-            this.groupBox_Port3.Controls.Add(this.checkBox_P3TailMessages);
-            this.groupBox_Port3.Controls.Add(this.checkBox_P3UnlockCode);
-            this.groupBox_Port3.Controls.Add(this.checkBox_P3IDs);
-            this.groupBox_Port3.Location = new System.Drawing.Point(12, 127);
-            this.groupBox_Port3.Name = "groupBox_Port3";
-            this.groupBox_Port3.Size = new System.Drawing.Size(331, 44);
-            this.groupBox_Port3.TabIndex = 3;
-            this.groupBox_Port3.TabStop = false;
-            this.groupBox_Port3.Text = "Port 3";
-            // 
-            // checkBox_P3Switches
-            // 
-            this.checkBox_P3Switches.AutoSize = true;
-            this.checkBox_P3Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Switches;
-            this.checkBox_P3Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P3Switches.Location = new System.Drawing.Point(252, 19);
-            this.checkBox_P3Switches.Name = "checkBox_P3Switches";
-            this.checkBox_P3Switches.Size = new System.Drawing.Size(69, 17);
-            this.checkBox_P3Switches.TabIndex = 5;
-            this.checkBox_P3Switches.Text = "Switches";
-            this.checkBox_P3Switches.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P3Timers
-            // 
-            this.checkBox_P3Timers.AutoSize = true;
-            this.checkBox_P3Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Timers;
-            this.checkBox_P3Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P3Timers.Location = new System.Drawing.Point(188, 19);
-            this.checkBox_P3Timers.Name = "checkBox_P3Timers";
-            this.checkBox_P3Timers.Size = new System.Drawing.Size(57, 17);
-            this.checkBox_P3Timers.TabIndex = 4;
-            this.checkBox_P3Timers.Text = "Timers";
-            this.checkBox_P3Timers.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P3TailMessages
-            // 
-            this.checkBox_P3TailMessages.AutoSize = true;
-            this.checkBox_P3TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3TailMsgs;
-            this.checkBox_P3TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P3TailMessages.Location = new System.Drawing.Point(111, 19);
-            this.checkBox_P3TailMessages.Name = "checkBox_P3TailMessages";
-            this.checkBox_P3TailMessages.Size = new System.Drawing.Size(71, 17);
-            this.checkBox_P3TailMessages.TabIndex = 4;
-            this.checkBox_P3TailMessages.Text = "Tail Msgs";
-            this.checkBox_P3TailMessages.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P3UnlockCode
-            // 
-            this.checkBox_P3UnlockCode.AutoSize = true;
-            this.checkBox_P3UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3UnlockCode;
-            this.checkBox_P3UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P3UnlockCode.Location = new System.Drawing.Point(6, 19);
-            this.checkBox_P3UnlockCode.Name = "checkBox_P3UnlockCode";
-            this.checkBox_P3UnlockCode.Size = new System.Drawing.Size(51, 17);
-            this.checkBox_P3UnlockCode.TabIndex = 4;
-            this.checkBox_P3UnlockCode.Text = "Code";
-            this.checkBox_P3UnlockCode.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_P3IDs
-            // 
-            this.checkBox_P3IDs.AutoSize = true;
-            this.checkBox_P3IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3IDs;
-            this.checkBox_P3IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_P3IDs.Location = new System.Drawing.Point(63, 19);
-            this.checkBox_P3IDs.Name = "checkBox_P3IDs";
-            this.checkBox_P3IDs.Size = new System.Drawing.Size(42, 17);
-            this.checkBox_P3IDs.TabIndex = 4;
-            this.checkBox_P3IDs.Text = "IDs";
-            this.checkBox_P3IDs.UseVisualStyleBackColor = true;
-            // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.checkBox_CTMessageMacros);
-            this.groupBox4.Controls.Add(this.checkBox_MessageMacros);
-            this.groupBox4.Controls.Add(this.checkBox_MacroCodes);
-            this.groupBox4.Controls.Add(this.checkBox_Macros);
-            this.groupBox4.Location = new System.Drawing.Point(349, 27);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(136, 144);
-            this.groupBox4.TabIndex = 6;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Macros";
-            // 
-            // checkBox_CTMessageMacros
-            // 
-            this.checkBox_CTMessageMacros.AutoSize = true;
-            this.checkBox_CTMessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CTMessageMacros;
-            this.checkBox_CTMessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CTMessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_CTMessageMacros.Location = new System.Drawing.Point(6, 88);
-            this.checkBox_CTMessageMacros.Name = "checkBox_CTMessageMacros";
-            this.checkBox_CTMessageMacros.Size = new System.Drawing.Size(124, 17);
-            this.checkBox_CTMessageMacros.TabIndex = 4;
-            this.checkBox_CTMessageMacros.Text = "CT Message Macros";
-            this.checkBox_CTMessageMacros.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_MessageMacros
-            // 
-            this.checkBox_MessageMacros.AutoSize = true;
-            this.checkBox_MessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MessageMacros;
-            this.checkBox_MessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_MessageMacros.Location = new System.Drawing.Point(6, 65);
-            this.checkBox_MessageMacros.Name = "checkBox_MessageMacros";
-            this.checkBox_MessageMacros.Size = new System.Drawing.Size(107, 17);
-            this.checkBox_MessageMacros.TabIndex = 4;
-            this.checkBox_MessageMacros.Text = "Message Macros";
-            this.checkBox_MessageMacros.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_MacroCodes
-            // 
-            this.checkBox_MacroCodes.AutoSize = true;
-            this.checkBox_MacroCodes.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MacroCodes;
-            this.checkBox_MacroCodes.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MacroCodes", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_MacroCodes.Location = new System.Drawing.Point(6, 42);
-            this.checkBox_MacroCodes.Name = "checkBox_MacroCodes";
-            this.checkBox_MacroCodes.Size = new System.Drawing.Size(119, 17);
-            this.checkBox_MacroCodes.TabIndex = 4;
-            this.checkBox_MacroCodes.Text = "Show Macro Codes";
-            this.checkBox_MacroCodes.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_Macros
-            // 
-            this.checkBox_Macros.AutoSize = true;
-            this.checkBox_Macros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Macros;
-            this.checkBox_Macros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Macros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_Macros.Location = new System.Drawing.Point(6, 19);
-            this.checkBox_Macros.Name = "checkBox_Macros";
-            this.checkBox_Macros.Size = new System.Drawing.Size(61, 17);
-            this.checkBox_Macros.TabIndex = 4;
-            this.checkBox_Macros.Text = "Macros";
-            this.checkBox_Macros.UseVisualStyleBackColor = true;
-            // 
-            // groupBox6
-            // 
-            this.groupBox6.Controls.Add(this.checkBox_PreAccessPrefix);
-            this.groupBox6.Controls.Add(this.checkBox_RemoteBaseMemories);
-            this.groupBox6.Controls.Add(this.checkBox_GeneralTimers);
-            this.groupBox6.Controls.Add(this.checkBox_Alarms);
-            this.groupBox6.Controls.Add(this.checkBox_AnalogMeters);
-            this.groupBox6.Controls.Add(this.checkBox_SetpointsScheduler);
-            this.groupBox6.Controls.Add(this.checkBox_GlobalLockCode);
-            this.groupBox6.Controls.Add(this.checkBox_TerminatorDigit);
-            this.groupBox6.Location = new System.Drawing.Point(491, 27);
-            this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(146, 209);
-            this.groupBox6.TabIndex = 6;
-            this.groupBox6.TabStop = false;
-            this.groupBox6.Text = "Misc";
-            // 
-            // checkBox_PreAccessPrefix
-            // 
-            this.checkBox_PreAccessPrefix.AutoSize = true;
-            this.checkBox_PreAccessPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.PreAccessPrefix;
-            this.checkBox_PreAccessPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "PreAccessPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_PreAccessPrefix.Location = new System.Drawing.Point(5, 19);
-            this.checkBox_PreAccessPrefix.Name = "checkBox_PreAccessPrefix";
-            this.checkBox_PreAccessPrefix.Size = new System.Drawing.Size(106, 17);
-            this.checkBox_PreAccessPrefix.TabIndex = 5;
-            this.checkBox_PreAccessPrefix.Text = "PreAccess Prefix";
-            this.checkBox_PreAccessPrefix.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_RemoteBaseMemories
-            // 
-            this.checkBox_RemoteBaseMemories.AutoSize = true;
-            this.checkBox_RemoteBaseMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RemoteBaseMemories;
-            this.checkBox_RemoteBaseMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RemoteBaseMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_RemoteBaseMemories.Location = new System.Drawing.Point(5, 180);
-            this.checkBox_RemoteBaseMemories.Name = "checkBox_RemoteBaseMemories";
-            this.checkBox_RemoteBaseMemories.Size = new System.Drawing.Size(138, 17);
-            this.checkBox_RemoteBaseMemories.TabIndex = 4;
-            this.checkBox_RemoteBaseMemories.Text = "Remote Base Memories";
-            this.checkBox_RemoteBaseMemories.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_GeneralTimers
-            // 
-            this.checkBox_GeneralTimers.AutoSize = true;
-            this.checkBox_GeneralTimers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GeneralTimers;
-            this.checkBox_GeneralTimers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GeneralTimers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_GeneralTimers.Location = new System.Drawing.Point(6, 157);
-            this.checkBox_GeneralTimers.Name = "checkBox_GeneralTimers";
-            this.checkBox_GeneralTimers.Size = new System.Drawing.Size(97, 17);
-            this.checkBox_GeneralTimers.TabIndex = 4;
-            this.checkBox_GeneralTimers.Text = "General Timers";
-            this.checkBox_GeneralTimers.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_Alarms
-            // 
-            this.checkBox_Alarms.AutoSize = true;
-            this.checkBox_Alarms.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Alarms;
-            this.checkBox_Alarms.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Alarms", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_Alarms.Location = new System.Drawing.Point(6, 134);
-            this.checkBox_Alarms.Name = "checkBox_Alarms";
-            this.checkBox_Alarms.Size = new System.Drawing.Size(57, 17);
-            this.checkBox_Alarms.TabIndex = 4;
-            this.checkBox_Alarms.Text = "Alarms";
-            this.checkBox_Alarms.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_AnalogMeters
-            // 
-            this.checkBox_AnalogMeters.AutoSize = true;
-            this.checkBox_AnalogMeters.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.AnalogMeters;
-            this.checkBox_AnalogMeters.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "AnalogMeters", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_AnalogMeters.Location = new System.Drawing.Point(6, 111);
-            this.checkBox_AnalogMeters.Name = "checkBox_AnalogMeters";
-            this.checkBox_AnalogMeters.Size = new System.Drawing.Size(94, 17);
-            this.checkBox_AnalogMeters.TabIndex = 4;
-            this.checkBox_AnalogMeters.Text = "Analog Meters";
-            this.checkBox_AnalogMeters.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_SetpointsScheduler
-            // 
-            this.checkBox_SetpointsScheduler.AutoSize = true;
-            this.checkBox_SetpointsScheduler.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.SetpointsScheduler;
-            this.checkBox_SetpointsScheduler.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "SetpointsScheduler", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_SetpointsScheduler.Location = new System.Drawing.Point(6, 88);
-            this.checkBox_SetpointsScheduler.Name = "checkBox_SetpointsScheduler";
-            this.checkBox_SetpointsScheduler.Size = new System.Drawing.Size(123, 17);
-            this.checkBox_SetpointsScheduler.TabIndex = 4;
-            this.checkBox_SetpointsScheduler.Text = "Setpoints/Scheduler";
-            this.checkBox_SetpointsScheduler.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_GlobalLockCode
-            // 
-            this.checkBox_GlobalLockCode.AutoSize = true;
-            this.checkBox_GlobalLockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GlobalLockCode;
-            this.checkBox_GlobalLockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GlobalLockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_GlobalLockCode.Location = new System.Drawing.Point(6, 42);
-            this.checkBox_GlobalLockCode.Name = "checkBox_GlobalLockCode";
-            this.checkBox_GlobalLockCode.Size = new System.Drawing.Size(106, 17);
-            this.checkBox_GlobalLockCode.TabIndex = 4;
-            this.checkBox_GlobalLockCode.Text = "Global lock code";
-            this.checkBox_GlobalLockCode.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_TerminatorDigit
-            // 
-            this.checkBox_TerminatorDigit.AutoSize = true;
-            this.checkBox_TerminatorDigit.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.TerminatorDigit;
-            this.checkBox_TerminatorDigit.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "TerminatorDigit", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_TerminatorDigit.Location = new System.Drawing.Point(6, 65);
-            this.checkBox_TerminatorDigit.Name = "checkBox_TerminatorDigit";
-            this.checkBox_TerminatorDigit.Size = new System.Drawing.Size(100, 17);
-            this.checkBox_TerminatorDigit.TabIndex = 4;
-            this.checkBox_TerminatorDigit.Text = "Terminator Digit";
-            this.checkBox_TerminatorDigit.UseVisualStyleBackColor = true;
-            // 
-            // groupBox7
-            // 
-            this.groupBox7.Controls.Add(this.checkBox_DTMFMemories);
-            this.groupBox7.Controls.Add(this.checkBox_DTMFTestPadCode);
-            this.groupBox7.Location = new System.Drawing.Point(491, 240);
-            this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(146, 69);
-            this.groupBox7.TabIndex = 6;
-            this.groupBox7.TabStop = false;
-            this.groupBox7.Text = "DTMF";
-            // 
-            // checkBox_DTMFMemories
-            // 
-            this.checkBox_DTMFMemories.AutoSize = true;
-            this.checkBox_DTMFMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFMemories;
-            this.checkBox_DTMFMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_DTMFMemories.Location = new System.Drawing.Point(6, 19);
-            this.checkBox_DTMFMemories.Name = "checkBox_DTMFMemories";
-            this.checkBox_DTMFMemories.Size = new System.Drawing.Size(71, 17);
-            this.checkBox_DTMFMemories.TabIndex = 4;
-            this.checkBox_DTMFMemories.Text = "Memories";
-            this.checkBox_DTMFMemories.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_DTMFTestPadCode
-            // 
-            this.checkBox_DTMFTestPadCode.AutoSize = true;
-            this.checkBox_DTMFTestPadCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFTestPadCode;
-            this.checkBox_DTMFTestPadCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFTestPadCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_DTMFTestPadCode.Location = new System.Drawing.Point(6, 42);
-            this.checkBox_DTMFTestPadCode.Name = "checkBox_DTMFTestPadCode";
-            this.checkBox_DTMFTestPadCode.Size = new System.Drawing.Size(97, 17);
-            this.checkBox_DTMFTestPadCode.TabIndex = 4;
-            this.checkBox_DTMFTestPadCode.Text = "Test Pad Code";
-            this.checkBox_DTMFTestPadCode.UseVisualStyleBackColor = true;
-            // 
-            // groupBox8
-            // 
-            this.groupBox8.Controls.Add(this.checkBox_APSettings);
-            this.groupBox8.Controls.Add(this.checkBox_APMemories);
-            this.groupBox8.Controls.Add(this.checkBox_APPrefix);
-            this.groupBox8.Controls.Add(this.checkBox_APAnswerCode);
-            this.groupBox8.Controls.Add(this.checkBox_APTollRestrictions);
-            this.groupBox8.Location = new System.Drawing.Point(349, 177);
-            this.groupBox8.Name = "groupBox8";
-            this.groupBox8.Size = new System.Drawing.Size(136, 132);
-            this.groupBox8.TabIndex = 6;
-            this.groupBox8.TabStop = false;
-            this.groupBox8.Text = "Auto Patch";
-            // 
-            // checkBox_APSettings
-            // 
-            this.checkBox_APSettings.AutoSize = true;
-            this.checkBox_APSettings.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APSettings;
-            this.checkBox_APSettings.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APSettings", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_APSettings.Location = new System.Drawing.Point(5, 20);
-            this.checkBox_APSettings.Name = "checkBox_APSettings";
-            this.checkBox_APSettings.Size = new System.Drawing.Size(64, 17);
-            this.checkBox_APSettings.TabIndex = 5;
-            this.checkBox_APSettings.Text = "Settings";
-            this.checkBox_APSettings.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_APMemories
-            // 
-            this.checkBox_APMemories.AutoSize = true;
-            this.checkBox_APMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APMemories;
-            this.checkBox_APMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_APMemories.Location = new System.Drawing.Point(5, 88);
-            this.checkBox_APMemories.Name = "checkBox_APMemories";
-            this.checkBox_APMemories.Size = new System.Drawing.Size(71, 17);
-            this.checkBox_APMemories.TabIndex = 4;
-            this.checkBox_APMemories.Text = "Memories";
-            this.checkBox_APMemories.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_APPrefix
-            // 
-            this.checkBox_APPrefix.AutoSize = true;
-            this.checkBox_APPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APPrefix;
-            this.checkBox_APPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_APPrefix.Location = new System.Drawing.Point(5, 42);
-            this.checkBox_APPrefix.Name = "checkBox_APPrefix";
-            this.checkBox_APPrefix.Size = new System.Drawing.Size(52, 17);
-            this.checkBox_APPrefix.TabIndex = 4;
-            this.checkBox_APPrefix.Text = "Prefix";
-            this.checkBox_APPrefix.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_APAnswerCode
-            // 
-            this.checkBox_APAnswerCode.AutoSize = true;
-            this.checkBox_APAnswerCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APAnswerCode;
-            this.checkBox_APAnswerCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APAnswerCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_APAnswerCode.Location = new System.Drawing.Point(5, 65);
-            this.checkBox_APAnswerCode.Name = "checkBox_APAnswerCode";
-            this.checkBox_APAnswerCode.Size = new System.Drawing.Size(92, 17);
-            this.checkBox_APAnswerCode.TabIndex = 4;
-            this.checkBox_APAnswerCode.Text = " Answer Code";
-            this.checkBox_APAnswerCode.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_APTollRestrictions
-            // 
-            this.checkBox_APTollRestrictions.AutoSize = true;
-            this.checkBox_APTollRestrictions.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APTollRestrictions;
-            this.checkBox_APTollRestrictions.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APTollRestrictions", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_APTollRestrictions.Location = new System.Drawing.Point(5, 111);
-            this.checkBox_APTollRestrictions.Name = "checkBox_APTollRestrictions";
-            this.checkBox_APTollRestrictions.Size = new System.Drawing.Size(101, 17);
-            this.checkBox_APTollRestrictions.TabIndex = 4;
-            this.checkBox_APTollRestrictions.Text = "Toll Restrictions";
-            this.checkBox_APTollRestrictions.UseVisualStyleBackColor = true;
-            // 
-            // menuStrip1
-            // 
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.groupBox_Port1 = new System.Windows.Forms.GroupBox();
+			this.checkBox_P1Switches = new System.Windows.Forms.CheckBox();
+			this.checkBox_P1Timers = new System.Windows.Forms.CheckBox();
+			this.checkBox_P1TailMessages = new System.Windows.Forms.CheckBox();
+			this.checkBox_P1UnlockCode = new System.Windows.Forms.CheckBox();
+			this.checkBox_P1IDs = new System.Windows.Forms.CheckBox();
+			this.groupBox_Port2 = new System.Windows.Forms.GroupBox();
+			this.checkBox_P2Switches = new System.Windows.Forms.CheckBox();
+			this.checkBox_P2Timers = new System.Windows.Forms.CheckBox();
+			this.checkBox_P2TailMessages = new System.Windows.Forms.CheckBox();
+			this.checkBox_P2UnlockCode = new System.Windows.Forms.CheckBox();
+			this.checkBox_P2IDs = new System.Windows.Forms.CheckBox();
+			this.groupBox_Port3 = new System.Windows.Forms.GroupBox();
+			this.checkBox_P3Switches = new System.Windows.Forms.CheckBox();
+			this.checkBox_P3Timers = new System.Windows.Forms.CheckBox();
+			this.checkBox_P3TailMessages = new System.Windows.Forms.CheckBox();
+			this.checkBox_P3UnlockCode = new System.Windows.Forms.CheckBox();
+			this.checkBox_P3IDs = new System.Windows.Forms.CheckBox();
+			this.groupBox4 = new System.Windows.Forms.GroupBox();
+			this.checkBox_CTMessageMacros = new System.Windows.Forms.CheckBox();
+			this.checkBox_MessageMacros = new System.Windows.Forms.CheckBox();
+			this.checkBox_MacroCodes = new System.Windows.Forms.CheckBox();
+			this.checkBox_Macros = new System.Windows.Forms.CheckBox();
+			this.groupBox6 = new System.Windows.Forms.GroupBox();
+			this.checkBox_PreAccessPrefix = new System.Windows.Forms.CheckBox();
+			this.checkBox_RemoteBaseMemories = new System.Windows.Forms.CheckBox();
+			this.checkBox_GeneralTimers = new System.Windows.Forms.CheckBox();
+			this.checkBox_Alarms = new System.Windows.Forms.CheckBox();
+			this.checkBox_AnalogMeters = new System.Windows.Forms.CheckBox();
+			this.checkBox_SetpointsScheduler = new System.Windows.Forms.CheckBox();
+			this.checkBox_GlobalLockCode = new System.Windows.Forms.CheckBox();
+			this.checkBox_TerminatorDigit = new System.Windows.Forms.CheckBox();
+			this.groupBox7 = new System.Windows.Forms.GroupBox();
+			this.checkBox_DTMFMemories = new System.Windows.Forms.CheckBox();
+			this.checkBox_DTMFTestPadCode = new System.Windows.Forms.CheckBox();
+			this.groupBox8 = new System.Windows.Forms.GroupBox();
+			this.checkBox_APSettings = new System.Windows.Forms.CheckBox();
+			this.checkBox_APMemories = new System.Windows.Forms.CheckBox();
+			this.checkBox_APPrefix = new System.Windows.Forms.CheckBox();
+			this.checkBox_APAnswerCode = new System.Windows.Forms.CheckBox();
+			this.checkBox_APTollRestrictions = new System.Windows.Forms.CheckBox();
+			this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.recallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+			this.portNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.port1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.port2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.port3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.macroDefinitionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.versionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.updateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.reportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.generateReportToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+			this.viewReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.openReportFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.checkBox_CustomHeader = new System.Windows.Forms.CheckBox();
+			this.checkBox_DateHeader = new System.Windows.Forms.CheckBox();
+			this.textBox_CustomHeader = new System.Windows.Forms.TextBox();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.checkBox_RTCOption = new System.Windows.Forms.CheckBox();
+			this.comboBox_FwVersion = new System.Windows.Forms.ComboBox();
+			this.groupBox_Port1.SuspendLayout();
+			this.groupBox_Port2.SuspendLayout();
+			this.groupBox_Port3.SuspendLayout();
+			this.groupBox4.SuspendLayout();
+			this.groupBox6.SuspendLayout();
+			this.groupBox7.SuspendLayout();
+			this.groupBox8.SuspendLayout();
+			this.menuStrip1.SuspendLayout();
+			this.groupBox1.SuspendLayout();
+			this.groupBox2.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// groupBox_Port1
+			// 
+			this.groupBox_Port1.Controls.Add(this.checkBox_P1Switches);
+			this.groupBox_Port1.Controls.Add(this.checkBox_P1Timers);
+			this.groupBox_Port1.Controls.Add(this.checkBox_P1TailMessages);
+			this.groupBox_Port1.Controls.Add(this.checkBox_P1UnlockCode);
+			this.groupBox_Port1.Controls.Add(this.checkBox_P1IDs);
+			this.groupBox_Port1.Location = new System.Drawing.Point(12, 27);
+			this.groupBox_Port1.Name = "groupBox_Port1";
+			this.groupBox_Port1.Size = new System.Drawing.Size(331, 44);
+			this.groupBox_Port1.TabIndex = 3;
+			this.groupBox_Port1.TabStop = false;
+			this.groupBox_Port1.Text = "Port 1";
+			// 
+			// checkBox_P1Switches
+			// 
+			this.checkBox_P1Switches.AutoSize = true;
+			this.checkBox_P1Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Switches;
+			this.checkBox_P1Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P1Switches.Location = new System.Drawing.Point(252, 20);
+			this.checkBox_P1Switches.Name = "checkBox_P1Switches";
+			this.checkBox_P1Switches.Size = new System.Drawing.Size(69, 17);
+			this.checkBox_P1Switches.TabIndex = 5;
+			this.checkBox_P1Switches.Text = "Switches";
+			this.checkBox_P1Switches.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P1Timers
+			// 
+			this.checkBox_P1Timers.AutoSize = true;
+			this.checkBox_P1Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Timers;
+			this.checkBox_P1Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P1Timers.Location = new System.Drawing.Point(188, 19);
+			this.checkBox_P1Timers.Name = "checkBox_P1Timers";
+			this.checkBox_P1Timers.Size = new System.Drawing.Size(57, 17);
+			this.checkBox_P1Timers.TabIndex = 4;
+			this.checkBox_P1Timers.Text = "Timers";
+			this.checkBox_P1Timers.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P1TailMessages
+			// 
+			this.checkBox_P1TailMessages.AutoSize = true;
+			this.checkBox_P1TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1TailMsgs;
+			this.checkBox_P1TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P1TailMessages.Location = new System.Drawing.Point(111, 19);
+			this.checkBox_P1TailMessages.Name = "checkBox_P1TailMessages";
+			this.checkBox_P1TailMessages.Size = new System.Drawing.Size(71, 17);
+			this.checkBox_P1TailMessages.TabIndex = 4;
+			this.checkBox_P1TailMessages.Text = "Tail Msgs";
+			this.checkBox_P1TailMessages.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P1UnlockCode
+			// 
+			this.checkBox_P1UnlockCode.AutoSize = true;
+			this.checkBox_P1UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1UnlockCode;
+			this.checkBox_P1UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P1UnlockCode.Location = new System.Drawing.Point(6, 19);
+			this.checkBox_P1UnlockCode.Name = "checkBox_P1UnlockCode";
+			this.checkBox_P1UnlockCode.Size = new System.Drawing.Size(51, 17);
+			this.checkBox_P1UnlockCode.TabIndex = 4;
+			this.checkBox_P1UnlockCode.Text = "Code";
+			this.checkBox_P1UnlockCode.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P1IDs
+			// 
+			this.checkBox_P1IDs.AutoSize = true;
+			this.checkBox_P1IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1IDs;
+			this.checkBox_P1IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P1IDs.Location = new System.Drawing.Point(63, 19);
+			this.checkBox_P1IDs.Name = "checkBox_P1IDs";
+			this.checkBox_P1IDs.Size = new System.Drawing.Size(42, 17);
+			this.checkBox_P1IDs.TabIndex = 4;
+			this.checkBox_P1IDs.Text = "IDs";
+			this.checkBox_P1IDs.UseVisualStyleBackColor = true;
+			// 
+			// groupBox_Port2
+			// 
+			this.groupBox_Port2.Controls.Add(this.checkBox_P2Switches);
+			this.groupBox_Port2.Controls.Add(this.checkBox_P2Timers);
+			this.groupBox_Port2.Controls.Add(this.checkBox_P2TailMessages);
+			this.groupBox_Port2.Controls.Add(this.checkBox_P2UnlockCode);
+			this.groupBox_Port2.Controls.Add(this.checkBox_P2IDs);
+			this.groupBox_Port2.Location = new System.Drawing.Point(12, 77);
+			this.groupBox_Port2.Name = "groupBox_Port2";
+			this.groupBox_Port2.Size = new System.Drawing.Size(331, 44);
+			this.groupBox_Port2.TabIndex = 3;
+			this.groupBox_Port2.TabStop = false;
+			this.groupBox_Port2.Text = "Port 2";
+			// 
+			// checkBox_P2Switches
+			// 
+			this.checkBox_P2Switches.AutoSize = true;
+			this.checkBox_P2Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Switches;
+			this.checkBox_P2Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P2Switches.Location = new System.Drawing.Point(252, 19);
+			this.checkBox_P2Switches.Name = "checkBox_P2Switches";
+			this.checkBox_P2Switches.Size = new System.Drawing.Size(69, 17);
+			this.checkBox_P2Switches.TabIndex = 5;
+			this.checkBox_P2Switches.Text = "Switches";
+			this.checkBox_P2Switches.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P2Timers
+			// 
+			this.checkBox_P2Timers.AutoSize = true;
+			this.checkBox_P2Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Timers;
+			this.checkBox_P2Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P2Timers.Location = new System.Drawing.Point(188, 19);
+			this.checkBox_P2Timers.Name = "checkBox_P2Timers";
+			this.checkBox_P2Timers.Size = new System.Drawing.Size(57, 17);
+			this.checkBox_P2Timers.TabIndex = 4;
+			this.checkBox_P2Timers.Text = "Timers";
+			this.checkBox_P2Timers.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P2TailMessages
+			// 
+			this.checkBox_P2TailMessages.AutoSize = true;
+			this.checkBox_P2TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2TailMsgs;
+			this.checkBox_P2TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P2TailMessages.Location = new System.Drawing.Point(111, 19);
+			this.checkBox_P2TailMessages.Name = "checkBox_P2TailMessages";
+			this.checkBox_P2TailMessages.Size = new System.Drawing.Size(71, 17);
+			this.checkBox_P2TailMessages.TabIndex = 4;
+			this.checkBox_P2TailMessages.Text = "Tail Msgs";
+			this.checkBox_P2TailMessages.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P2UnlockCode
+			// 
+			this.checkBox_P2UnlockCode.AutoSize = true;
+			this.checkBox_P2UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2UnlockCode;
+			this.checkBox_P2UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P2UnlockCode.Location = new System.Drawing.Point(6, 19);
+			this.checkBox_P2UnlockCode.Name = "checkBox_P2UnlockCode";
+			this.checkBox_P2UnlockCode.Size = new System.Drawing.Size(51, 17);
+			this.checkBox_P2UnlockCode.TabIndex = 4;
+			this.checkBox_P2UnlockCode.Text = "Code";
+			this.checkBox_P2UnlockCode.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P2IDs
+			// 
+			this.checkBox_P2IDs.AutoSize = true;
+			this.checkBox_P2IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2IDs;
+			this.checkBox_P2IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P2IDs.Location = new System.Drawing.Point(63, 19);
+			this.checkBox_P2IDs.Name = "checkBox_P2IDs";
+			this.checkBox_P2IDs.Size = new System.Drawing.Size(42, 17);
+			this.checkBox_P2IDs.TabIndex = 4;
+			this.checkBox_P2IDs.Text = "IDs";
+			this.checkBox_P2IDs.UseVisualStyleBackColor = true;
+			// 
+			// groupBox_Port3
+			// 
+			this.groupBox_Port3.Controls.Add(this.checkBox_P3Switches);
+			this.groupBox_Port3.Controls.Add(this.checkBox_P3Timers);
+			this.groupBox_Port3.Controls.Add(this.checkBox_P3TailMessages);
+			this.groupBox_Port3.Controls.Add(this.checkBox_P3UnlockCode);
+			this.groupBox_Port3.Controls.Add(this.checkBox_P3IDs);
+			this.groupBox_Port3.Location = new System.Drawing.Point(12, 127);
+			this.groupBox_Port3.Name = "groupBox_Port3";
+			this.groupBox_Port3.Size = new System.Drawing.Size(331, 44);
+			this.groupBox_Port3.TabIndex = 3;
+			this.groupBox_Port3.TabStop = false;
+			this.groupBox_Port3.Text = "Port 3";
+			// 
+			// checkBox_P3Switches
+			// 
+			this.checkBox_P3Switches.AutoSize = true;
+			this.checkBox_P3Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Switches;
+			this.checkBox_P3Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P3Switches.Location = new System.Drawing.Point(252, 19);
+			this.checkBox_P3Switches.Name = "checkBox_P3Switches";
+			this.checkBox_P3Switches.Size = new System.Drawing.Size(69, 17);
+			this.checkBox_P3Switches.TabIndex = 5;
+			this.checkBox_P3Switches.Text = "Switches";
+			this.checkBox_P3Switches.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P3Timers
+			// 
+			this.checkBox_P3Timers.AutoSize = true;
+			this.checkBox_P3Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Timers;
+			this.checkBox_P3Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P3Timers.Location = new System.Drawing.Point(188, 19);
+			this.checkBox_P3Timers.Name = "checkBox_P3Timers";
+			this.checkBox_P3Timers.Size = new System.Drawing.Size(57, 17);
+			this.checkBox_P3Timers.TabIndex = 4;
+			this.checkBox_P3Timers.Text = "Timers";
+			this.checkBox_P3Timers.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P3TailMessages
+			// 
+			this.checkBox_P3TailMessages.AutoSize = true;
+			this.checkBox_P3TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3TailMsgs;
+			this.checkBox_P3TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P3TailMessages.Location = new System.Drawing.Point(111, 19);
+			this.checkBox_P3TailMessages.Name = "checkBox_P3TailMessages";
+			this.checkBox_P3TailMessages.Size = new System.Drawing.Size(71, 17);
+			this.checkBox_P3TailMessages.TabIndex = 4;
+			this.checkBox_P3TailMessages.Text = "Tail Msgs";
+			this.checkBox_P3TailMessages.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P3UnlockCode
+			// 
+			this.checkBox_P3UnlockCode.AutoSize = true;
+			this.checkBox_P3UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3UnlockCode;
+			this.checkBox_P3UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P3UnlockCode.Location = new System.Drawing.Point(6, 19);
+			this.checkBox_P3UnlockCode.Name = "checkBox_P3UnlockCode";
+			this.checkBox_P3UnlockCode.Size = new System.Drawing.Size(51, 17);
+			this.checkBox_P3UnlockCode.TabIndex = 4;
+			this.checkBox_P3UnlockCode.Text = "Code";
+			this.checkBox_P3UnlockCode.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_P3IDs
+			// 
+			this.checkBox_P3IDs.AutoSize = true;
+			this.checkBox_P3IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3IDs;
+			this.checkBox_P3IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_P3IDs.Location = new System.Drawing.Point(63, 19);
+			this.checkBox_P3IDs.Name = "checkBox_P3IDs";
+			this.checkBox_P3IDs.Size = new System.Drawing.Size(42, 17);
+			this.checkBox_P3IDs.TabIndex = 4;
+			this.checkBox_P3IDs.Text = "IDs";
+			this.checkBox_P3IDs.UseVisualStyleBackColor = true;
+			// 
+			// groupBox4
+			// 
+			this.groupBox4.Controls.Add(this.checkBox_CTMessageMacros);
+			this.groupBox4.Controls.Add(this.checkBox_MessageMacros);
+			this.groupBox4.Controls.Add(this.checkBox_MacroCodes);
+			this.groupBox4.Controls.Add(this.checkBox_Macros);
+			this.groupBox4.Location = new System.Drawing.Point(349, 27);
+			this.groupBox4.Name = "groupBox4";
+			this.groupBox4.Size = new System.Drawing.Size(136, 144);
+			this.groupBox4.TabIndex = 6;
+			this.groupBox4.TabStop = false;
+			this.groupBox4.Text = "Macros";
+			// 
+			// checkBox_CTMessageMacros
+			// 
+			this.checkBox_CTMessageMacros.AutoSize = true;
+			this.checkBox_CTMessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CTMessageMacros;
+			this.checkBox_CTMessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CTMessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_CTMessageMacros.Location = new System.Drawing.Point(6, 88);
+			this.checkBox_CTMessageMacros.Name = "checkBox_CTMessageMacros";
+			this.checkBox_CTMessageMacros.Size = new System.Drawing.Size(124, 17);
+			this.checkBox_CTMessageMacros.TabIndex = 4;
+			this.checkBox_CTMessageMacros.Text = "CT Message Macros";
+			this.checkBox_CTMessageMacros.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_MessageMacros
+			// 
+			this.checkBox_MessageMacros.AutoSize = true;
+			this.checkBox_MessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MessageMacros;
+			this.checkBox_MessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_MessageMacros.Location = new System.Drawing.Point(6, 65);
+			this.checkBox_MessageMacros.Name = "checkBox_MessageMacros";
+			this.checkBox_MessageMacros.Size = new System.Drawing.Size(107, 17);
+			this.checkBox_MessageMacros.TabIndex = 4;
+			this.checkBox_MessageMacros.Text = "Message Macros";
+			this.checkBox_MessageMacros.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_MacroCodes
+			// 
+			this.checkBox_MacroCodes.AutoSize = true;
+			this.checkBox_MacroCodes.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MacroCodes;
+			this.checkBox_MacroCodes.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MacroCodes", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_MacroCodes.Location = new System.Drawing.Point(6, 42);
+			this.checkBox_MacroCodes.Name = "checkBox_MacroCodes";
+			this.checkBox_MacroCodes.Size = new System.Drawing.Size(119, 17);
+			this.checkBox_MacroCodes.TabIndex = 4;
+			this.checkBox_MacroCodes.Text = "Show Macro Codes";
+			this.checkBox_MacroCodes.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_Macros
+			// 
+			this.checkBox_Macros.AutoSize = true;
+			this.checkBox_Macros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Macros;
+			this.checkBox_Macros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Macros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_Macros.Location = new System.Drawing.Point(6, 19);
+			this.checkBox_Macros.Name = "checkBox_Macros";
+			this.checkBox_Macros.Size = new System.Drawing.Size(61, 17);
+			this.checkBox_Macros.TabIndex = 4;
+			this.checkBox_Macros.Text = "Macros";
+			this.checkBox_Macros.UseVisualStyleBackColor = true;
+			// 
+			// groupBox6
+			// 
+			this.groupBox6.Controls.Add(this.checkBox_PreAccessPrefix);
+			this.groupBox6.Controls.Add(this.checkBox_RemoteBaseMemories);
+			this.groupBox6.Controls.Add(this.checkBox_GeneralTimers);
+			this.groupBox6.Controls.Add(this.checkBox_Alarms);
+			this.groupBox6.Controls.Add(this.checkBox_AnalogMeters);
+			this.groupBox6.Controls.Add(this.checkBox_SetpointsScheduler);
+			this.groupBox6.Controls.Add(this.checkBox_GlobalLockCode);
+			this.groupBox6.Controls.Add(this.checkBox_TerminatorDigit);
+			this.groupBox6.Location = new System.Drawing.Point(491, 27);
+			this.groupBox6.Name = "groupBox6";
+			this.groupBox6.Size = new System.Drawing.Size(146, 209);
+			this.groupBox6.TabIndex = 6;
+			this.groupBox6.TabStop = false;
+			this.groupBox6.Text = "Misc";
+			// 
+			// checkBox_PreAccessPrefix
+			// 
+			this.checkBox_PreAccessPrefix.AutoSize = true;
+			this.checkBox_PreAccessPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.PreAccessPrefix;
+			this.checkBox_PreAccessPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "PreAccessPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_PreAccessPrefix.Location = new System.Drawing.Point(5, 19);
+			this.checkBox_PreAccessPrefix.Name = "checkBox_PreAccessPrefix";
+			this.checkBox_PreAccessPrefix.Size = new System.Drawing.Size(106, 17);
+			this.checkBox_PreAccessPrefix.TabIndex = 5;
+			this.checkBox_PreAccessPrefix.Text = "PreAccess Prefix";
+			this.checkBox_PreAccessPrefix.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_RemoteBaseMemories
+			// 
+			this.checkBox_RemoteBaseMemories.AutoSize = true;
+			this.checkBox_RemoteBaseMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RemoteBaseMemories;
+			this.checkBox_RemoteBaseMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RemoteBaseMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_RemoteBaseMemories.Location = new System.Drawing.Point(5, 180);
+			this.checkBox_RemoteBaseMemories.Name = "checkBox_RemoteBaseMemories";
+			this.checkBox_RemoteBaseMemories.Size = new System.Drawing.Size(138, 17);
+			this.checkBox_RemoteBaseMemories.TabIndex = 4;
+			this.checkBox_RemoteBaseMemories.Text = "Remote Base Memories";
+			this.checkBox_RemoteBaseMemories.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_GeneralTimers
+			// 
+			this.checkBox_GeneralTimers.AutoSize = true;
+			this.checkBox_GeneralTimers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GeneralTimers;
+			this.checkBox_GeneralTimers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GeneralTimers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_GeneralTimers.Location = new System.Drawing.Point(6, 157);
+			this.checkBox_GeneralTimers.Name = "checkBox_GeneralTimers";
+			this.checkBox_GeneralTimers.Size = new System.Drawing.Size(97, 17);
+			this.checkBox_GeneralTimers.TabIndex = 4;
+			this.checkBox_GeneralTimers.Text = "General Timers";
+			this.checkBox_GeneralTimers.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_Alarms
+			// 
+			this.checkBox_Alarms.AutoSize = true;
+			this.checkBox_Alarms.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Alarms;
+			this.checkBox_Alarms.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Alarms", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_Alarms.Location = new System.Drawing.Point(6, 134);
+			this.checkBox_Alarms.Name = "checkBox_Alarms";
+			this.checkBox_Alarms.Size = new System.Drawing.Size(57, 17);
+			this.checkBox_Alarms.TabIndex = 4;
+			this.checkBox_Alarms.Text = "Alarms";
+			this.checkBox_Alarms.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_AnalogMeters
+			// 
+			this.checkBox_AnalogMeters.AutoSize = true;
+			this.checkBox_AnalogMeters.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.AnalogMeters;
+			this.checkBox_AnalogMeters.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "AnalogMeters", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_AnalogMeters.Location = new System.Drawing.Point(6, 111);
+			this.checkBox_AnalogMeters.Name = "checkBox_AnalogMeters";
+			this.checkBox_AnalogMeters.Size = new System.Drawing.Size(94, 17);
+			this.checkBox_AnalogMeters.TabIndex = 4;
+			this.checkBox_AnalogMeters.Text = "Analog Meters";
+			this.checkBox_AnalogMeters.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_SetpointsScheduler
+			// 
+			this.checkBox_SetpointsScheduler.AutoSize = true;
+			this.checkBox_SetpointsScheduler.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.SetpointsScheduler;
+			this.checkBox_SetpointsScheduler.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "SetpointsScheduler", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_SetpointsScheduler.Location = new System.Drawing.Point(6, 88);
+			this.checkBox_SetpointsScheduler.Name = "checkBox_SetpointsScheduler";
+			this.checkBox_SetpointsScheduler.Size = new System.Drawing.Size(123, 17);
+			this.checkBox_SetpointsScheduler.TabIndex = 4;
+			this.checkBox_SetpointsScheduler.Text = "Setpoints/Scheduler";
+			this.checkBox_SetpointsScheduler.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_GlobalLockCode
+			// 
+			this.checkBox_GlobalLockCode.AutoSize = true;
+			this.checkBox_GlobalLockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GlobalLockCode;
+			this.checkBox_GlobalLockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GlobalLockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_GlobalLockCode.Location = new System.Drawing.Point(6, 42);
+			this.checkBox_GlobalLockCode.Name = "checkBox_GlobalLockCode";
+			this.checkBox_GlobalLockCode.Size = new System.Drawing.Size(106, 17);
+			this.checkBox_GlobalLockCode.TabIndex = 4;
+			this.checkBox_GlobalLockCode.Text = "Global lock code";
+			this.checkBox_GlobalLockCode.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_TerminatorDigit
+			// 
+			this.checkBox_TerminatorDigit.AutoSize = true;
+			this.checkBox_TerminatorDigit.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.TerminatorDigit;
+			this.checkBox_TerminatorDigit.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "TerminatorDigit", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_TerminatorDigit.Location = new System.Drawing.Point(6, 65);
+			this.checkBox_TerminatorDigit.Name = "checkBox_TerminatorDigit";
+			this.checkBox_TerminatorDigit.Size = new System.Drawing.Size(100, 17);
+			this.checkBox_TerminatorDigit.TabIndex = 4;
+			this.checkBox_TerminatorDigit.Text = "Terminator Digit";
+			this.checkBox_TerminatorDigit.UseVisualStyleBackColor = true;
+			// 
+			// groupBox7
+			// 
+			this.groupBox7.Controls.Add(this.checkBox_DTMFMemories);
+			this.groupBox7.Controls.Add(this.checkBox_DTMFTestPadCode);
+			this.groupBox7.Location = new System.Drawing.Point(491, 240);
+			this.groupBox7.Name = "groupBox7";
+			this.groupBox7.Size = new System.Drawing.Size(146, 69);
+			this.groupBox7.TabIndex = 6;
+			this.groupBox7.TabStop = false;
+			this.groupBox7.Text = "DTMF";
+			// 
+			// checkBox_DTMFMemories
+			// 
+			this.checkBox_DTMFMemories.AutoSize = true;
+			this.checkBox_DTMFMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFMemories;
+			this.checkBox_DTMFMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_DTMFMemories.Location = new System.Drawing.Point(6, 19);
+			this.checkBox_DTMFMemories.Name = "checkBox_DTMFMemories";
+			this.checkBox_DTMFMemories.Size = new System.Drawing.Size(71, 17);
+			this.checkBox_DTMFMemories.TabIndex = 4;
+			this.checkBox_DTMFMemories.Text = "Memories";
+			this.checkBox_DTMFMemories.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_DTMFTestPadCode
+			// 
+			this.checkBox_DTMFTestPadCode.AutoSize = true;
+			this.checkBox_DTMFTestPadCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFTestPadCode;
+			this.checkBox_DTMFTestPadCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFTestPadCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_DTMFTestPadCode.Location = new System.Drawing.Point(6, 42);
+			this.checkBox_DTMFTestPadCode.Name = "checkBox_DTMFTestPadCode";
+			this.checkBox_DTMFTestPadCode.Size = new System.Drawing.Size(97, 17);
+			this.checkBox_DTMFTestPadCode.TabIndex = 4;
+			this.checkBox_DTMFTestPadCode.Text = "Test Pad Code";
+			this.checkBox_DTMFTestPadCode.UseVisualStyleBackColor = true;
+			// 
+			// groupBox8
+			// 
+			this.groupBox8.Controls.Add(this.checkBox_APSettings);
+			this.groupBox8.Controls.Add(this.checkBox_APMemories);
+			this.groupBox8.Controls.Add(this.checkBox_APPrefix);
+			this.groupBox8.Controls.Add(this.checkBox_APAnswerCode);
+			this.groupBox8.Controls.Add(this.checkBox_APTollRestrictions);
+			this.groupBox8.Location = new System.Drawing.Point(349, 177);
+			this.groupBox8.Name = "groupBox8";
+			this.groupBox8.Size = new System.Drawing.Size(136, 132);
+			this.groupBox8.TabIndex = 6;
+			this.groupBox8.TabStop = false;
+			this.groupBox8.Text = "Auto Patch";
+			// 
+			// checkBox_APSettings
+			// 
+			this.checkBox_APSettings.AutoSize = true;
+			this.checkBox_APSettings.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APSettings;
+			this.checkBox_APSettings.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APSettings", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_APSettings.Location = new System.Drawing.Point(5, 20);
+			this.checkBox_APSettings.Name = "checkBox_APSettings";
+			this.checkBox_APSettings.Size = new System.Drawing.Size(64, 17);
+			this.checkBox_APSettings.TabIndex = 5;
+			this.checkBox_APSettings.Text = "Settings";
+			this.checkBox_APSettings.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_APMemories
+			// 
+			this.checkBox_APMemories.AutoSize = true;
+			this.checkBox_APMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APMemories;
+			this.checkBox_APMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_APMemories.Location = new System.Drawing.Point(5, 88);
+			this.checkBox_APMemories.Name = "checkBox_APMemories";
+			this.checkBox_APMemories.Size = new System.Drawing.Size(71, 17);
+			this.checkBox_APMemories.TabIndex = 4;
+			this.checkBox_APMemories.Text = "Memories";
+			this.checkBox_APMemories.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_APPrefix
+			// 
+			this.checkBox_APPrefix.AutoSize = true;
+			this.checkBox_APPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APPrefix;
+			this.checkBox_APPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_APPrefix.Location = new System.Drawing.Point(5, 42);
+			this.checkBox_APPrefix.Name = "checkBox_APPrefix";
+			this.checkBox_APPrefix.Size = new System.Drawing.Size(52, 17);
+			this.checkBox_APPrefix.TabIndex = 4;
+			this.checkBox_APPrefix.Text = "Prefix";
+			this.checkBox_APPrefix.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_APAnswerCode
+			// 
+			this.checkBox_APAnswerCode.AutoSize = true;
+			this.checkBox_APAnswerCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APAnswerCode;
+			this.checkBox_APAnswerCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APAnswerCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_APAnswerCode.Location = new System.Drawing.Point(5, 65);
+			this.checkBox_APAnswerCode.Name = "checkBox_APAnswerCode";
+			this.checkBox_APAnswerCode.Size = new System.Drawing.Size(92, 17);
+			this.checkBox_APAnswerCode.TabIndex = 4;
+			this.checkBox_APAnswerCode.Text = " Answer Code";
+			this.checkBox_APAnswerCode.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_APTollRestrictions
+			// 
+			this.checkBox_APTollRestrictions.AutoSize = true;
+			this.checkBox_APTollRestrictions.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APTollRestrictions;
+			this.checkBox_APTollRestrictions.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APTollRestrictions", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_APTollRestrictions.Location = new System.Drawing.Point(5, 111);
+			this.checkBox_APTollRestrictions.Name = "checkBox_APTollRestrictions";
+			this.checkBox_APTollRestrictions.Size = new System.Drawing.Size(101, 17);
+			this.checkBox_APTollRestrictions.TabIndex = 4;
+			this.checkBox_APTollRestrictions.Text = "Toll Restrictions";
+			this.checkBox_APTollRestrictions.UseVisualStyleBackColor = true;
+			// 
+			// menuStrip1
+			// 
+			this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.optionsToolStripMenuItem,
             this.reportToolStripMenuItem,
             this.aboutToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(650, 24);
-            this.menuStrip1.TabIndex = 7;
-            this.menuStrip1.Text = "menuStrip1";
-            // 
-            // fileToolStripMenuItem
-            // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+			this.menuStrip1.Name = "menuStrip1";
+			this.menuStrip1.Size = new System.Drawing.Size(650, 24);
+			this.menuStrip1.TabIndex = 7;
+			this.menuStrip1.Text = "menuStrip1";
+			// 
+			// fileToolStripMenuItem
+			// 
+			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openToolStripMenuItem,
             this.closeToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.fileToolStripMenuItem.Text = "&File";
-            // 
-            // openToolStripMenuItem
-            // 
-            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
-            this.openToolStripMenuItem.Text = "&Open";
-            this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
-            // 
-            // closeToolStripMenuItem
-            // 
-            this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
-            this.closeToolStripMenuItem.Text = "&Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
-            // 
-            // optionsToolStripMenuItem
-            // 
-            this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+			this.fileToolStripMenuItem.Text = "&File";
+			// 
+			// openToolStripMenuItem
+			// 
+			this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+			this.openToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.openToolStripMenuItem.Text = "&Open";
+			this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItem_Click);
+			// 
+			// closeToolStripMenuItem
+			// 
+			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
+			this.closeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.closeToolStripMenuItem.Text = "&Close";
+			this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
+			// 
+			// optionsToolStripMenuItem
+			// 
+			this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveToolStripMenuItem,
             this.resetToolStripMenuItem,
             this.recallToolStripMenuItem,
             this.toolStripMenuItem1,
             this.portNamesToolStripMenuItem,
-            this.macroDefinitionsToolStripMenuItem,
-            this.xMLFilePathToolStripMenuItem});
-            this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
-            this.optionsToolStripMenuItem.Text = "&Options";
-            // 
-            // saveToolStripMenuItem
-            // 
-            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-            this.saveToolStripMenuItem.Text = "&Save";
-            this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
-            // 
-            // resetToolStripMenuItem
-            // 
-            this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
-            this.resetToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-            this.resetToolStripMenuItem.Text = "&Reset";
-            this.resetToolStripMenuItem.Click += new System.EventHandler(this.resetToolStripMenuItem_Click);
-            // 
-            // recallToolStripMenuItem
-            // 
-            this.recallToolStripMenuItem.Name = "recallToolStripMenuItem";
-            this.recallToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-            this.recallToolStripMenuItem.Text = "Re&call";
-            this.recallToolStripMenuItem.Click += new System.EventHandler(this.recallToolStripMenuItem_Click);
-            // 
-            // toolStripMenuItem1
-            // 
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(165, 6);
-            // 
-            // portNamesToolStripMenuItem
-            // 
-            this.portNamesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.macroDefinitionsToolStripMenuItem});
+			this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
+			this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
+			this.optionsToolStripMenuItem.Text = "&Options";
+			// 
+			// saveToolStripMenuItem
+			// 
+			this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+			this.saveToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+			this.saveToolStripMenuItem.Text = "&Save";
+			this.saveToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
+			// 
+			// resetToolStripMenuItem
+			// 
+			this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
+			this.resetToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+			this.resetToolStripMenuItem.Text = "&Reset";
+			this.resetToolStripMenuItem.Click += new System.EventHandler(this.ResetToolStripMenuItem_Click);
+			// 
+			// recallToolStripMenuItem
+			// 
+			this.recallToolStripMenuItem.Name = "recallToolStripMenuItem";
+			this.recallToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+			this.recallToolStripMenuItem.Text = "Re&call";
+			this.recallToolStripMenuItem.Click += new System.EventHandler(this.RecallToolStripMenuItem_Click);
+			// 
+			// toolStripMenuItem1
+			// 
+			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+			this.toolStripMenuItem1.Size = new System.Drawing.Size(165, 6);
+			// 
+			// portNamesToolStripMenuItem
+			// 
+			this.portNamesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.port1ToolStripMenuItem,
             this.port2ToolStripMenuItem,
             this.port3ToolStripMenuItem});
-            this.portNamesToolStripMenuItem.Name = "portNamesToolStripMenuItem";
-            this.portNamesToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-            this.portNamesToolStripMenuItem.Text = "Port Names";
-            // 
-            // port1ToolStripMenuItem
-            // 
-            this.port1ToolStripMenuItem.Name = "port1ToolStripMenuItem";
-            this.port1ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
-            this.port1ToolStripMenuItem.Text = "Port 1";
-            this.port1ToolStripMenuItem.Click += new System.EventHandler(this.port1ToolStripMenuItem_Click);
-            // 
-            // port2ToolStripMenuItem
-            // 
-            this.port2ToolStripMenuItem.Name = "port2ToolStripMenuItem";
-            this.port2ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
-            this.port2ToolStripMenuItem.Text = "Port 2";
-            this.port2ToolStripMenuItem.Click += new System.EventHandler(this.port2ToolStripMenuItem_Click);
-            // 
-            // port3ToolStripMenuItem
-            // 
-            this.port3ToolStripMenuItem.Name = "port3ToolStripMenuItem";
-            this.port3ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
-            this.port3ToolStripMenuItem.Text = "Port 3";
-            this.port3ToolStripMenuItem.Click += new System.EventHandler(this.port3ToolStripMenuItem_Click);
-            // 
-            // macroDefinitionsToolStripMenuItem
-            // 
-            this.macroDefinitionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.portNamesToolStripMenuItem.Name = "portNamesToolStripMenuItem";
+			this.portNamesToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+			this.portNamesToolStripMenuItem.Text = "Port Names";
+			// 
+			// port1ToolStripMenuItem
+			// 
+			this.port1ToolStripMenuItem.Name = "port1ToolStripMenuItem";
+			this.port1ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
+			this.port1ToolStripMenuItem.Text = "Port 1";
+			this.port1ToolStripMenuItem.Click += new System.EventHandler(this.Port1ToolStripMenuItem_Click);
+			// 
+			// port2ToolStripMenuItem
+			// 
+			this.port2ToolStripMenuItem.Name = "port2ToolStripMenuItem";
+			this.port2ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
+			this.port2ToolStripMenuItem.Text = "Port 2";
+			this.port2ToolStripMenuItem.Click += new System.EventHandler(this.Port2ToolStripMenuItem_Click);
+			// 
+			// port3ToolStripMenuItem
+			// 
+			this.port3ToolStripMenuItem.Name = "port3ToolStripMenuItem";
+			this.port3ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
+			this.port3ToolStripMenuItem.Text = "Port 3";
+			this.port3ToolStripMenuItem.Click += new System.EventHandler(this.Port3ToolStripMenuItem_Click);
+			// 
+			// macroDefinitionsToolStripMenuItem
+			// 
+			this.macroDefinitionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.versionToolStripMenuItem,
             this.updateToolStripMenuItem});
-            this.macroDefinitionsToolStripMenuItem.Name = "macroDefinitionsToolStripMenuItem";
-            this.macroDefinitionsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-            this.macroDefinitionsToolStripMenuItem.Text = "Macro Definitions";
-            // 
-            // versionToolStripMenuItem
-            // 
-            this.versionToolStripMenuItem.Name = "versionToolStripMenuItem";
-            this.versionToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-            this.versionToolStripMenuItem.Text = "Version";
-            this.versionToolStripMenuItem.Click += new System.EventHandler(this.versionToolStripMenuItem_Click);
-            // 
-            // updateToolStripMenuItem
-            // 
-            this.updateToolStripMenuItem.Name = "updateToolStripMenuItem";
-            this.updateToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-            this.updateToolStripMenuItem.Text = "Update";
-            this.updateToolStripMenuItem.Click += new System.EventHandler(this.updateToolStripMenuItem_Click);
-            // 
-            // xMLFilePathToolStripMenuItem
-            // 
-            this.xMLFilePathToolStripMenuItem.Name = "xMLFilePathToolStripMenuItem";
-            this.xMLFilePathToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-            this.xMLFilePathToolStripMenuItem.Text = "XML File Path";
-            this.xMLFilePathToolStripMenuItem.Click += new System.EventHandler(this.xMLFilePathToolStripMenuItem_Click);
-            // 
-            // reportToolStripMenuItem
-            // 
-            this.reportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.macroDefinitionsToolStripMenuItem.Name = "macroDefinitionsToolStripMenuItem";
+			this.macroDefinitionsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+			this.macroDefinitionsToolStripMenuItem.Text = "Macro Definitions";
+			// 
+			// versionToolStripMenuItem
+			// 
+			this.versionToolStripMenuItem.Name = "versionToolStripMenuItem";
+			this.versionToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+			this.versionToolStripMenuItem.Text = "Version";
+			this.versionToolStripMenuItem.Click += new System.EventHandler(this.VersionToolStripMenuItem_Click);
+			// 
+			// updateToolStripMenuItem
+			// 
+			this.updateToolStripMenuItem.Name = "updateToolStripMenuItem";
+			this.updateToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+			this.updateToolStripMenuItem.Text = "Update";
+			this.updateToolStripMenuItem.Click += new System.EventHandler(this.UpdateToolStripMenuItem_Click);
+			// 
+			// reportToolStripMenuItem
+			// 
+			this.reportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.generateReportToolStripMenuItem1,
             this.viewReportToolStripMenuItem,
             this.openReportFolderToolStripMenuItem});
-            this.reportToolStripMenuItem.Name = "reportToolStripMenuItem";
-            this.reportToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
-            this.reportToolStripMenuItem.Text = "&Report";
-            // 
-            // generateReportToolStripMenuItem1
-            // 
-            this.generateReportToolStripMenuItem1.Enabled = false;
-            this.generateReportToolStripMenuItem1.Name = "generateReportToolStripMenuItem1";
-            this.generateReportToolStripMenuItem1.Size = new System.Drawing.Size(177, 22);
-            this.generateReportToolStripMenuItem1.Text = "&Generate Report";
-            this.generateReportToolStripMenuItem1.Click += new System.EventHandler(this.generateReportToolStripMenuItem_Click);
-            // 
-            // viewReportToolStripMenuItem
-            // 
-            this.viewReportToolStripMenuItem.Enabled = false;
-            this.viewReportToolStripMenuItem.Name = "viewReportToolStripMenuItem";
-            this.viewReportToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
-            this.viewReportToolStripMenuItem.Text = "&View Report";
-            this.viewReportToolStripMenuItem.Click += new System.EventHandler(this.viewReportToolStripMenuItem_Click);
-            // 
-            // openReportFolderToolStripMenuItem
-            // 
-            this.openReportFolderToolStripMenuItem.Enabled = false;
-            this.openReportFolderToolStripMenuItem.Name = "openReportFolderToolStripMenuItem";
-            this.openReportFolderToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
-            this.openReportFolderToolStripMenuItem.Text = "&Open Report Folder";
-            this.openReportFolderToolStripMenuItem.Click += new System.EventHandler(this.openReportFolderToolStripMenuItem_Click);
-            // 
-            // aboutToolStripMenuItem
-            // 
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
-            this.aboutToolStripMenuItem.Text = "&About";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.checkBox_CustomHeader);
-            this.groupBox1.Controls.Add(this.checkBox_DateHeader);
-            this.groupBox1.Controls.Add(this.textBox_CustomHeader);
-            this.groupBox1.Location = new System.Drawing.Point(12, 246);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(331, 63);
-            this.groupBox1.TabIndex = 9;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Report Header";
-            // 
-            // checkBox_CustomHeader
-            // 
-            this.checkBox_CustomHeader.AutoSize = true;
-            this.checkBox_CustomHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomHeader;
-            this.checkBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_CustomHeader.Location = new System.Drawing.Point(6, 19);
-            this.checkBox_CustomHeader.Name = "checkBox_CustomHeader";
-            this.checkBox_CustomHeader.Size = new System.Drawing.Size(160, 17);
-            this.checkBox_CustomHeader.TabIndex = 4;
-            this.checkBox_CustomHeader.Text = "Display custom page header";
-            this.checkBox_CustomHeader.UseVisualStyleBackColor = true;
-            // 
-            // checkBox_DateHeader
-            // 
-            this.checkBox_DateHeader.AutoSize = true;
-            this.checkBox_DateHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DateHeader;
-            this.checkBox_DateHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DateHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_DateHeader.Location = new System.Drawing.Point(234, 19);
-            this.checkBox_DateHeader.Name = "checkBox_DateHeader";
-            this.checkBox_DateHeader.Size = new System.Drawing.Size(87, 17);
-            this.checkBox_DateHeader.TabIndex = 8;
-            this.checkBox_DateHeader.Text = "Date Header";
-            this.checkBox_DateHeader.UseVisualStyleBackColor = true;
-            // 
-            // textBox_CustomHeader
-            // 
-            this.textBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomeHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.textBox_CustomHeader.Location = new System.Drawing.Point(6, 39);
-            this.textBox_CustomHeader.Name = "textBox_CustomHeader";
-            this.textBox_CustomHeader.Size = new System.Drawing.Size(315, 20);
-            this.textBox_CustomHeader.TabIndex = 5;
-            this.textBox_CustomHeader.Text = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomeHeader;
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.checkBox_RTCOption);
-            this.groupBox2.Controls.Add(this.comboBox_FwVersion);
-            this.groupBox2.Location = new System.Drawing.Point(12, 184);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(331, 56);
-            this.groupBox2.TabIndex = 10;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "RC210 Options";
-            // 
-            // checkBox_RTCOption
-            // 
-            this.checkBox_RTCOption.AutoSize = true;
-            this.checkBox_RTCOption.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RTCOption;
-            this.checkBox_RTCOption.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RTCOption", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.checkBox_RTCOption.Location = new System.Drawing.Point(192, 21);
-            this.checkBox_RTCOption.Name = "checkBox_RTCOption";
-            this.checkBox_RTCOption.Size = new System.Drawing.Size(133, 17);
-            this.checkBox_RTCOption.TabIndex = 4;
-            this.checkBox_RTCOption.Text = "I Have the RTC option";
-            this.checkBox_RTCOption.UseVisualStyleBackColor = true;
-            // 
-            // comboBox_FwVersion
-            // 
-            this.comboBox_FwVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_FwVersion.FormattingEnabled = true;
-            this.comboBox_FwVersion.Location = new System.Drawing.Point(6, 19);
-            this.comboBox_FwVersion.Name = "comboBox_FwVersion";
-            this.comboBox_FwVersion.Size = new System.Drawing.Size(176, 21);
-            this.comboBox_FwVersion.TabIndex = 5;
-            // 
-            // Form1
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(650, 318);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.groupBox8);
-            this.Controls.Add(this.groupBox7);
-            this.Controls.Add(this.groupBox6);
-            this.Controls.Add(this.groupBox4);
-            this.Controls.Add(this.groupBox_Port3);
-            this.Controls.Add(this.groupBox_Port2);
-            this.Controls.Add(this.groupBox_Port1);
-            this.Controls.Add(this.menuStrip1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MainMenuStrip = this.menuStrip1;
-            this.MaximizeBox = false;
-            this.Name = "Form1";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "RC210 Data Assistant 2";
-            this.Load += new System.EventHandler(this.Form1_Load);
-            this.groupBox_Port1.ResumeLayout(false);
-            this.groupBox_Port1.PerformLayout();
-            this.groupBox_Port2.ResumeLayout(false);
-            this.groupBox_Port2.PerformLayout();
-            this.groupBox_Port3.ResumeLayout(false);
-            this.groupBox_Port3.PerformLayout();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox4.PerformLayout();
-            this.groupBox6.ResumeLayout(false);
-            this.groupBox6.PerformLayout();
-            this.groupBox7.ResumeLayout(false);
-            this.groupBox7.PerformLayout();
-            this.groupBox8.ResumeLayout(false);
-            this.groupBox8.PerformLayout();
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.reportToolStripMenuItem.Name = "reportToolStripMenuItem";
+			this.reportToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
+			this.reportToolStripMenuItem.Text = "&Report";
+			// 
+			// generateReportToolStripMenuItem1
+			// 
+			this.generateReportToolStripMenuItem1.Enabled = false;
+			this.generateReportToolStripMenuItem1.Name = "generateReportToolStripMenuItem1";
+			this.generateReportToolStripMenuItem1.Size = new System.Drawing.Size(177, 22);
+			this.generateReportToolStripMenuItem1.Text = "&Generate Report";
+			this.generateReportToolStripMenuItem1.Click += new System.EventHandler(this.GenerateReportToolStripMenuItem_Click);
+			// 
+			// viewReportToolStripMenuItem
+			// 
+			this.viewReportToolStripMenuItem.Enabled = false;
+			this.viewReportToolStripMenuItem.Name = "viewReportToolStripMenuItem";
+			this.viewReportToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+			this.viewReportToolStripMenuItem.Text = "&View Report";
+			this.viewReportToolStripMenuItem.Click += new System.EventHandler(this.ViewReportToolStripMenuItem_Click);
+			// 
+			// openReportFolderToolStripMenuItem
+			// 
+			this.openReportFolderToolStripMenuItem.Enabled = false;
+			this.openReportFolderToolStripMenuItem.Name = "openReportFolderToolStripMenuItem";
+			this.openReportFolderToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+			this.openReportFolderToolStripMenuItem.Text = "&Open Report Folder";
+			this.openReportFolderToolStripMenuItem.Click += new System.EventHandler(this.OpenReportFolderToolStripMenuItem_Click);
+			// 
+			// aboutToolStripMenuItem
+			// 
+			this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+			this.aboutToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+			this.aboutToolStripMenuItem.Text = "&About";
+			this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutToolStripMenuItem_Click);
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Controls.Add(this.checkBox_CustomHeader);
+			this.groupBox1.Controls.Add(this.checkBox_DateHeader);
+			this.groupBox1.Controls.Add(this.textBox_CustomHeader);
+			this.groupBox1.Location = new System.Drawing.Point(12, 246);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Size = new System.Drawing.Size(331, 63);
+			this.groupBox1.TabIndex = 9;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "Report Header";
+			// 
+			// checkBox_CustomHeader
+			// 
+			this.checkBox_CustomHeader.AutoSize = true;
+			this.checkBox_CustomHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomHeader;
+			this.checkBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_CustomHeader.Location = new System.Drawing.Point(6, 19);
+			this.checkBox_CustomHeader.Name = "checkBox_CustomHeader";
+			this.checkBox_CustomHeader.Size = new System.Drawing.Size(160, 17);
+			this.checkBox_CustomHeader.TabIndex = 4;
+			this.checkBox_CustomHeader.Text = "Display custom page header";
+			this.checkBox_CustomHeader.UseVisualStyleBackColor = true;
+			// 
+			// checkBox_DateHeader
+			// 
+			this.checkBox_DateHeader.AutoSize = true;
+			this.checkBox_DateHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DateHeader;
+			this.checkBox_DateHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DateHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_DateHeader.Location = new System.Drawing.Point(234, 19);
+			this.checkBox_DateHeader.Name = "checkBox_DateHeader";
+			this.checkBox_DateHeader.Size = new System.Drawing.Size(87, 17);
+			this.checkBox_DateHeader.TabIndex = 8;
+			this.checkBox_DateHeader.Text = "Date Header";
+			this.checkBox_DateHeader.UseVisualStyleBackColor = true;
+			// 
+			// textBox_CustomHeader
+			// 
+			this.textBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomeHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.textBox_CustomHeader.Location = new System.Drawing.Point(6, 39);
+			this.textBox_CustomHeader.Name = "textBox_CustomHeader";
+			this.textBox_CustomHeader.Size = new System.Drawing.Size(315, 20);
+			this.textBox_CustomHeader.TabIndex = 5;
+			this.textBox_CustomHeader.Text = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomeHeader;
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Controls.Add(this.checkBox_RTCOption);
+			this.groupBox2.Controls.Add(this.comboBox_FwVersion);
+			this.groupBox2.Location = new System.Drawing.Point(12, 184);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(331, 56);
+			this.groupBox2.TabIndex = 10;
+			this.groupBox2.TabStop = false;
+			this.groupBox2.Text = "RC210 Options";
+			// 
+			// checkBox_RTCOption
+			// 
+			this.checkBox_RTCOption.AutoSize = true;
+			this.checkBox_RTCOption.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RTCOption;
+			this.checkBox_RTCOption.CheckState = System.Windows.Forms.CheckState.Unchecked;
+			this.checkBox_RTCOption.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RTCOption", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.checkBox_RTCOption.Enabled = true;
+			this.checkBox_RTCOption.Location = new System.Drawing.Point(192, 21);
+			this.checkBox_RTCOption.Name = "checkBox_RTCOption";
+			this.checkBox_RTCOption.Size = new System.Drawing.Size(133, 17);
+			this.checkBox_RTCOption.TabIndex = 4;
+			this.checkBox_RTCOption.Text = "I Have the RTC option";
+			this.checkBox_RTCOption.UseVisualStyleBackColor = true;
+			// 
+			// comboBox_FwVersion
+			// 
+			this.comboBox_FwVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBox_FwVersion.FormattingEnabled = true;
+			this.comboBox_FwVersion.Location = new System.Drawing.Point(6, 19);
+			this.comboBox_FwVersion.Name = "comboBox_FwVersion";
+			this.comboBox_FwVersion.Size = new System.Drawing.Size(176, 21);
+			this.comboBox_FwVersion.TabIndex = 5;
+			// 
+			// Form1
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(650, 318);
+			this.Controls.Add(this.groupBox2);
+			this.Controls.Add(this.groupBox1);
+			this.Controls.Add(this.groupBox8);
+			this.Controls.Add(this.groupBox7);
+			this.Controls.Add(this.groupBox6);
+			this.Controls.Add(this.groupBox4);
+			this.Controls.Add(this.groupBox_Port3);
+			this.Controls.Add(this.groupBox_Port2);
+			this.Controls.Add(this.groupBox_Port1);
+			this.Controls.Add(this.menuStrip1);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+			this.MainMenuStrip = this.menuStrip1;
+			this.MaximizeBox = false;
+			this.Name = "Form1";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+			this.Text = "RC210 Data Assistant 2";
+			this.Load += new System.EventHandler(this.Form1_Load);
+			this.groupBox_Port1.ResumeLayout(false);
+			this.groupBox_Port1.PerformLayout();
+			this.groupBox_Port2.ResumeLayout(false);
+			this.groupBox_Port2.PerformLayout();
+			this.groupBox_Port3.ResumeLayout(false);
+			this.groupBox_Port3.PerformLayout();
+			this.groupBox4.ResumeLayout(false);
+			this.groupBox4.PerformLayout();
+			this.groupBox6.ResumeLayout(false);
+			this.groupBox6.PerformLayout();
+			this.groupBox7.ResumeLayout(false);
+			this.groupBox7.PerformLayout();
+			this.groupBox8.ResumeLayout(false);
+			this.groupBox8.PerformLayout();
+			this.menuStrip1.ResumeLayout(false);
+			this.menuStrip1.PerformLayout();
+			this.groupBox1.ResumeLayout(false);
+			this.groupBox1.PerformLayout();
+			this.groupBox2.ResumeLayout(false);
+			this.groupBox2.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
 		}
 
@@ -988,7 +981,6 @@
 		private System.Windows.Forms.ToolStripMenuItem macroDefinitionsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem versionToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem updateToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem xMLFilePathToolStripMenuItem;
 	}
 }
 

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -28,885 +28,892 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.groupBox_Port1 = new System.Windows.Forms.GroupBox();
-			this.checkBox_P1Switches = new System.Windows.Forms.CheckBox();
-			this.checkBox_P1Timers = new System.Windows.Forms.CheckBox();
-			this.checkBox_P1TailMessages = new System.Windows.Forms.CheckBox();
-			this.checkBox_P1UnlockCode = new System.Windows.Forms.CheckBox();
-			this.checkBox_P1IDs = new System.Windows.Forms.CheckBox();
-			this.groupBox_Port2 = new System.Windows.Forms.GroupBox();
-			this.checkBox_P2Switches = new System.Windows.Forms.CheckBox();
-			this.checkBox_P2Timers = new System.Windows.Forms.CheckBox();
-			this.checkBox_P2TailMessages = new System.Windows.Forms.CheckBox();
-			this.checkBox_P2UnlockCode = new System.Windows.Forms.CheckBox();
-			this.checkBox_P2IDs = new System.Windows.Forms.CheckBox();
-			this.groupBox_Port3 = new System.Windows.Forms.GroupBox();
-			this.checkBox_P3Switches = new System.Windows.Forms.CheckBox();
-			this.checkBox_P3Timers = new System.Windows.Forms.CheckBox();
-			this.checkBox_P3TailMessages = new System.Windows.Forms.CheckBox();
-			this.checkBox_P3UnlockCode = new System.Windows.Forms.CheckBox();
-			this.checkBox_P3IDs = new System.Windows.Forms.CheckBox();
-			this.groupBox4 = new System.Windows.Forms.GroupBox();
-			this.checkBox_CTMessageMacros = new System.Windows.Forms.CheckBox();
-			this.checkBox_MessageMacros = new System.Windows.Forms.CheckBox();
-			this.checkBox_MacroCodes = new System.Windows.Forms.CheckBox();
-			this.checkBox_Macros = new System.Windows.Forms.CheckBox();
-			this.groupBox6 = new System.Windows.Forms.GroupBox();
-			this.checkBox_PreAccessPrefix = new System.Windows.Forms.CheckBox();
-			this.checkBox_RemoteBaseMemories = new System.Windows.Forms.CheckBox();
-			this.checkBox_GeneralTimers = new System.Windows.Forms.CheckBox();
-			this.checkBox_Alarms = new System.Windows.Forms.CheckBox();
-			this.checkBox_AnalogMeters = new System.Windows.Forms.CheckBox();
-			this.checkBox_SetpointsScheduler = new System.Windows.Forms.CheckBox();
-			this.checkBox_GlobalLockCode = new System.Windows.Forms.CheckBox();
-			this.checkBox_TerminatorDigit = new System.Windows.Forms.CheckBox();
-			this.groupBox7 = new System.Windows.Forms.GroupBox();
-			this.checkBox_DTMFMemories = new System.Windows.Forms.CheckBox();
-			this.checkBox_DTMFTestPadCode = new System.Windows.Forms.CheckBox();
-			this.groupBox8 = new System.Windows.Forms.GroupBox();
-			this.checkBox_APSettings = new System.Windows.Forms.CheckBox();
-			this.checkBox_APMemories = new System.Windows.Forms.CheckBox();
-			this.checkBox_APPrefix = new System.Windows.Forms.CheckBox();
-			this.checkBox_APAnswerCode = new System.Windows.Forms.CheckBox();
-			this.checkBox_APTollRestrictions = new System.Windows.Forms.CheckBox();
-			this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.recallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.portNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.port1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.port2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.port3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.macroDefinitionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.versionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.updateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.reportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.generateReportToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.viewReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.openReportFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.checkBox_CustomHeader = new System.Windows.Forms.CheckBox();
-			this.checkBox_DateHeader = new System.Windows.Forms.CheckBox();
-			this.textBox_CustomHeader = new System.Windows.Forms.TextBox();
-			this.groupBox2 = new System.Windows.Forms.GroupBox();
-			this.checkBox_RTCOption = new System.Windows.Forms.CheckBox();
-			this.comboBox_FwVersion = new System.Windows.Forms.ComboBox();
-			this.groupBox_Port1.SuspendLayout();
-			this.groupBox_Port2.SuspendLayout();
-			this.groupBox_Port3.SuspendLayout();
-			this.groupBox4.SuspendLayout();
-			this.groupBox6.SuspendLayout();
-			this.groupBox7.SuspendLayout();
-			this.groupBox8.SuspendLayout();
-			this.menuStrip1.SuspendLayout();
-			this.groupBox1.SuspendLayout();
-			this.groupBox2.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// groupBox_Port1
-			// 
-			this.groupBox_Port1.Controls.Add(this.checkBox_P1Switches);
-			this.groupBox_Port1.Controls.Add(this.checkBox_P1Timers);
-			this.groupBox_Port1.Controls.Add(this.checkBox_P1TailMessages);
-			this.groupBox_Port1.Controls.Add(this.checkBox_P1UnlockCode);
-			this.groupBox_Port1.Controls.Add(this.checkBox_P1IDs);
-			this.groupBox_Port1.Location = new System.Drawing.Point(12, 27);
-			this.groupBox_Port1.Name = "groupBox_Port1";
-			this.groupBox_Port1.Size = new System.Drawing.Size(331, 44);
-			this.groupBox_Port1.TabIndex = 3;
-			this.groupBox_Port1.TabStop = false;
-			this.groupBox_Port1.Text = "Port 1";
-			// 
-			// checkBox_P1Switches
-			// 
-			this.checkBox_P1Switches.AutoSize = true;
-			this.checkBox_P1Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Switches;
-			this.checkBox_P1Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P1Switches.Location = new System.Drawing.Point(252, 20);
-			this.checkBox_P1Switches.Name = "checkBox_P1Switches";
-			this.checkBox_P1Switches.Size = new System.Drawing.Size(69, 17);
-			this.checkBox_P1Switches.TabIndex = 5;
-			this.checkBox_P1Switches.Text = "Switches";
-			this.checkBox_P1Switches.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P1Timers
-			// 
-			this.checkBox_P1Timers.AutoSize = true;
-			this.checkBox_P1Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Timers;
-			this.checkBox_P1Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P1Timers.Location = new System.Drawing.Point(188, 19);
-			this.checkBox_P1Timers.Name = "checkBox_P1Timers";
-			this.checkBox_P1Timers.Size = new System.Drawing.Size(57, 17);
-			this.checkBox_P1Timers.TabIndex = 4;
-			this.checkBox_P1Timers.Text = "Timers";
-			this.checkBox_P1Timers.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P1TailMessages
-			// 
-			this.checkBox_P1TailMessages.AutoSize = true;
-			this.checkBox_P1TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1TailMsgs;
-			this.checkBox_P1TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P1TailMessages.Location = new System.Drawing.Point(111, 19);
-			this.checkBox_P1TailMessages.Name = "checkBox_P1TailMessages";
-			this.checkBox_P1TailMessages.Size = new System.Drawing.Size(71, 17);
-			this.checkBox_P1TailMessages.TabIndex = 4;
-			this.checkBox_P1TailMessages.Text = "Tail Msgs";
-			this.checkBox_P1TailMessages.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P1UnlockCode
-			// 
-			this.checkBox_P1UnlockCode.AutoSize = true;
-			this.checkBox_P1UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1UnlockCode;
-			this.checkBox_P1UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P1UnlockCode.Location = new System.Drawing.Point(6, 19);
-			this.checkBox_P1UnlockCode.Name = "checkBox_P1UnlockCode";
-			this.checkBox_P1UnlockCode.Size = new System.Drawing.Size(51, 17);
-			this.checkBox_P1UnlockCode.TabIndex = 4;
-			this.checkBox_P1UnlockCode.Text = "Code";
-			this.checkBox_P1UnlockCode.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P1IDs
-			// 
-			this.checkBox_P1IDs.AutoSize = true;
-			this.checkBox_P1IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1IDs;
-			this.checkBox_P1IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P1IDs.Location = new System.Drawing.Point(63, 19);
-			this.checkBox_P1IDs.Name = "checkBox_P1IDs";
-			this.checkBox_P1IDs.Size = new System.Drawing.Size(42, 17);
-			this.checkBox_P1IDs.TabIndex = 4;
-			this.checkBox_P1IDs.Text = "IDs";
-			this.checkBox_P1IDs.UseVisualStyleBackColor = true;
-			// 
-			// groupBox_Port2
-			// 
-			this.groupBox_Port2.Controls.Add(this.checkBox_P2Switches);
-			this.groupBox_Port2.Controls.Add(this.checkBox_P2Timers);
-			this.groupBox_Port2.Controls.Add(this.checkBox_P2TailMessages);
-			this.groupBox_Port2.Controls.Add(this.checkBox_P2UnlockCode);
-			this.groupBox_Port2.Controls.Add(this.checkBox_P2IDs);
-			this.groupBox_Port2.Location = new System.Drawing.Point(12, 77);
-			this.groupBox_Port2.Name = "groupBox_Port2";
-			this.groupBox_Port2.Size = new System.Drawing.Size(331, 44);
-			this.groupBox_Port2.TabIndex = 3;
-			this.groupBox_Port2.TabStop = false;
-			this.groupBox_Port2.Text = "Port 2";
-			// 
-			// checkBox_P2Switches
-			// 
-			this.checkBox_P2Switches.AutoSize = true;
-			this.checkBox_P2Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Switches;
-			this.checkBox_P2Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P2Switches.Location = new System.Drawing.Point(252, 19);
-			this.checkBox_P2Switches.Name = "checkBox_P2Switches";
-			this.checkBox_P2Switches.Size = new System.Drawing.Size(69, 17);
-			this.checkBox_P2Switches.TabIndex = 5;
-			this.checkBox_P2Switches.Text = "Switches";
-			this.checkBox_P2Switches.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P2Timers
-			// 
-			this.checkBox_P2Timers.AutoSize = true;
-			this.checkBox_P2Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Timers;
-			this.checkBox_P2Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P2Timers.Location = new System.Drawing.Point(188, 19);
-			this.checkBox_P2Timers.Name = "checkBox_P2Timers";
-			this.checkBox_P2Timers.Size = new System.Drawing.Size(57, 17);
-			this.checkBox_P2Timers.TabIndex = 4;
-			this.checkBox_P2Timers.Text = "Timers";
-			this.checkBox_P2Timers.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P2TailMessages
-			// 
-			this.checkBox_P2TailMessages.AutoSize = true;
-			this.checkBox_P2TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2TailMsgs;
-			this.checkBox_P2TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P2TailMessages.Location = new System.Drawing.Point(111, 19);
-			this.checkBox_P2TailMessages.Name = "checkBox_P2TailMessages";
-			this.checkBox_P2TailMessages.Size = new System.Drawing.Size(71, 17);
-			this.checkBox_P2TailMessages.TabIndex = 4;
-			this.checkBox_P2TailMessages.Text = "Tail Msgs";
-			this.checkBox_P2TailMessages.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P2UnlockCode
-			// 
-			this.checkBox_P2UnlockCode.AutoSize = true;
-			this.checkBox_P2UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2UnlockCode;
-			this.checkBox_P2UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P2UnlockCode.Location = new System.Drawing.Point(6, 19);
-			this.checkBox_P2UnlockCode.Name = "checkBox_P2UnlockCode";
-			this.checkBox_P2UnlockCode.Size = new System.Drawing.Size(51, 17);
-			this.checkBox_P2UnlockCode.TabIndex = 4;
-			this.checkBox_P2UnlockCode.Text = "Code";
-			this.checkBox_P2UnlockCode.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P2IDs
-			// 
-			this.checkBox_P2IDs.AutoSize = true;
-			this.checkBox_P2IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2IDs;
-			this.checkBox_P2IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P2IDs.Location = new System.Drawing.Point(63, 19);
-			this.checkBox_P2IDs.Name = "checkBox_P2IDs";
-			this.checkBox_P2IDs.Size = new System.Drawing.Size(42, 17);
-			this.checkBox_P2IDs.TabIndex = 4;
-			this.checkBox_P2IDs.Text = "IDs";
-			this.checkBox_P2IDs.UseVisualStyleBackColor = true;
-			// 
-			// groupBox_Port3
-			// 
-			this.groupBox_Port3.Controls.Add(this.checkBox_P3Switches);
-			this.groupBox_Port3.Controls.Add(this.checkBox_P3Timers);
-			this.groupBox_Port3.Controls.Add(this.checkBox_P3TailMessages);
-			this.groupBox_Port3.Controls.Add(this.checkBox_P3UnlockCode);
-			this.groupBox_Port3.Controls.Add(this.checkBox_P3IDs);
-			this.groupBox_Port3.Location = new System.Drawing.Point(12, 127);
-			this.groupBox_Port3.Name = "groupBox_Port3";
-			this.groupBox_Port3.Size = new System.Drawing.Size(331, 44);
-			this.groupBox_Port3.TabIndex = 3;
-			this.groupBox_Port3.TabStop = false;
-			this.groupBox_Port3.Text = "Port 3";
-			// 
-			// checkBox_P3Switches
-			// 
-			this.checkBox_P3Switches.AutoSize = true;
-			this.checkBox_P3Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Switches;
-			this.checkBox_P3Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P3Switches.Location = new System.Drawing.Point(252, 19);
-			this.checkBox_P3Switches.Name = "checkBox_P3Switches";
-			this.checkBox_P3Switches.Size = new System.Drawing.Size(69, 17);
-			this.checkBox_P3Switches.TabIndex = 5;
-			this.checkBox_P3Switches.Text = "Switches";
-			this.checkBox_P3Switches.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P3Timers
-			// 
-			this.checkBox_P3Timers.AutoSize = true;
-			this.checkBox_P3Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Timers;
-			this.checkBox_P3Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P3Timers.Location = new System.Drawing.Point(188, 19);
-			this.checkBox_P3Timers.Name = "checkBox_P3Timers";
-			this.checkBox_P3Timers.Size = new System.Drawing.Size(57, 17);
-			this.checkBox_P3Timers.TabIndex = 4;
-			this.checkBox_P3Timers.Text = "Timers";
-			this.checkBox_P3Timers.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P3TailMessages
-			// 
-			this.checkBox_P3TailMessages.AutoSize = true;
-			this.checkBox_P3TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3TailMsgs;
-			this.checkBox_P3TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P3TailMessages.Location = new System.Drawing.Point(111, 19);
-			this.checkBox_P3TailMessages.Name = "checkBox_P3TailMessages";
-			this.checkBox_P3TailMessages.Size = new System.Drawing.Size(71, 17);
-			this.checkBox_P3TailMessages.TabIndex = 4;
-			this.checkBox_P3TailMessages.Text = "Tail Msgs";
-			this.checkBox_P3TailMessages.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P3UnlockCode
-			// 
-			this.checkBox_P3UnlockCode.AutoSize = true;
-			this.checkBox_P3UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3UnlockCode;
-			this.checkBox_P3UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P3UnlockCode.Location = new System.Drawing.Point(6, 19);
-			this.checkBox_P3UnlockCode.Name = "checkBox_P3UnlockCode";
-			this.checkBox_P3UnlockCode.Size = new System.Drawing.Size(51, 17);
-			this.checkBox_P3UnlockCode.TabIndex = 4;
-			this.checkBox_P3UnlockCode.Text = "Code";
-			this.checkBox_P3UnlockCode.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_P3IDs
-			// 
-			this.checkBox_P3IDs.AutoSize = true;
-			this.checkBox_P3IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3IDs;
-			this.checkBox_P3IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_P3IDs.Location = new System.Drawing.Point(63, 19);
-			this.checkBox_P3IDs.Name = "checkBox_P3IDs";
-			this.checkBox_P3IDs.Size = new System.Drawing.Size(42, 17);
-			this.checkBox_P3IDs.TabIndex = 4;
-			this.checkBox_P3IDs.Text = "IDs";
-			this.checkBox_P3IDs.UseVisualStyleBackColor = true;
-			// 
-			// groupBox4
-			// 
-			this.groupBox4.Controls.Add(this.checkBox_CTMessageMacros);
-			this.groupBox4.Controls.Add(this.checkBox_MessageMacros);
-			this.groupBox4.Controls.Add(this.checkBox_MacroCodes);
-			this.groupBox4.Controls.Add(this.checkBox_Macros);
-			this.groupBox4.Location = new System.Drawing.Point(349, 27);
-			this.groupBox4.Name = "groupBox4";
-			this.groupBox4.Size = new System.Drawing.Size(136, 144);
-			this.groupBox4.TabIndex = 6;
-			this.groupBox4.TabStop = false;
-			this.groupBox4.Text = "Macros";
-			// 
-			// checkBox_CTMessageMacros
-			// 
-			this.checkBox_CTMessageMacros.AutoSize = true;
-			this.checkBox_CTMessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CTMessageMacros;
-			this.checkBox_CTMessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CTMessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_CTMessageMacros.Location = new System.Drawing.Point(6, 88);
-			this.checkBox_CTMessageMacros.Name = "checkBox_CTMessageMacros";
-			this.checkBox_CTMessageMacros.Size = new System.Drawing.Size(124, 17);
-			this.checkBox_CTMessageMacros.TabIndex = 4;
-			this.checkBox_CTMessageMacros.Text = "CT Message Macros";
-			this.checkBox_CTMessageMacros.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_MessageMacros
-			// 
-			this.checkBox_MessageMacros.AutoSize = true;
-			this.checkBox_MessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MessageMacros;
-			this.checkBox_MessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_MessageMacros.Location = new System.Drawing.Point(6, 65);
-			this.checkBox_MessageMacros.Name = "checkBox_MessageMacros";
-			this.checkBox_MessageMacros.Size = new System.Drawing.Size(107, 17);
-			this.checkBox_MessageMacros.TabIndex = 4;
-			this.checkBox_MessageMacros.Text = "Message Macros";
-			this.checkBox_MessageMacros.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_MacroCodes
-			// 
-			this.checkBox_MacroCodes.AutoSize = true;
-			this.checkBox_MacroCodes.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MacroCodes;
-			this.checkBox_MacroCodes.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MacroCodes", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_MacroCodes.Location = new System.Drawing.Point(6, 42);
-			this.checkBox_MacroCodes.Name = "checkBox_MacroCodes";
-			this.checkBox_MacroCodes.Size = new System.Drawing.Size(119, 17);
-			this.checkBox_MacroCodes.TabIndex = 4;
-			this.checkBox_MacroCodes.Text = "Show Macro Codes";
-			this.checkBox_MacroCodes.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_Macros
-			// 
-			this.checkBox_Macros.AutoSize = true;
-			this.checkBox_Macros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Macros;
-			this.checkBox_Macros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Macros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_Macros.Location = new System.Drawing.Point(6, 19);
-			this.checkBox_Macros.Name = "checkBox_Macros";
-			this.checkBox_Macros.Size = new System.Drawing.Size(61, 17);
-			this.checkBox_Macros.TabIndex = 4;
-			this.checkBox_Macros.Text = "Macros";
-			this.checkBox_Macros.UseVisualStyleBackColor = true;
-			// 
-			// groupBox6
-			// 
-			this.groupBox6.Controls.Add(this.checkBox_PreAccessPrefix);
-			this.groupBox6.Controls.Add(this.checkBox_RemoteBaseMemories);
-			this.groupBox6.Controls.Add(this.checkBox_GeneralTimers);
-			this.groupBox6.Controls.Add(this.checkBox_Alarms);
-			this.groupBox6.Controls.Add(this.checkBox_AnalogMeters);
-			this.groupBox6.Controls.Add(this.checkBox_SetpointsScheduler);
-			this.groupBox6.Controls.Add(this.checkBox_GlobalLockCode);
-			this.groupBox6.Controls.Add(this.checkBox_TerminatorDigit);
-			this.groupBox6.Location = new System.Drawing.Point(491, 27);
-			this.groupBox6.Name = "groupBox6";
-			this.groupBox6.Size = new System.Drawing.Size(146, 209);
-			this.groupBox6.TabIndex = 6;
-			this.groupBox6.TabStop = false;
-			this.groupBox6.Text = "Misc";
-			// 
-			// checkBox_PreAccessPrefix
-			// 
-			this.checkBox_PreAccessPrefix.AutoSize = true;
-			this.checkBox_PreAccessPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.PreAccessPrefix;
-			this.checkBox_PreAccessPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "PreAccessPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_PreAccessPrefix.Location = new System.Drawing.Point(5, 19);
-			this.checkBox_PreAccessPrefix.Name = "checkBox_PreAccessPrefix";
-			this.checkBox_PreAccessPrefix.Size = new System.Drawing.Size(106, 17);
-			this.checkBox_PreAccessPrefix.TabIndex = 5;
-			this.checkBox_PreAccessPrefix.Text = "PreAccess Prefix";
-			this.checkBox_PreAccessPrefix.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_RemoteBaseMemories
-			// 
-			this.checkBox_RemoteBaseMemories.AutoSize = true;
-			this.checkBox_RemoteBaseMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RemoteBaseMemories;
-			this.checkBox_RemoteBaseMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RemoteBaseMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_RemoteBaseMemories.Location = new System.Drawing.Point(5, 180);
-			this.checkBox_RemoteBaseMemories.Name = "checkBox_RemoteBaseMemories";
-			this.checkBox_RemoteBaseMemories.Size = new System.Drawing.Size(138, 17);
-			this.checkBox_RemoteBaseMemories.TabIndex = 4;
-			this.checkBox_RemoteBaseMemories.Text = "Remote Base Memories";
-			this.checkBox_RemoteBaseMemories.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_GeneralTimers
-			// 
-			this.checkBox_GeneralTimers.AutoSize = true;
-			this.checkBox_GeneralTimers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GeneralTimers;
-			this.checkBox_GeneralTimers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GeneralTimers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_GeneralTimers.Location = new System.Drawing.Point(6, 157);
-			this.checkBox_GeneralTimers.Name = "checkBox_GeneralTimers";
-			this.checkBox_GeneralTimers.Size = new System.Drawing.Size(97, 17);
-			this.checkBox_GeneralTimers.TabIndex = 4;
-			this.checkBox_GeneralTimers.Text = "General Timers";
-			this.checkBox_GeneralTimers.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_Alarms
-			// 
-			this.checkBox_Alarms.AutoSize = true;
-			this.checkBox_Alarms.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Alarms;
-			this.checkBox_Alarms.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Alarms", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_Alarms.Location = new System.Drawing.Point(6, 134);
-			this.checkBox_Alarms.Name = "checkBox_Alarms";
-			this.checkBox_Alarms.Size = new System.Drawing.Size(57, 17);
-			this.checkBox_Alarms.TabIndex = 4;
-			this.checkBox_Alarms.Text = "Alarms";
-			this.checkBox_Alarms.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_AnalogMeters
-			// 
-			this.checkBox_AnalogMeters.AutoSize = true;
-			this.checkBox_AnalogMeters.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.AnalogMeters;
-			this.checkBox_AnalogMeters.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "AnalogMeters", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_AnalogMeters.Location = new System.Drawing.Point(6, 111);
-			this.checkBox_AnalogMeters.Name = "checkBox_AnalogMeters";
-			this.checkBox_AnalogMeters.Size = new System.Drawing.Size(94, 17);
-			this.checkBox_AnalogMeters.TabIndex = 4;
-			this.checkBox_AnalogMeters.Text = "Analog Meters";
-			this.checkBox_AnalogMeters.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_SetpointsScheduler
-			// 
-			this.checkBox_SetpointsScheduler.AutoSize = true;
-			this.checkBox_SetpointsScheduler.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.SetpointsScheduler;
-			this.checkBox_SetpointsScheduler.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "SetpointsScheduler", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_SetpointsScheduler.Location = new System.Drawing.Point(6, 88);
-			this.checkBox_SetpointsScheduler.Name = "checkBox_SetpointsScheduler";
-			this.checkBox_SetpointsScheduler.Size = new System.Drawing.Size(123, 17);
-			this.checkBox_SetpointsScheduler.TabIndex = 4;
-			this.checkBox_SetpointsScheduler.Text = "Setpoints/Scheduler";
-			this.checkBox_SetpointsScheduler.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_GlobalLockCode
-			// 
-			this.checkBox_GlobalLockCode.AutoSize = true;
-			this.checkBox_GlobalLockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GlobalLockCode;
-			this.checkBox_GlobalLockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GlobalLockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_GlobalLockCode.Location = new System.Drawing.Point(6, 42);
-			this.checkBox_GlobalLockCode.Name = "checkBox_GlobalLockCode";
-			this.checkBox_GlobalLockCode.Size = new System.Drawing.Size(106, 17);
-			this.checkBox_GlobalLockCode.TabIndex = 4;
-			this.checkBox_GlobalLockCode.Text = "Global lock code";
-			this.checkBox_GlobalLockCode.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_TerminatorDigit
-			// 
-			this.checkBox_TerminatorDigit.AutoSize = true;
-			this.checkBox_TerminatorDigit.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.TerminatorDigit;
-			this.checkBox_TerminatorDigit.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "TerminatorDigit", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_TerminatorDigit.Location = new System.Drawing.Point(6, 65);
-			this.checkBox_TerminatorDigit.Name = "checkBox_TerminatorDigit";
-			this.checkBox_TerminatorDigit.Size = new System.Drawing.Size(100, 17);
-			this.checkBox_TerminatorDigit.TabIndex = 4;
-			this.checkBox_TerminatorDigit.Text = "Terminator Digit";
-			this.checkBox_TerminatorDigit.UseVisualStyleBackColor = true;
-			// 
-			// groupBox7
-			// 
-			this.groupBox7.Controls.Add(this.checkBox_DTMFMemories);
-			this.groupBox7.Controls.Add(this.checkBox_DTMFTestPadCode);
-			this.groupBox7.Location = new System.Drawing.Point(491, 240);
-			this.groupBox7.Name = "groupBox7";
-			this.groupBox7.Size = new System.Drawing.Size(146, 69);
-			this.groupBox7.TabIndex = 6;
-			this.groupBox7.TabStop = false;
-			this.groupBox7.Text = "DTMF";
-			// 
-			// checkBox_DTMFMemories
-			// 
-			this.checkBox_DTMFMemories.AutoSize = true;
-			this.checkBox_DTMFMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFMemories;
-			this.checkBox_DTMFMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_DTMFMemories.Location = new System.Drawing.Point(6, 19);
-			this.checkBox_DTMFMemories.Name = "checkBox_DTMFMemories";
-			this.checkBox_DTMFMemories.Size = new System.Drawing.Size(71, 17);
-			this.checkBox_DTMFMemories.TabIndex = 4;
-			this.checkBox_DTMFMemories.Text = "Memories";
-			this.checkBox_DTMFMemories.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_DTMFTestPadCode
-			// 
-			this.checkBox_DTMFTestPadCode.AutoSize = true;
-			this.checkBox_DTMFTestPadCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFTestPadCode;
-			this.checkBox_DTMFTestPadCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFTestPadCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_DTMFTestPadCode.Location = new System.Drawing.Point(6, 42);
-			this.checkBox_DTMFTestPadCode.Name = "checkBox_DTMFTestPadCode";
-			this.checkBox_DTMFTestPadCode.Size = new System.Drawing.Size(97, 17);
-			this.checkBox_DTMFTestPadCode.TabIndex = 4;
-			this.checkBox_DTMFTestPadCode.Text = "Test Pad Code";
-			this.checkBox_DTMFTestPadCode.UseVisualStyleBackColor = true;
-			// 
-			// groupBox8
-			// 
-			this.groupBox8.Controls.Add(this.checkBox_APSettings);
-			this.groupBox8.Controls.Add(this.checkBox_APMemories);
-			this.groupBox8.Controls.Add(this.checkBox_APPrefix);
-			this.groupBox8.Controls.Add(this.checkBox_APAnswerCode);
-			this.groupBox8.Controls.Add(this.checkBox_APTollRestrictions);
-			this.groupBox8.Location = new System.Drawing.Point(349, 177);
-			this.groupBox8.Name = "groupBox8";
-			this.groupBox8.Size = new System.Drawing.Size(136, 132);
-			this.groupBox8.TabIndex = 6;
-			this.groupBox8.TabStop = false;
-			this.groupBox8.Text = "Auto Patch";
-			// 
-			// checkBox_APSettings
-			// 
-			this.checkBox_APSettings.AutoSize = true;
-			this.checkBox_APSettings.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APSettings;
-			this.checkBox_APSettings.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APSettings", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_APSettings.Location = new System.Drawing.Point(5, 20);
-			this.checkBox_APSettings.Name = "checkBox_APSettings";
-			this.checkBox_APSettings.Size = new System.Drawing.Size(64, 17);
-			this.checkBox_APSettings.TabIndex = 5;
-			this.checkBox_APSettings.Text = "Settings";
-			this.checkBox_APSettings.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_APMemories
-			// 
-			this.checkBox_APMemories.AutoSize = true;
-			this.checkBox_APMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APMemories;
-			this.checkBox_APMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_APMemories.Location = new System.Drawing.Point(5, 88);
-			this.checkBox_APMemories.Name = "checkBox_APMemories";
-			this.checkBox_APMemories.Size = new System.Drawing.Size(71, 17);
-			this.checkBox_APMemories.TabIndex = 4;
-			this.checkBox_APMemories.Text = "Memories";
-			this.checkBox_APMemories.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_APPrefix
-			// 
-			this.checkBox_APPrefix.AutoSize = true;
-			this.checkBox_APPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APPrefix;
-			this.checkBox_APPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_APPrefix.Location = new System.Drawing.Point(5, 42);
-			this.checkBox_APPrefix.Name = "checkBox_APPrefix";
-			this.checkBox_APPrefix.Size = new System.Drawing.Size(52, 17);
-			this.checkBox_APPrefix.TabIndex = 4;
-			this.checkBox_APPrefix.Text = "Prefix";
-			this.checkBox_APPrefix.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_APAnswerCode
-			// 
-			this.checkBox_APAnswerCode.AutoSize = true;
-			this.checkBox_APAnswerCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APAnswerCode;
-			this.checkBox_APAnswerCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APAnswerCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_APAnswerCode.Location = new System.Drawing.Point(5, 65);
-			this.checkBox_APAnswerCode.Name = "checkBox_APAnswerCode";
-			this.checkBox_APAnswerCode.Size = new System.Drawing.Size(92, 17);
-			this.checkBox_APAnswerCode.TabIndex = 4;
-			this.checkBox_APAnswerCode.Text = " Answer Code";
-			this.checkBox_APAnswerCode.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_APTollRestrictions
-			// 
-			this.checkBox_APTollRestrictions.AutoSize = true;
-			this.checkBox_APTollRestrictions.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APTollRestrictions;
-			this.checkBox_APTollRestrictions.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APTollRestrictions", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_APTollRestrictions.Location = new System.Drawing.Point(5, 111);
-			this.checkBox_APTollRestrictions.Name = "checkBox_APTollRestrictions";
-			this.checkBox_APTollRestrictions.Size = new System.Drawing.Size(101, 17);
-			this.checkBox_APTollRestrictions.TabIndex = 4;
-			this.checkBox_APTollRestrictions.Text = "Toll Restrictions";
-			this.checkBox_APTollRestrictions.UseVisualStyleBackColor = true;
-			// 
-			// menuStrip1
-			// 
-			this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.groupBox_Port1 = new System.Windows.Forms.GroupBox();
+            this.checkBox_P1Switches = new System.Windows.Forms.CheckBox();
+            this.checkBox_P1Timers = new System.Windows.Forms.CheckBox();
+            this.checkBox_P1TailMessages = new System.Windows.Forms.CheckBox();
+            this.checkBox_P1UnlockCode = new System.Windows.Forms.CheckBox();
+            this.checkBox_P1IDs = new System.Windows.Forms.CheckBox();
+            this.groupBox_Port2 = new System.Windows.Forms.GroupBox();
+            this.checkBox_P2Switches = new System.Windows.Forms.CheckBox();
+            this.checkBox_P2Timers = new System.Windows.Forms.CheckBox();
+            this.checkBox_P2TailMessages = new System.Windows.Forms.CheckBox();
+            this.checkBox_P2UnlockCode = new System.Windows.Forms.CheckBox();
+            this.checkBox_P2IDs = new System.Windows.Forms.CheckBox();
+            this.groupBox_Port3 = new System.Windows.Forms.GroupBox();
+            this.checkBox_P3Switches = new System.Windows.Forms.CheckBox();
+            this.checkBox_P3Timers = new System.Windows.Forms.CheckBox();
+            this.checkBox_P3TailMessages = new System.Windows.Forms.CheckBox();
+            this.checkBox_P3UnlockCode = new System.Windows.Forms.CheckBox();
+            this.checkBox_P3IDs = new System.Windows.Forms.CheckBox();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.checkBox_CTMessageMacros = new System.Windows.Forms.CheckBox();
+            this.checkBox_MessageMacros = new System.Windows.Forms.CheckBox();
+            this.checkBox_MacroCodes = new System.Windows.Forms.CheckBox();
+            this.checkBox_Macros = new System.Windows.Forms.CheckBox();
+            this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.checkBox_PreAccessPrefix = new System.Windows.Forms.CheckBox();
+            this.checkBox_RemoteBaseMemories = new System.Windows.Forms.CheckBox();
+            this.checkBox_GeneralTimers = new System.Windows.Forms.CheckBox();
+            this.checkBox_Alarms = new System.Windows.Forms.CheckBox();
+            this.checkBox_AnalogMeters = new System.Windows.Forms.CheckBox();
+            this.checkBox_SetpointsScheduler = new System.Windows.Forms.CheckBox();
+            this.checkBox_GlobalLockCode = new System.Windows.Forms.CheckBox();
+            this.checkBox_TerminatorDigit = new System.Windows.Forms.CheckBox();
+            this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.checkBox_DTMFMemories = new System.Windows.Forms.CheckBox();
+            this.checkBox_DTMFTestPadCode = new System.Windows.Forms.CheckBox();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.checkBox_APSettings = new System.Windows.Forms.CheckBox();
+            this.checkBox_APMemories = new System.Windows.Forms.CheckBox();
+            this.checkBox_APPrefix = new System.Windows.Forms.CheckBox();
+            this.checkBox_APAnswerCode = new System.Windows.Forms.CheckBox();
+            this.checkBox_APTollRestrictions = new System.Windows.Forms.CheckBox();
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.recallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.portNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.port1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.port2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.port3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.macroDefinitionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.versionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.updateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.xMLFilePathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.reportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.generateReportToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.viewReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openReportFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.checkBox_CustomHeader = new System.Windows.Forms.CheckBox();
+            this.checkBox_DateHeader = new System.Windows.Forms.CheckBox();
+            this.textBox_CustomHeader = new System.Windows.Forms.TextBox();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.checkBox_RTCOption = new System.Windows.Forms.CheckBox();
+            this.comboBox_FwVersion = new System.Windows.Forms.ComboBox();
+            this.groupBox_Port1.SuspendLayout();
+            this.groupBox_Port2.SuspendLayout();
+            this.groupBox_Port3.SuspendLayout();
+            this.groupBox4.SuspendLayout();
+            this.groupBox6.SuspendLayout();
+            this.groupBox7.SuspendLayout();
+            this.groupBox8.SuspendLayout();
+            this.menuStrip1.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox_Port1
+            // 
+            this.groupBox_Port1.Controls.Add(this.checkBox_P1Switches);
+            this.groupBox_Port1.Controls.Add(this.checkBox_P1Timers);
+            this.groupBox_Port1.Controls.Add(this.checkBox_P1TailMessages);
+            this.groupBox_Port1.Controls.Add(this.checkBox_P1UnlockCode);
+            this.groupBox_Port1.Controls.Add(this.checkBox_P1IDs);
+            this.groupBox_Port1.Location = new System.Drawing.Point(12, 27);
+            this.groupBox_Port1.Name = "groupBox_Port1";
+            this.groupBox_Port1.Size = new System.Drawing.Size(331, 44);
+            this.groupBox_Port1.TabIndex = 3;
+            this.groupBox_Port1.TabStop = false;
+            this.groupBox_Port1.Text = "Port 1";
+            // 
+            // checkBox_P1Switches
+            // 
+            this.checkBox_P1Switches.AutoSize = true;
+            this.checkBox_P1Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Switches;
+            this.checkBox_P1Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P1Switches.Location = new System.Drawing.Point(252, 20);
+            this.checkBox_P1Switches.Name = "checkBox_P1Switches";
+            this.checkBox_P1Switches.Size = new System.Drawing.Size(69, 17);
+            this.checkBox_P1Switches.TabIndex = 5;
+            this.checkBox_P1Switches.Text = "Switches";
+            this.checkBox_P1Switches.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P1Timers
+            // 
+            this.checkBox_P1Timers.AutoSize = true;
+            this.checkBox_P1Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1Timers;
+            this.checkBox_P1Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P1Timers.Location = new System.Drawing.Point(188, 19);
+            this.checkBox_P1Timers.Name = "checkBox_P1Timers";
+            this.checkBox_P1Timers.Size = new System.Drawing.Size(57, 17);
+            this.checkBox_P1Timers.TabIndex = 4;
+            this.checkBox_P1Timers.Text = "Timers";
+            this.checkBox_P1Timers.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P1TailMessages
+            // 
+            this.checkBox_P1TailMessages.AutoSize = true;
+            this.checkBox_P1TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1TailMsgs;
+            this.checkBox_P1TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P1TailMessages.Location = new System.Drawing.Point(111, 19);
+            this.checkBox_P1TailMessages.Name = "checkBox_P1TailMessages";
+            this.checkBox_P1TailMessages.Size = new System.Drawing.Size(71, 17);
+            this.checkBox_P1TailMessages.TabIndex = 4;
+            this.checkBox_P1TailMessages.Text = "Tail Msgs";
+            this.checkBox_P1TailMessages.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P1UnlockCode
+            // 
+            this.checkBox_P1UnlockCode.AutoSize = true;
+            this.checkBox_P1UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1UnlockCode;
+            this.checkBox_P1UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P1UnlockCode.Location = new System.Drawing.Point(6, 19);
+            this.checkBox_P1UnlockCode.Name = "checkBox_P1UnlockCode";
+            this.checkBox_P1UnlockCode.Size = new System.Drawing.Size(51, 17);
+            this.checkBox_P1UnlockCode.TabIndex = 4;
+            this.checkBox_P1UnlockCode.Text = "Code";
+            this.checkBox_P1UnlockCode.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P1IDs
+            // 
+            this.checkBox_P1IDs.AutoSize = true;
+            this.checkBox_P1IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P1IDs;
+            this.checkBox_P1IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P1IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P1IDs.Location = new System.Drawing.Point(63, 19);
+            this.checkBox_P1IDs.Name = "checkBox_P1IDs";
+            this.checkBox_P1IDs.Size = new System.Drawing.Size(42, 17);
+            this.checkBox_P1IDs.TabIndex = 4;
+            this.checkBox_P1IDs.Text = "IDs";
+            this.checkBox_P1IDs.UseVisualStyleBackColor = true;
+            // 
+            // groupBox_Port2
+            // 
+            this.groupBox_Port2.Controls.Add(this.checkBox_P2Switches);
+            this.groupBox_Port2.Controls.Add(this.checkBox_P2Timers);
+            this.groupBox_Port2.Controls.Add(this.checkBox_P2TailMessages);
+            this.groupBox_Port2.Controls.Add(this.checkBox_P2UnlockCode);
+            this.groupBox_Port2.Controls.Add(this.checkBox_P2IDs);
+            this.groupBox_Port2.Location = new System.Drawing.Point(12, 77);
+            this.groupBox_Port2.Name = "groupBox_Port2";
+            this.groupBox_Port2.Size = new System.Drawing.Size(331, 44);
+            this.groupBox_Port2.TabIndex = 3;
+            this.groupBox_Port2.TabStop = false;
+            this.groupBox_Port2.Text = "Port 2";
+            // 
+            // checkBox_P2Switches
+            // 
+            this.checkBox_P2Switches.AutoSize = true;
+            this.checkBox_P2Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Switches;
+            this.checkBox_P2Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P2Switches.Location = new System.Drawing.Point(252, 19);
+            this.checkBox_P2Switches.Name = "checkBox_P2Switches";
+            this.checkBox_P2Switches.Size = new System.Drawing.Size(69, 17);
+            this.checkBox_P2Switches.TabIndex = 5;
+            this.checkBox_P2Switches.Text = "Switches";
+            this.checkBox_P2Switches.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P2Timers
+            // 
+            this.checkBox_P2Timers.AutoSize = true;
+            this.checkBox_P2Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2Timers;
+            this.checkBox_P2Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P2Timers.Location = new System.Drawing.Point(188, 19);
+            this.checkBox_P2Timers.Name = "checkBox_P2Timers";
+            this.checkBox_P2Timers.Size = new System.Drawing.Size(57, 17);
+            this.checkBox_P2Timers.TabIndex = 4;
+            this.checkBox_P2Timers.Text = "Timers";
+            this.checkBox_P2Timers.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P2TailMessages
+            // 
+            this.checkBox_P2TailMessages.AutoSize = true;
+            this.checkBox_P2TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2TailMsgs;
+            this.checkBox_P2TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P2TailMessages.Location = new System.Drawing.Point(111, 19);
+            this.checkBox_P2TailMessages.Name = "checkBox_P2TailMessages";
+            this.checkBox_P2TailMessages.Size = new System.Drawing.Size(71, 17);
+            this.checkBox_P2TailMessages.TabIndex = 4;
+            this.checkBox_P2TailMessages.Text = "Tail Msgs";
+            this.checkBox_P2TailMessages.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P2UnlockCode
+            // 
+            this.checkBox_P2UnlockCode.AutoSize = true;
+            this.checkBox_P2UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2UnlockCode;
+            this.checkBox_P2UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P2UnlockCode.Location = new System.Drawing.Point(6, 19);
+            this.checkBox_P2UnlockCode.Name = "checkBox_P2UnlockCode";
+            this.checkBox_P2UnlockCode.Size = new System.Drawing.Size(51, 17);
+            this.checkBox_P2UnlockCode.TabIndex = 4;
+            this.checkBox_P2UnlockCode.Text = "Code";
+            this.checkBox_P2UnlockCode.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P2IDs
+            // 
+            this.checkBox_P2IDs.AutoSize = true;
+            this.checkBox_P2IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P2IDs;
+            this.checkBox_P2IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P2IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P2IDs.Location = new System.Drawing.Point(63, 19);
+            this.checkBox_P2IDs.Name = "checkBox_P2IDs";
+            this.checkBox_P2IDs.Size = new System.Drawing.Size(42, 17);
+            this.checkBox_P2IDs.TabIndex = 4;
+            this.checkBox_P2IDs.Text = "IDs";
+            this.checkBox_P2IDs.UseVisualStyleBackColor = true;
+            // 
+            // groupBox_Port3
+            // 
+            this.groupBox_Port3.Controls.Add(this.checkBox_P3Switches);
+            this.groupBox_Port3.Controls.Add(this.checkBox_P3Timers);
+            this.groupBox_Port3.Controls.Add(this.checkBox_P3TailMessages);
+            this.groupBox_Port3.Controls.Add(this.checkBox_P3UnlockCode);
+            this.groupBox_Port3.Controls.Add(this.checkBox_P3IDs);
+            this.groupBox_Port3.Location = new System.Drawing.Point(12, 127);
+            this.groupBox_Port3.Name = "groupBox_Port3";
+            this.groupBox_Port3.Size = new System.Drawing.Size(331, 44);
+            this.groupBox_Port3.TabIndex = 3;
+            this.groupBox_Port3.TabStop = false;
+            this.groupBox_Port3.Text = "Port 3";
+            // 
+            // checkBox_P3Switches
+            // 
+            this.checkBox_P3Switches.AutoSize = true;
+            this.checkBox_P3Switches.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Switches;
+            this.checkBox_P3Switches.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Switches", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P3Switches.Location = new System.Drawing.Point(252, 19);
+            this.checkBox_P3Switches.Name = "checkBox_P3Switches";
+            this.checkBox_P3Switches.Size = new System.Drawing.Size(69, 17);
+            this.checkBox_P3Switches.TabIndex = 5;
+            this.checkBox_P3Switches.Text = "Switches";
+            this.checkBox_P3Switches.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P3Timers
+            // 
+            this.checkBox_P3Timers.AutoSize = true;
+            this.checkBox_P3Timers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3Timers;
+            this.checkBox_P3Timers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3Timers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P3Timers.Location = new System.Drawing.Point(188, 19);
+            this.checkBox_P3Timers.Name = "checkBox_P3Timers";
+            this.checkBox_P3Timers.Size = new System.Drawing.Size(57, 17);
+            this.checkBox_P3Timers.TabIndex = 4;
+            this.checkBox_P3Timers.Text = "Timers";
+            this.checkBox_P3Timers.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P3TailMessages
+            // 
+            this.checkBox_P3TailMessages.AutoSize = true;
+            this.checkBox_P3TailMessages.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3TailMsgs;
+            this.checkBox_P3TailMessages.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3TailMsgs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P3TailMessages.Location = new System.Drawing.Point(111, 19);
+            this.checkBox_P3TailMessages.Name = "checkBox_P3TailMessages";
+            this.checkBox_P3TailMessages.Size = new System.Drawing.Size(71, 17);
+            this.checkBox_P3TailMessages.TabIndex = 4;
+            this.checkBox_P3TailMessages.Text = "Tail Msgs";
+            this.checkBox_P3TailMessages.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P3UnlockCode
+            // 
+            this.checkBox_P3UnlockCode.AutoSize = true;
+            this.checkBox_P3UnlockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3UnlockCode;
+            this.checkBox_P3UnlockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3UnlockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P3UnlockCode.Location = new System.Drawing.Point(6, 19);
+            this.checkBox_P3UnlockCode.Name = "checkBox_P3UnlockCode";
+            this.checkBox_P3UnlockCode.Size = new System.Drawing.Size(51, 17);
+            this.checkBox_P3UnlockCode.TabIndex = 4;
+            this.checkBox_P3UnlockCode.Text = "Code";
+            this.checkBox_P3UnlockCode.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_P3IDs
+            // 
+            this.checkBox_P3IDs.AutoSize = true;
+            this.checkBox_P3IDs.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.P3IDs;
+            this.checkBox_P3IDs.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "P3IDs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_P3IDs.Location = new System.Drawing.Point(63, 19);
+            this.checkBox_P3IDs.Name = "checkBox_P3IDs";
+            this.checkBox_P3IDs.Size = new System.Drawing.Size(42, 17);
+            this.checkBox_P3IDs.TabIndex = 4;
+            this.checkBox_P3IDs.Text = "IDs";
+            this.checkBox_P3IDs.UseVisualStyleBackColor = true;
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.checkBox_CTMessageMacros);
+            this.groupBox4.Controls.Add(this.checkBox_MessageMacros);
+            this.groupBox4.Controls.Add(this.checkBox_MacroCodes);
+            this.groupBox4.Controls.Add(this.checkBox_Macros);
+            this.groupBox4.Location = new System.Drawing.Point(349, 27);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(136, 144);
+            this.groupBox4.TabIndex = 6;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Macros";
+            // 
+            // checkBox_CTMessageMacros
+            // 
+            this.checkBox_CTMessageMacros.AutoSize = true;
+            this.checkBox_CTMessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CTMessageMacros;
+            this.checkBox_CTMessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CTMessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_CTMessageMacros.Location = new System.Drawing.Point(6, 88);
+            this.checkBox_CTMessageMacros.Name = "checkBox_CTMessageMacros";
+            this.checkBox_CTMessageMacros.Size = new System.Drawing.Size(124, 17);
+            this.checkBox_CTMessageMacros.TabIndex = 4;
+            this.checkBox_CTMessageMacros.Text = "CT Message Macros";
+            this.checkBox_CTMessageMacros.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_MessageMacros
+            // 
+            this.checkBox_MessageMacros.AutoSize = true;
+            this.checkBox_MessageMacros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MessageMacros;
+            this.checkBox_MessageMacros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MessageMacros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_MessageMacros.Location = new System.Drawing.Point(6, 65);
+            this.checkBox_MessageMacros.Name = "checkBox_MessageMacros";
+            this.checkBox_MessageMacros.Size = new System.Drawing.Size(107, 17);
+            this.checkBox_MessageMacros.TabIndex = 4;
+            this.checkBox_MessageMacros.Text = "Message Macros";
+            this.checkBox_MessageMacros.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_MacroCodes
+            // 
+            this.checkBox_MacroCodes.AutoSize = true;
+            this.checkBox_MacroCodes.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.MacroCodes;
+            this.checkBox_MacroCodes.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "MacroCodes", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_MacroCodes.Location = new System.Drawing.Point(6, 42);
+            this.checkBox_MacroCodes.Name = "checkBox_MacroCodes";
+            this.checkBox_MacroCodes.Size = new System.Drawing.Size(119, 17);
+            this.checkBox_MacroCodes.TabIndex = 4;
+            this.checkBox_MacroCodes.Text = "Show Macro Codes";
+            this.checkBox_MacroCodes.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_Macros
+            // 
+            this.checkBox_Macros.AutoSize = true;
+            this.checkBox_Macros.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Macros;
+            this.checkBox_Macros.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Macros", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_Macros.Location = new System.Drawing.Point(6, 19);
+            this.checkBox_Macros.Name = "checkBox_Macros";
+            this.checkBox_Macros.Size = new System.Drawing.Size(61, 17);
+            this.checkBox_Macros.TabIndex = 4;
+            this.checkBox_Macros.Text = "Macros";
+            this.checkBox_Macros.UseVisualStyleBackColor = true;
+            // 
+            // groupBox6
+            // 
+            this.groupBox6.Controls.Add(this.checkBox_PreAccessPrefix);
+            this.groupBox6.Controls.Add(this.checkBox_RemoteBaseMemories);
+            this.groupBox6.Controls.Add(this.checkBox_GeneralTimers);
+            this.groupBox6.Controls.Add(this.checkBox_Alarms);
+            this.groupBox6.Controls.Add(this.checkBox_AnalogMeters);
+            this.groupBox6.Controls.Add(this.checkBox_SetpointsScheduler);
+            this.groupBox6.Controls.Add(this.checkBox_GlobalLockCode);
+            this.groupBox6.Controls.Add(this.checkBox_TerminatorDigit);
+            this.groupBox6.Location = new System.Drawing.Point(491, 27);
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.Size = new System.Drawing.Size(146, 209);
+            this.groupBox6.TabIndex = 6;
+            this.groupBox6.TabStop = false;
+            this.groupBox6.Text = "Misc";
+            // 
+            // checkBox_PreAccessPrefix
+            // 
+            this.checkBox_PreAccessPrefix.AutoSize = true;
+            this.checkBox_PreAccessPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.PreAccessPrefix;
+            this.checkBox_PreAccessPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "PreAccessPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_PreAccessPrefix.Location = new System.Drawing.Point(5, 19);
+            this.checkBox_PreAccessPrefix.Name = "checkBox_PreAccessPrefix";
+            this.checkBox_PreAccessPrefix.Size = new System.Drawing.Size(106, 17);
+            this.checkBox_PreAccessPrefix.TabIndex = 5;
+            this.checkBox_PreAccessPrefix.Text = "PreAccess Prefix";
+            this.checkBox_PreAccessPrefix.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_RemoteBaseMemories
+            // 
+            this.checkBox_RemoteBaseMemories.AutoSize = true;
+            this.checkBox_RemoteBaseMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RemoteBaseMemories;
+            this.checkBox_RemoteBaseMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RemoteBaseMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_RemoteBaseMemories.Location = new System.Drawing.Point(5, 180);
+            this.checkBox_RemoteBaseMemories.Name = "checkBox_RemoteBaseMemories";
+            this.checkBox_RemoteBaseMemories.Size = new System.Drawing.Size(138, 17);
+            this.checkBox_RemoteBaseMemories.TabIndex = 4;
+            this.checkBox_RemoteBaseMemories.Text = "Remote Base Memories";
+            this.checkBox_RemoteBaseMemories.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_GeneralTimers
+            // 
+            this.checkBox_GeneralTimers.AutoSize = true;
+            this.checkBox_GeneralTimers.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GeneralTimers;
+            this.checkBox_GeneralTimers.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GeneralTimers", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_GeneralTimers.Location = new System.Drawing.Point(6, 157);
+            this.checkBox_GeneralTimers.Name = "checkBox_GeneralTimers";
+            this.checkBox_GeneralTimers.Size = new System.Drawing.Size(97, 17);
+            this.checkBox_GeneralTimers.TabIndex = 4;
+            this.checkBox_GeneralTimers.Text = "General Timers";
+            this.checkBox_GeneralTimers.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_Alarms
+            // 
+            this.checkBox_Alarms.AutoSize = true;
+            this.checkBox_Alarms.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.Alarms;
+            this.checkBox_Alarms.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "Alarms", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_Alarms.Location = new System.Drawing.Point(6, 134);
+            this.checkBox_Alarms.Name = "checkBox_Alarms";
+            this.checkBox_Alarms.Size = new System.Drawing.Size(57, 17);
+            this.checkBox_Alarms.TabIndex = 4;
+            this.checkBox_Alarms.Text = "Alarms";
+            this.checkBox_Alarms.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_AnalogMeters
+            // 
+            this.checkBox_AnalogMeters.AutoSize = true;
+            this.checkBox_AnalogMeters.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.AnalogMeters;
+            this.checkBox_AnalogMeters.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "AnalogMeters", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_AnalogMeters.Location = new System.Drawing.Point(6, 111);
+            this.checkBox_AnalogMeters.Name = "checkBox_AnalogMeters";
+            this.checkBox_AnalogMeters.Size = new System.Drawing.Size(94, 17);
+            this.checkBox_AnalogMeters.TabIndex = 4;
+            this.checkBox_AnalogMeters.Text = "Analog Meters";
+            this.checkBox_AnalogMeters.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_SetpointsScheduler
+            // 
+            this.checkBox_SetpointsScheduler.AutoSize = true;
+            this.checkBox_SetpointsScheduler.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.SetpointsScheduler;
+            this.checkBox_SetpointsScheduler.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "SetpointsScheduler", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_SetpointsScheduler.Location = new System.Drawing.Point(6, 88);
+            this.checkBox_SetpointsScheduler.Name = "checkBox_SetpointsScheduler";
+            this.checkBox_SetpointsScheduler.Size = new System.Drawing.Size(123, 17);
+            this.checkBox_SetpointsScheduler.TabIndex = 4;
+            this.checkBox_SetpointsScheduler.Text = "Setpoints/Scheduler";
+            this.checkBox_SetpointsScheduler.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_GlobalLockCode
+            // 
+            this.checkBox_GlobalLockCode.AutoSize = true;
+            this.checkBox_GlobalLockCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.GlobalLockCode;
+            this.checkBox_GlobalLockCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "GlobalLockCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_GlobalLockCode.Location = new System.Drawing.Point(6, 42);
+            this.checkBox_GlobalLockCode.Name = "checkBox_GlobalLockCode";
+            this.checkBox_GlobalLockCode.Size = new System.Drawing.Size(106, 17);
+            this.checkBox_GlobalLockCode.TabIndex = 4;
+            this.checkBox_GlobalLockCode.Text = "Global lock code";
+            this.checkBox_GlobalLockCode.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_TerminatorDigit
+            // 
+            this.checkBox_TerminatorDigit.AutoSize = true;
+            this.checkBox_TerminatorDigit.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.TerminatorDigit;
+            this.checkBox_TerminatorDigit.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "TerminatorDigit", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_TerminatorDigit.Location = new System.Drawing.Point(6, 65);
+            this.checkBox_TerminatorDigit.Name = "checkBox_TerminatorDigit";
+            this.checkBox_TerminatorDigit.Size = new System.Drawing.Size(100, 17);
+            this.checkBox_TerminatorDigit.TabIndex = 4;
+            this.checkBox_TerminatorDigit.Text = "Terminator Digit";
+            this.checkBox_TerminatorDigit.UseVisualStyleBackColor = true;
+            // 
+            // groupBox7
+            // 
+            this.groupBox7.Controls.Add(this.checkBox_DTMFMemories);
+            this.groupBox7.Controls.Add(this.checkBox_DTMFTestPadCode);
+            this.groupBox7.Location = new System.Drawing.Point(491, 240);
+            this.groupBox7.Name = "groupBox7";
+            this.groupBox7.Size = new System.Drawing.Size(146, 69);
+            this.groupBox7.TabIndex = 6;
+            this.groupBox7.TabStop = false;
+            this.groupBox7.Text = "DTMF";
+            // 
+            // checkBox_DTMFMemories
+            // 
+            this.checkBox_DTMFMemories.AutoSize = true;
+            this.checkBox_DTMFMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFMemories;
+            this.checkBox_DTMFMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_DTMFMemories.Location = new System.Drawing.Point(6, 19);
+            this.checkBox_DTMFMemories.Name = "checkBox_DTMFMemories";
+            this.checkBox_DTMFMemories.Size = new System.Drawing.Size(71, 17);
+            this.checkBox_DTMFMemories.TabIndex = 4;
+            this.checkBox_DTMFMemories.Text = "Memories";
+            this.checkBox_DTMFMemories.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_DTMFTestPadCode
+            // 
+            this.checkBox_DTMFTestPadCode.AutoSize = true;
+            this.checkBox_DTMFTestPadCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DTMFTestPadCode;
+            this.checkBox_DTMFTestPadCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DTMFTestPadCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_DTMFTestPadCode.Location = new System.Drawing.Point(6, 42);
+            this.checkBox_DTMFTestPadCode.Name = "checkBox_DTMFTestPadCode";
+            this.checkBox_DTMFTestPadCode.Size = new System.Drawing.Size(97, 17);
+            this.checkBox_DTMFTestPadCode.TabIndex = 4;
+            this.checkBox_DTMFTestPadCode.Text = "Test Pad Code";
+            this.checkBox_DTMFTestPadCode.UseVisualStyleBackColor = true;
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.Controls.Add(this.checkBox_APSettings);
+            this.groupBox8.Controls.Add(this.checkBox_APMemories);
+            this.groupBox8.Controls.Add(this.checkBox_APPrefix);
+            this.groupBox8.Controls.Add(this.checkBox_APAnswerCode);
+            this.groupBox8.Controls.Add(this.checkBox_APTollRestrictions);
+            this.groupBox8.Location = new System.Drawing.Point(349, 177);
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.Size = new System.Drawing.Size(136, 132);
+            this.groupBox8.TabIndex = 6;
+            this.groupBox8.TabStop = false;
+            this.groupBox8.Text = "Auto Patch";
+            // 
+            // checkBox_APSettings
+            // 
+            this.checkBox_APSettings.AutoSize = true;
+            this.checkBox_APSettings.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APSettings;
+            this.checkBox_APSettings.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APSettings", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_APSettings.Location = new System.Drawing.Point(5, 20);
+            this.checkBox_APSettings.Name = "checkBox_APSettings";
+            this.checkBox_APSettings.Size = new System.Drawing.Size(64, 17);
+            this.checkBox_APSettings.TabIndex = 5;
+            this.checkBox_APSettings.Text = "Settings";
+            this.checkBox_APSettings.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_APMemories
+            // 
+            this.checkBox_APMemories.AutoSize = true;
+            this.checkBox_APMemories.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APMemories;
+            this.checkBox_APMemories.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APMemories", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_APMemories.Location = new System.Drawing.Point(5, 88);
+            this.checkBox_APMemories.Name = "checkBox_APMemories";
+            this.checkBox_APMemories.Size = new System.Drawing.Size(71, 17);
+            this.checkBox_APMemories.TabIndex = 4;
+            this.checkBox_APMemories.Text = "Memories";
+            this.checkBox_APMemories.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_APPrefix
+            // 
+            this.checkBox_APPrefix.AutoSize = true;
+            this.checkBox_APPrefix.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APPrefix;
+            this.checkBox_APPrefix.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APPrefix", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_APPrefix.Location = new System.Drawing.Point(5, 42);
+            this.checkBox_APPrefix.Name = "checkBox_APPrefix";
+            this.checkBox_APPrefix.Size = new System.Drawing.Size(52, 17);
+            this.checkBox_APPrefix.TabIndex = 4;
+            this.checkBox_APPrefix.Text = "Prefix";
+            this.checkBox_APPrefix.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_APAnswerCode
+            // 
+            this.checkBox_APAnswerCode.AutoSize = true;
+            this.checkBox_APAnswerCode.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APAnswerCode;
+            this.checkBox_APAnswerCode.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APAnswerCode", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_APAnswerCode.Location = new System.Drawing.Point(5, 65);
+            this.checkBox_APAnswerCode.Name = "checkBox_APAnswerCode";
+            this.checkBox_APAnswerCode.Size = new System.Drawing.Size(92, 17);
+            this.checkBox_APAnswerCode.TabIndex = 4;
+            this.checkBox_APAnswerCode.Text = " Answer Code";
+            this.checkBox_APAnswerCode.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_APTollRestrictions
+            // 
+            this.checkBox_APTollRestrictions.AutoSize = true;
+            this.checkBox_APTollRestrictions.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.APTollRestrictions;
+            this.checkBox_APTollRestrictions.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "APTollRestrictions", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_APTollRestrictions.Location = new System.Drawing.Point(5, 111);
+            this.checkBox_APTollRestrictions.Name = "checkBox_APTollRestrictions";
+            this.checkBox_APTollRestrictions.Size = new System.Drawing.Size(101, 17);
+            this.checkBox_APTollRestrictions.TabIndex = 4;
+            this.checkBox_APTollRestrictions.Text = "Toll Restrictions";
+            this.checkBox_APTollRestrictions.UseVisualStyleBackColor = true;
+            // 
+            // menuStrip1
+            // 
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.optionsToolStripMenuItem,
             this.reportToolStripMenuItem,
             this.aboutToolStripMenuItem});
-			this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-			this.menuStrip1.Name = "menuStrip1";
-			this.menuStrip1.Size = new System.Drawing.Size(650, 24);
-			this.menuStrip1.TabIndex = 7;
-			this.menuStrip1.Text = "menuStrip1";
-			// 
-			// fileToolStripMenuItem
-			// 
-			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Size = new System.Drawing.Size(650, 24);
+            this.menuStrip1.TabIndex = 7;
+            this.menuStrip1.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openToolStripMenuItem,
             this.closeToolStripMenuItem});
-			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-			this.fileToolStripMenuItem.Text = "&File";
-			// 
-			// openToolStripMenuItem
-			// 
-			this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-			this.openToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.openToolStripMenuItem.Text = "&Open";
-			this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
-			// 
-			// closeToolStripMenuItem
-			// 
-			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-			this.closeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.closeToolStripMenuItem.Text = "&Close";
-			this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
-			// 
-			// optionsToolStripMenuItem
-			// 
-			this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "&File";
+            // 
+            // openToolStripMenuItem
+            // 
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.openToolStripMenuItem.Text = "&Open";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
+            // 
+            // closeToolStripMenuItem
+            // 
+            this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.closeToolStripMenuItem.Text = "&Close";
+            this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
+            // 
+            // optionsToolStripMenuItem
+            // 
+            this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveToolStripMenuItem,
             this.resetToolStripMenuItem,
             this.recallToolStripMenuItem,
             this.toolStripMenuItem1,
             this.portNamesToolStripMenuItem,
-            this.macroDefinitionsToolStripMenuItem});
-			this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-			this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
-			this.optionsToolStripMenuItem.Text = "&Options";
-			// 
-			// saveToolStripMenuItem
-			// 
-			this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-			this.saveToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-			this.saveToolStripMenuItem.Text = "&Save";
-			this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
-			// 
-			// resetToolStripMenuItem
-			// 
-			this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
-			this.resetToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-			this.resetToolStripMenuItem.Text = "&Reset";
-			this.resetToolStripMenuItem.Click += new System.EventHandler(this.resetToolStripMenuItem_Click);
-			// 
-			// recallToolStripMenuItem
-			// 
-			this.recallToolStripMenuItem.Name = "recallToolStripMenuItem";
-			this.recallToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-			this.recallToolStripMenuItem.Text = "Re&call";
-			this.recallToolStripMenuItem.Click += new System.EventHandler(this.recallToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(165, 6);
-			// 
-			// portNamesToolStripMenuItem
-			// 
-			this.portNamesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.macroDefinitionsToolStripMenuItem,
+            this.xMLFilePathToolStripMenuItem});
+            this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
+            this.optionsToolStripMenuItem.Text = "&Options";
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.saveToolStripMenuItem.Text = "&Save";
+            this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
+            // 
+            // resetToolStripMenuItem
+            // 
+            this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
+            this.resetToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.resetToolStripMenuItem.Text = "&Reset";
+            this.resetToolStripMenuItem.Click += new System.EventHandler(this.resetToolStripMenuItem_Click);
+            // 
+            // recallToolStripMenuItem
+            // 
+            this.recallToolStripMenuItem.Name = "recallToolStripMenuItem";
+            this.recallToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.recallToolStripMenuItem.Text = "Re&call";
+            this.recallToolStripMenuItem.Click += new System.EventHandler(this.recallToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(165, 6);
+            // 
+            // portNamesToolStripMenuItem
+            // 
+            this.portNamesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.port1ToolStripMenuItem,
             this.port2ToolStripMenuItem,
             this.port3ToolStripMenuItem});
-			this.portNamesToolStripMenuItem.Name = "portNamesToolStripMenuItem";
-			this.portNamesToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-			this.portNamesToolStripMenuItem.Text = "Port Names";
-			// 
-			// port1ToolStripMenuItem
-			// 
-			this.port1ToolStripMenuItem.Name = "port1ToolStripMenuItem";
-			this.port1ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
-			this.port1ToolStripMenuItem.Text = "Port 1";
-			this.port1ToolStripMenuItem.Click += new System.EventHandler(this.port1ToolStripMenuItem_Click);
-			// 
-			// port2ToolStripMenuItem
-			// 
-			this.port2ToolStripMenuItem.Name = "port2ToolStripMenuItem";
-			this.port2ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
-			this.port2ToolStripMenuItem.Text = "Port 2";
-			this.port2ToolStripMenuItem.Click += new System.EventHandler(this.port2ToolStripMenuItem_Click);
-			// 
-			// port3ToolStripMenuItem
-			// 
-			this.port3ToolStripMenuItem.Name = "port3ToolStripMenuItem";
-			this.port3ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
-			this.port3ToolStripMenuItem.Text = "Port 3";
-			this.port3ToolStripMenuItem.Click += new System.EventHandler(this.port3ToolStripMenuItem_Click);
-			// 
-			// macroDefinitionsToolStripMenuItem
-			// 
-			this.macroDefinitionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.portNamesToolStripMenuItem.Name = "portNamesToolStripMenuItem";
+            this.portNamesToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.portNamesToolStripMenuItem.Text = "Port Names";
+            // 
+            // port1ToolStripMenuItem
+            // 
+            this.port1ToolStripMenuItem.Name = "port1ToolStripMenuItem";
+            this.port1ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
+            this.port1ToolStripMenuItem.Text = "Port 1";
+            this.port1ToolStripMenuItem.Click += new System.EventHandler(this.port1ToolStripMenuItem_Click);
+            // 
+            // port2ToolStripMenuItem
+            // 
+            this.port2ToolStripMenuItem.Name = "port2ToolStripMenuItem";
+            this.port2ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
+            this.port2ToolStripMenuItem.Text = "Port 2";
+            this.port2ToolStripMenuItem.Click += new System.EventHandler(this.port2ToolStripMenuItem_Click);
+            // 
+            // port3ToolStripMenuItem
+            // 
+            this.port3ToolStripMenuItem.Name = "port3ToolStripMenuItem";
+            this.port3ToolStripMenuItem.Size = new System.Drawing.Size(105, 22);
+            this.port3ToolStripMenuItem.Text = "Port 3";
+            this.port3ToolStripMenuItem.Click += new System.EventHandler(this.port3ToolStripMenuItem_Click);
+            // 
+            // macroDefinitionsToolStripMenuItem
+            // 
+            this.macroDefinitionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.versionToolStripMenuItem,
             this.updateToolStripMenuItem});
-			this.macroDefinitionsToolStripMenuItem.Name = "macroDefinitionsToolStripMenuItem";
-			this.macroDefinitionsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-			this.macroDefinitionsToolStripMenuItem.Text = "Macro Definitions";
-			// 
-			// versionToolStripMenuItem
-			// 
-			this.versionToolStripMenuItem.Name = "versionToolStripMenuItem";
-			this.versionToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-			this.versionToolStripMenuItem.Text = "Version";
-			this.versionToolStripMenuItem.Click += new System.EventHandler(this.versionToolStripMenuItem_Click);
-			// 
-			// updateToolStripMenuItem
-			// 
-			this.updateToolStripMenuItem.Name = "updateToolStripMenuItem";
-			this.updateToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-			this.updateToolStripMenuItem.Text = "Update";
-			this.updateToolStripMenuItem.Click += new System.EventHandler(this.updateToolStripMenuItem_Click);
-			// 
-			// reportToolStripMenuItem
-			// 
-			this.reportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.macroDefinitionsToolStripMenuItem.Name = "macroDefinitionsToolStripMenuItem";
+            this.macroDefinitionsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.macroDefinitionsToolStripMenuItem.Text = "Macro Definitions";
+            // 
+            // versionToolStripMenuItem
+            // 
+            this.versionToolStripMenuItem.Name = "versionToolStripMenuItem";
+            this.versionToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.versionToolStripMenuItem.Text = "Version";
+            this.versionToolStripMenuItem.Click += new System.EventHandler(this.versionToolStripMenuItem_Click);
+            // 
+            // updateToolStripMenuItem
+            // 
+            this.updateToolStripMenuItem.Name = "updateToolStripMenuItem";
+            this.updateToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.updateToolStripMenuItem.Text = "Update";
+            this.updateToolStripMenuItem.Click += new System.EventHandler(this.updateToolStripMenuItem_Click);
+            // 
+            // xMLFilePathToolStripMenuItem
+            // 
+            this.xMLFilePathToolStripMenuItem.Name = "xMLFilePathToolStripMenuItem";
+            this.xMLFilePathToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.xMLFilePathToolStripMenuItem.Text = "XML File Path";
+            this.xMLFilePathToolStripMenuItem.Click += new System.EventHandler(this.xMLFilePathToolStripMenuItem_Click);
+            // 
+            // reportToolStripMenuItem
+            // 
+            this.reportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.generateReportToolStripMenuItem1,
             this.viewReportToolStripMenuItem,
             this.openReportFolderToolStripMenuItem});
-			this.reportToolStripMenuItem.Name = "reportToolStripMenuItem";
-			this.reportToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
-			this.reportToolStripMenuItem.Text = "&Report";
-			// 
-			// generateReportToolStripMenuItem1
-			// 
-			this.generateReportToolStripMenuItem1.Enabled = false;
-			this.generateReportToolStripMenuItem1.Name = "generateReportToolStripMenuItem1";
-			this.generateReportToolStripMenuItem1.Size = new System.Drawing.Size(177, 22);
-			this.generateReportToolStripMenuItem1.Text = "&Generate Report";
-			this.generateReportToolStripMenuItem1.Click += new System.EventHandler(this.generateReportToolStripMenuItem_Click);
-			// 
-			// viewReportToolStripMenuItem
-			// 
-			this.viewReportToolStripMenuItem.Enabled = false;
-			this.viewReportToolStripMenuItem.Name = "viewReportToolStripMenuItem";
-			this.viewReportToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
-			this.viewReportToolStripMenuItem.Text = "&View Report";
-			this.viewReportToolStripMenuItem.Click += new System.EventHandler(this.viewReportToolStripMenuItem_Click);
-			// 
-			// openReportFolderToolStripMenuItem
-			// 
-			this.openReportFolderToolStripMenuItem.Enabled = false;
-			this.openReportFolderToolStripMenuItem.Name = "openReportFolderToolStripMenuItem";
-			this.openReportFolderToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
-			this.openReportFolderToolStripMenuItem.Text = "&Open Report Folder";
-			this.openReportFolderToolStripMenuItem.Click += new System.EventHandler(this.openReportFolderToolStripMenuItem_Click);
-			// 
-			// aboutToolStripMenuItem
-			// 
-			this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-			this.aboutToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.aboutToolStripMenuItem.Text = "&About";
-			this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.checkBox_CustomHeader);
-			this.groupBox1.Controls.Add(this.checkBox_DateHeader);
-			this.groupBox1.Controls.Add(this.textBox_CustomHeader);
-			this.groupBox1.Location = new System.Drawing.Point(12, 246);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(331, 63);
-			this.groupBox1.TabIndex = 9;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "Report Header";
-			// 
-			// checkBox_CustomHeader
-			// 
-			this.checkBox_CustomHeader.AutoSize = true;
-			this.checkBox_CustomHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomHeader;
-			this.checkBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_CustomHeader.Location = new System.Drawing.Point(6, 19);
-			this.checkBox_CustomHeader.Name = "checkBox_CustomHeader";
-			this.checkBox_CustomHeader.Size = new System.Drawing.Size(160, 17);
-			this.checkBox_CustomHeader.TabIndex = 4;
-			this.checkBox_CustomHeader.Text = "Display custom page header";
-			this.checkBox_CustomHeader.UseVisualStyleBackColor = true;
-			// 
-			// checkBox_DateHeader
-			// 
-			this.checkBox_DateHeader.AutoSize = true;
-			this.checkBox_DateHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DateHeader;
-			this.checkBox_DateHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DateHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_DateHeader.Location = new System.Drawing.Point(234, 19);
-			this.checkBox_DateHeader.Name = "checkBox_DateHeader";
-			this.checkBox_DateHeader.Size = new System.Drawing.Size(87, 17);
-			this.checkBox_DateHeader.TabIndex = 8;
-			this.checkBox_DateHeader.Text = "Date Header";
-			this.checkBox_DateHeader.UseVisualStyleBackColor = true;
-			// 
-			// textBox_CustomHeader
-			// 
-			this.textBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomeHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.textBox_CustomHeader.Location = new System.Drawing.Point(6, 39);
-			this.textBox_CustomHeader.Name = "textBox_CustomHeader";
-			this.textBox_CustomHeader.Size = new System.Drawing.Size(315, 20);
-			this.textBox_CustomHeader.TabIndex = 5;
-			this.textBox_CustomHeader.Text = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomeHeader;
-			// 
-			// groupBox2
-			// 
-			this.groupBox2.Controls.Add(this.checkBox_RTCOption);
-			this.groupBox2.Controls.Add(this.comboBox_FwVersion);
-			this.groupBox2.Location = new System.Drawing.Point(12, 184);
-			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(331, 56);
-			this.groupBox2.TabIndex = 10;
-			this.groupBox2.TabStop = false;
-			this.groupBox2.Text = "RC210 Options";
-			// 
-			// checkBox_RTCOption
-			// 
-			this.checkBox_RTCOption.AutoSize = true;
-			this.checkBox_RTCOption.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RTCOption;
-			this.checkBox_RTCOption.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.checkBox_RTCOption.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RTCOption", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.checkBox_RTCOption.Enabled = false;
-			this.checkBox_RTCOption.Location = new System.Drawing.Point(192, 21);
-			this.checkBox_RTCOption.Name = "checkBox_RTCOption";
-			this.checkBox_RTCOption.Size = new System.Drawing.Size(133, 17);
-			this.checkBox_RTCOption.TabIndex = 4;
-			this.checkBox_RTCOption.Text = "I Have the RTC option";
-			this.checkBox_RTCOption.UseVisualStyleBackColor = true;
-			// 
-			// comboBox_FwVersion
-			// 
-			this.comboBox_FwVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBox_FwVersion.FormattingEnabled = true;
-			this.comboBox_FwVersion.Location = new System.Drawing.Point(6, 19);
-			this.comboBox_FwVersion.Name = "comboBox_FwVersion";
-			this.comboBox_FwVersion.Size = new System.Drawing.Size(176, 21);
-			this.comboBox_FwVersion.TabIndex = 5;
-			// 
-			// Form1
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(650, 318);
-			this.Controls.Add(this.groupBox2);
-			this.Controls.Add(this.groupBox1);
-			this.Controls.Add(this.groupBox8);
-			this.Controls.Add(this.groupBox7);
-			this.Controls.Add(this.groupBox6);
-			this.Controls.Add(this.groupBox4);
-			this.Controls.Add(this.groupBox_Port3);
-			this.Controls.Add(this.groupBox_Port2);
-			this.Controls.Add(this.groupBox_Port1);
-			this.Controls.Add(this.menuStrip1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.MainMenuStrip = this.menuStrip1;
-			this.MaximizeBox = false;
-			this.Name = "Form1";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-			this.Text = "RC210 Data Assistant 2";
-			this.Load += new System.EventHandler(this.Form1_Load);
-			this.groupBox_Port1.ResumeLayout(false);
-			this.groupBox_Port1.PerformLayout();
-			this.groupBox_Port2.ResumeLayout(false);
-			this.groupBox_Port2.PerformLayout();
-			this.groupBox_Port3.ResumeLayout(false);
-			this.groupBox_Port3.PerformLayout();
-			this.groupBox4.ResumeLayout(false);
-			this.groupBox4.PerformLayout();
-			this.groupBox6.ResumeLayout(false);
-			this.groupBox6.PerformLayout();
-			this.groupBox7.ResumeLayout(false);
-			this.groupBox7.PerformLayout();
-			this.groupBox8.ResumeLayout(false);
-			this.groupBox8.PerformLayout();
-			this.menuStrip1.ResumeLayout(false);
-			this.menuStrip1.PerformLayout();
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			this.groupBox2.ResumeLayout(false);
-			this.groupBox2.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.reportToolStripMenuItem.Name = "reportToolStripMenuItem";
+            this.reportToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
+            this.reportToolStripMenuItem.Text = "&Report";
+            // 
+            // generateReportToolStripMenuItem1
+            // 
+            this.generateReportToolStripMenuItem1.Enabled = false;
+            this.generateReportToolStripMenuItem1.Name = "generateReportToolStripMenuItem1";
+            this.generateReportToolStripMenuItem1.Size = new System.Drawing.Size(177, 22);
+            this.generateReportToolStripMenuItem1.Text = "&Generate Report";
+            this.generateReportToolStripMenuItem1.Click += new System.EventHandler(this.generateReportToolStripMenuItem_Click);
+            // 
+            // viewReportToolStripMenuItem
+            // 
+            this.viewReportToolStripMenuItem.Enabled = false;
+            this.viewReportToolStripMenuItem.Name = "viewReportToolStripMenuItem";
+            this.viewReportToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this.viewReportToolStripMenuItem.Text = "&View Report";
+            this.viewReportToolStripMenuItem.Click += new System.EventHandler(this.viewReportToolStripMenuItem_Click);
+            // 
+            // openReportFolderToolStripMenuItem
+            // 
+            this.openReportFolderToolStripMenuItem.Enabled = false;
+            this.openReportFolderToolStripMenuItem.Name = "openReportFolderToolStripMenuItem";
+            this.openReportFolderToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this.openReportFolderToolStripMenuItem.Text = "&Open Report Folder";
+            this.openReportFolderToolStripMenuItem.Click += new System.EventHandler(this.openReportFolderToolStripMenuItem_Click);
+            // 
+            // aboutToolStripMenuItem
+            // 
+            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.aboutToolStripMenuItem.Text = "&About";
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.checkBox_CustomHeader);
+            this.groupBox1.Controls.Add(this.checkBox_DateHeader);
+            this.groupBox1.Controls.Add(this.textBox_CustomHeader);
+            this.groupBox1.Location = new System.Drawing.Point(12, 246);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(331, 63);
+            this.groupBox1.TabIndex = 9;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Report Header";
+            // 
+            // checkBox_CustomHeader
+            // 
+            this.checkBox_CustomHeader.AutoSize = true;
+            this.checkBox_CustomHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomHeader;
+            this.checkBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_CustomHeader.Location = new System.Drawing.Point(6, 19);
+            this.checkBox_CustomHeader.Name = "checkBox_CustomHeader";
+            this.checkBox_CustomHeader.Size = new System.Drawing.Size(160, 17);
+            this.checkBox_CustomHeader.TabIndex = 4;
+            this.checkBox_CustomHeader.Text = "Display custom page header";
+            this.checkBox_CustomHeader.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_DateHeader
+            // 
+            this.checkBox_DateHeader.AutoSize = true;
+            this.checkBox_DateHeader.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.DateHeader;
+            this.checkBox_DateHeader.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "DateHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_DateHeader.Location = new System.Drawing.Point(234, 19);
+            this.checkBox_DateHeader.Name = "checkBox_DateHeader";
+            this.checkBox_DateHeader.Size = new System.Drawing.Size(87, 17);
+            this.checkBox_DateHeader.TabIndex = 8;
+            this.checkBox_DateHeader.Text = "Date Header";
+            this.checkBox_DateHeader.UseVisualStyleBackColor = true;
+            // 
+            // textBox_CustomHeader
+            // 
+            this.textBox_CustomHeader.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::RC210_DataAssistant_V2.Properties.Settings.Default, "CustomeHeader", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.textBox_CustomHeader.Location = new System.Drawing.Point(6, 39);
+            this.textBox_CustomHeader.Name = "textBox_CustomHeader";
+            this.textBox_CustomHeader.Size = new System.Drawing.Size(315, 20);
+            this.textBox_CustomHeader.TabIndex = 5;
+            this.textBox_CustomHeader.Text = global::RC210_DataAssistant_V2.Properties.Settings.Default.CustomeHeader;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.checkBox_RTCOption);
+            this.groupBox2.Controls.Add(this.comboBox_FwVersion);
+            this.groupBox2.Location = new System.Drawing.Point(12, 184);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(331, 56);
+            this.groupBox2.TabIndex = 10;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "RC210 Options";
+            // 
+            // checkBox_RTCOption
+            // 
+            this.checkBox_RTCOption.AutoSize = true;
+            this.checkBox_RTCOption.Checked = global::RC210_DataAssistant_V2.Properties.Settings.Default.RTCOption;
+            this.checkBox_RTCOption.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::RC210_DataAssistant_V2.Properties.Settings.Default, "RTCOption", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBox_RTCOption.Location = new System.Drawing.Point(192, 21);
+            this.checkBox_RTCOption.Name = "checkBox_RTCOption";
+            this.checkBox_RTCOption.Size = new System.Drawing.Size(133, 17);
+            this.checkBox_RTCOption.TabIndex = 4;
+            this.checkBox_RTCOption.Text = "I Have the RTC option";
+            this.checkBox_RTCOption.UseVisualStyleBackColor = true;
+            // 
+            // comboBox_FwVersion
+            // 
+            this.comboBox_FwVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox_FwVersion.FormattingEnabled = true;
+            this.comboBox_FwVersion.Location = new System.Drawing.Point(6, 19);
+            this.comboBox_FwVersion.Name = "comboBox_FwVersion";
+            this.comboBox_FwVersion.Size = new System.Drawing.Size(176, 21);
+            this.comboBox_FwVersion.TabIndex = 5;
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(650, 318);
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.groupBox8);
+            this.Controls.Add(this.groupBox7);
+            this.Controls.Add(this.groupBox6);
+            this.Controls.Add(this.groupBox4);
+            this.Controls.Add(this.groupBox_Port3);
+            this.Controls.Add(this.groupBox_Port2);
+            this.Controls.Add(this.groupBox_Port1);
+            this.Controls.Add(this.menuStrip1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MainMenuStrip = this.menuStrip1;
+            this.MaximizeBox = false;
+            this.Name = "Form1";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "RC210 Data Assistant 2";
+            this.Load += new System.EventHandler(this.Form1_Load);
+            this.groupBox_Port1.ResumeLayout(false);
+            this.groupBox_Port1.PerformLayout();
+            this.groupBox_Port2.ResumeLayout(false);
+            this.groupBox_Port2.PerformLayout();
+            this.groupBox_Port3.ResumeLayout(false);
+            this.groupBox_Port3.PerformLayout();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
+            this.groupBox7.ResumeLayout(false);
+            this.groupBox7.PerformLayout();
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -981,6 +988,7 @@
 		private System.Windows.Forms.ToolStripMenuItem macroDefinitionsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem versionToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem updateToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem xMLFilePathToolStripMenuItem;
 	}
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -33,8 +33,8 @@ namespace RC210_DataAssistant_V2
 			public string PortCode;
 			public string HangTimer1;               //3 hangtimers per port with v7.00
 			public string HangTimer2;               //3 hangtimers per port with v7.00
-            public string HangTimer3;               //3 hangtimers per port with v7.00
-            public string TimeoutTimer;
+            		public string HangTimer3;               //3 hangtimers per port with v7.00
+            		public string TimeoutTimer;
 			public string InitialIdTimer;
 			public string PendingIdTimer;
 			public string InactivityTimer;
@@ -107,8 +107,8 @@ namespace RC210_DataAssistant_V2
 		private readonly Dictionary<int, Port> _ports = new Dictionary<int, Port>();
 		private readonly Dictionary<int, Macro> _macros = new Dictionary<int, Macro>();
 		private readonly Dictionary<int, Macro> _shortMacros = new Dictionary<int, Macro>();
-        private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();
-        private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
+        	private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();
+        	private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
 
 		#endregion Private Members
 
@@ -317,7 +317,7 @@ namespace RC210_DataAssistant_V2
 			Load_MessageMacros();
 			Load_Macros();
 			Load_ShortMacros();
-            Load_ExtendedMacros();
+            		Load_ExtendedMacros();
 			Load_AutoPatch();
 		}
 		
@@ -618,8 +618,7 @@ namespace RC210_DataAssistant_V2
 					string port3Header = _ports[3].PortName != string.Empty ? "Port 3 - " + _ports[3].PortName : "Port 3";
 					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
 					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port3Header + "</H2></TD></TR>");
-					rW.WriteLine(
-						"<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
 					rW.WriteLine("<TR>");
 
 					//Unlock Code
@@ -659,8 +658,7 @@ namespace RC210_DataAssistant_V2
 					if (checkBox_P3TailMessages.Checked)
 					{
 						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" +
-						             ((_ports[3].TailMessage == "0") ? "Disabled" : _ports[3].TailMessage) + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[3].TailMessage == "0") ? "Disabled" : _ports[3].TailMessage) + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[3].TailMessageCounter + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[3].TailMessageTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[3].TailMessage1Macro + "</TD></TR>");
@@ -693,8 +691,7 @@ namespace RC210_DataAssistant_V2
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[3].InactivityTimer + " (" +
-						             _ports[3].InactivityTimerMacro + ")</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[3].InactivityTimer + " (" + _ports[3].InactivityTimerMacro + ")</TD></TR>");
 						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMuteTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[3].EncoderTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[3].KerchunkTimer + "</TD></TR>");
@@ -764,22 +761,22 @@ namespace RC210_DataAssistant_V2
 						rW.WriteLine("</TD></TR>");
 					}
 
-                    //ExtendedMacros
+                    			//ExtendedMacros
 
-                    foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
-                    {
-                        rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
-                        rW.WriteLine("<TD>");
-                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-                        rW.WriteLine("</TD></TR>");
-                    }
+                    			foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
+                    			{
+                        			rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
+                        			rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+                        			rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+                        			//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
+                        			rW.WriteLine("<TD>");
+                        			rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+                        			rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+                        			rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+                        			rW.WriteLine("</TD></TR>");
+                    			}
 
-                    rW.WriteLine("</TABLE><HR>");
+                    			rW.WriteLine("</TABLE><HR>");
 				}
 
 				//Setpoints
@@ -792,23 +789,23 @@ namespace RC210_DataAssistant_V2
 						rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
 						rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
 					}
-                    else
-                    {
-                    	rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
+                    			else
+                    			{
+                    				rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
 						rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
-                    }
+                    			}
 
-                    if (fwVersion < 7.36)       //Added 20 additiional SetPoints with v7.36
-                    { 
+                    			if (fwVersion < 7.36)       //Added 20 additiional SetPoints with v7.36
+                    			{ 
 					    for (int i = 1; i <= 20; i++)
 					    {
-						    rW.WriteLine("<TR><TD>" + i + "</TD>");
-						    rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+						 rW.WriteLine("<TR><TD>" + i + "</TD>");
+						 rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
 						
-						    if (fwVersion > 7.00)
-                        	{
-                            	rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
-                        	}
+						 if (fwVersion > 7.00)
+                        			{
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                        			}
 						
 						    rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
 						    rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
@@ -825,37 +822,37 @@ namespace RC210_DataAssistant_V2
 						    rW.WriteLine("</TD></TR>");
 					    }
 					    rW.WriteLine("</TABLE><HR>");
-                    }
-                    else
-                    {
-                        for (int i = 1; i <= 40; i++)
-                        {
-                            rW.WriteLine("<TR><TD>" + i + "</TD>");
-                            rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+                    			}
+                    			else
+                    			{
+                        			for (int i = 1; i <= 40; i++)
+                        			{
+                            				rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            				rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
 
-                            if (fwVersion > 7.00)
-                            {
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
-                            }
+                            				if (fwVersion > 7.00)
+                            				{
+                                				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                            				}
 
-                            rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+                            				rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+                            				rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
 
-                            //if they want to
-                            var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            rW.WriteLine("<TR><TD colspan=7>");
+                            				//if they want to
+                            				var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            				rW.WriteLine("<TR><TD colspan=7>");
 
-                            rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+                            				rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
 
-                            rW.WriteLine("</TD></TR>");
-                        }
+                            				rW.WriteLine("</TD></TR>");
+                        			}
 
-                        rW.WriteLine("</TABLE><HR>");
-                    }
-                }
+                        			rW.WriteLine("</TABLE><HR>");
+                    			}
+                		}
 
 				//CT MSG Macros
 				if (checkBox_CTMessageMacros.Checked)

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -31,10 +31,10 @@ namespace RC210_DataAssistant_V2
 		{
 			public string PortName;
 			public string PortCode;
-			public string HangTimer1;                   //Added by v7.00
-            		public string HangTimer2;                   //Added by v7.00
-            		public string HangTimer3;                   //Added by v7.00
-			public string TimeoutTimer;
+			public string HangTimer1;               //3 hangtimers per port with v7.00
+			public string HangTimer2;               //3 hangtimers per port with v7.00
+            public string HangTimer3;               //3 hangtimers per port with v7.00
+            public string TimeoutTimer;
 			public string InitialIdTimer;
 			public string PendingIdTimer;
 			public string InactivityTimer;
@@ -103,12 +103,12 @@ namespace RC210_DataAssistant_V2
 		private string _datFilename;
 		private string _reportFilename;
 
-        	private readonly AutoPatch _autoPatch = new AutoPatch();
+		private readonly AutoPatch _autoPatch = new AutoPatch();
 		private readonly Dictionary<int, Port> _ports = new Dictionary<int, Port>();
 		private readonly Dictionary<int, Macro> _macros = new Dictionary<int, Macro>();
 		private readonly Dictionary<int, Macro> _shortMacros = new Dictionary<int, Macro>();
-        	private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();     //Added by v7.39
-		private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
+        private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();
+        private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
 
 		#endregion Private Members
 
@@ -242,18 +242,18 @@ namespace RC210_DataAssistant_V2
 
 		private void FetchDefXml()
 		{
-            		string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";      //Added to acommadate multiple XML version files
-            		DirectoryInfo d = new DirectoryInfo(filepath);
+			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";
+			DirectoryInfo d = new DirectoryInfo(filepath);
 
-            		foreach (var file in d.GetFiles("*.xml"))
-            		{
-                		LoadXMLFile(filepath + file.Name);
-            		}
-        	}
+			foreach (var file in d.GetFiles("*.xml"))
+			{
+				LoadXMLFile(filepath + file.Name);
+			}
+		}
 
-        	private void LoadXMLFile(string file)
-        	{
-            		if (File.Exists(file))
+		private void LoadXMLFile(string file)
+		{
+			if (File.Exists(file))
 			{
 				_localXmlDocument.Load(file);
 
@@ -317,26 +317,26 @@ namespace RC210_DataAssistant_V2
 			Load_MessageMacros();
 			Load_Macros();
 			Load_ShortMacros();
-            		Load_ExtendedMacros();
+            Load_ExtendedMacros();
 			Load_AutoPatch();
 		}
-                
-        	#endregion Load .dat file
+		
+		#endregion Load .dat file
 
-        	#region Generate Report
+		#region Generate Report
 
-        	private void Generate_Report()
+		private void Generate_Report()
 		{
-            		double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);   //Added to acommodate option changes per version
-            		Load_Ports(fwVersion);
+			double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);
+			Load_Ports(fwVersion);
 
-            		if (!File.Exists(_datFilename))
-            		{
-               			MessageBox.Show(@"Unable to locate .dat file: " + _datFilename);
-                		return;
-            		}
+			if (!File.Exists(_datFilename))
+			{
+				MessageBox.Show(@"Unable to locate .dat file: " + _datFilename);
+				return;
+			}
 
-           		SaveFileDialog result = new SaveFileDialog
+			SaveFileDialog result = new SaveFileDialog
 			{
 				Filter = @"HTML File (*.html)|*.html",
 				InitialDirectory = Path.GetDirectoryName(_reportFilename)
@@ -448,18 +448,18 @@ namespace RC210_DataAssistant_V2
 					{
 						rW.WriteLine("<TABLE border=0>");
 
-                        			if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
-                        			{
-						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                        			}
-                        			else
-                        			{
-                            				rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                            				rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
-                            				rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
-                        			}
-                        
-                        			rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
+						if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
+						{
+							rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+						}
+						else
+						{
+							rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+							rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+							rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
+						}
+
+						rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[1].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[1].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[1].PendingIdSpeechTimer + "</TD></TR>");
@@ -562,18 +562,18 @@ namespace RC210_DataAssistant_V2
 					{
 						rW.WriteLine("<TABLE border=0>");
 
-                        			if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
-                        			{
-							rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                        			}
-                        			else
-                        			{
-                            				rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                            				rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
-                            				rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
-                        			}
+						if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
+                        {
+							rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[2].HangTimer1 + "</TD></TR>");
+						}
+						else
+						{
+							rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[2].HangTimer1 + "</TD></TR>");
+							rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[2].HangTimer2 + "</TD></TR>");
+							rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[2].HangTimer3 + "</TD></TR>");
+						}
 
-                        			rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[2].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[2].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[2].PendingIdSpeechTimer + "</TD></TR>");
@@ -678,18 +678,18 @@ namespace RC210_DataAssistant_V2
 					{
 						rW.WriteLine("<TABLE border=0>");
 
-                        			if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
-                        			{
-			    				rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                        			}
-                        			else
-                        			{
-                            				rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                            				rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
-                            				rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
-                        			}
+						if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
+                        {
+							rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[3].HangTimer1 + "</TD></TR>");
+						}
+						else
+						{
+							rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[3].HangTimer1 + "</TD></TR>");
+							rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[3].HangTimer2 + "</TD></TR>");
+							rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[3].HangTimer3 + "</TD></TR>");
+						}
 
-                       				rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
@@ -764,360 +764,360 @@ namespace RC210_DataAssistant_V2
 						rW.WriteLine("</TD></TR>");
 					}
 
-                    			//ExtendedMacros            Added 15 Macro positions 91 - 105 with 20 slots in each position with v7.39
+                    //ExtendedMacros
 
-					foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
+                    foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
+                    {
+                        rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
+                        rW.WriteLine("<TD>");
+                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+                        rW.WriteLine("</TD></TR>");
+                    }
+
+                    rW.WriteLine("</TABLE><HR>");
+				}
+
+				//Setpoints
+				if (checkBox_SetpointsScheduler.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center width=75%>");
+					
+					if (fwVersion < 7.32)       //Reinstated Month of Year with v7.32
+                    			{
+						rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
+					}
+                    else
+                    {
+                    	rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
+                    }
+
+                    if (fwVersion < 7.36)       //Added 20 additiional SetPoints with v7.36
+                    { 
+					    for (int i = 1; i <= 20; i++)
+					    {
+						    rW.WriteLine("<TR><TD>" + i + "</TD>");
+						    rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+						
+						    if (fwVersion > 7.00)
+                        	{
+                            	rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                        	}
+						
+						    rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+						    rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+						    rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+						    rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+						    rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+
+						    //if they want to
+						    var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+						    rW.WriteLine("<TR><TD colspan=7>");
+
+						    rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+
+						    rW.WriteLine("</TD></TR>");
+					    }
+					    rW.WriteLine("</TABLE><HR>");
+                    }
+                    else
+                    {
+                        for (int i = 1; i <= 40; i++)
+                        {
+                            rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+
+                            if (fwVersion > 7.00)
+                            {
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                            }
+
+                            rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+
+                            //if they want to
+                            var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            rW.WriteLine("<TR><TD colspan=7>");
+
+                            rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+
+                            rW.WriteLine("</TD></TR>");
+                        }
+
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+                }
+
+				//CT MSG Macros
+				if (checkBox_CTMessageMacros.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
+
+					for (int i = 1; i <= 3; i++)
 					{
-						rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
-						rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-						rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-						//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
-						rW.WriteLine("<TD>");
-						rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-						rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-						rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-						rW.WriteLine("</TD></TR>");
+						for (int j = 1; j <= 10; j++)
+						{
+							var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
+								
+							if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
+								continue;
+
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + j + "</TD>");
+							rW.WriteLine("<TD>" + tone1 + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
+						}
+
+						if (fwVersion >= 7.02) //From version 7.02 there is a single pool of Courtesy Tones @ P1Tone1 - P1Tone10
+							break;
 					}
 
 					rW.WriteLine("</TABLE><HR>");
 				}
 
-                		//Setpoints
-                		if (checkBox_SetpointsScheduler.Checked)
-                		{
-                    			rW.WriteLine("<TABLE border=1 align=center width=75%>");
+				//Messages
+				if (checkBox_MessageMacros.Checked)
+				{
 
-                    			if (fwVersion < 7.32)       //Reinstated Month of Run with v7.32. Added 8th column
-                    			{
-                        			rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
-                        			rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
-                    			}
-                    			else
-                    			{
-                        			rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
-                       				rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
-                    			}
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
 
-                    			if (fwVersion < 7.36)      //added 20 more Setpoints with v7.36
-                    			{
-                        			for (int i = 1; i <= 20; i++)
-                        			{
-                            				rW.WriteLine("<TR><TD>" + i + "</TD>");
-                            				rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
-
-                            				if (fwVersion > 7.00)   //Month To Run actually added at v7.01
-                            				{
-                                				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
-                            				}
-
-                            				rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
-                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
-                            				rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
-                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
-                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
-
-                            				//if they want to
-                            				var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            				rW.WriteLine("<TR><TD colspan=7>");
-
-                            				rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
-
-                            				rW.WriteLine("</TD></TR>");
-                        			}
-                        			rW.WriteLine("</TABLE><HR>");
-                    			}
-                    			else
-                    			{
-		        			for (int i = 1; i <= 40; i++)       //added 20 additional Setpoints with v.7.361
-
-                        			{
-                           				rW.WriteLine("<TR><TD>" + i + "</TD>");
-                            				rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
-
-                            				if (fwVersion > 7.00)
-                            				{
-                                				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
-                            				}
-
-                            				rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
-                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
-                            				rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
-                           				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
-                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
-
-                            				//if they want to
-                            				var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            				rW.WriteLine("<TR><TD colspan=7>");
-
-                            				rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
-
-                            				rW.WriteLine("</TD></TR>");
-                        			}
-
-                        			rW.WriteLine("</TABLE><HR>");
-                    			}
-                    			//CT MSG Macros
-                    			if (checkBox_CTMessageMacros.Checked)
+					int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
+					for (int i = 1; i <= lastMessage; i++)
 					{
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
-
-						for (int i = 1; i <= 3; i++)
-						{
-							for (int j = 1; j <= 10; j++)
-							{
-								var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
-								
-								if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
-									continue;
-
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + j + "</TD>");
-								rW.WriteLine("<TD>" + tone1 + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
-							}
-
-                            				if (fwVersion >= 7.02) //From version 7.02 there is a single pool of Courtesy Tones @ P1Tone1 - P1Tone10
-                               			 		break;
-                    				}
-
-						rW.WriteLine("</TABLE><HR>");
-					}
-
-					//Messages
-					if (checkBox_MessageMacros.Checked)
-					{
-
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
-
-						int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
-						for (int i = 1; i <= lastMessage; i++)
-						{
-							var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
-							if (messageMacro != "" && messageMacro != "NONE STORED")
-							{
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + messageMacro +"</TD></TR>");
-							}
-						}
-					
-						rW.WriteLine("</TABLE><HR>");
-					}
-
-					//General Timers
-					if (checkBox_GeneralTimers.Checked)
-					{
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-						for (int i = 1; i <= 6; i++)        //Added 3 additional General Times at v6.044
-						{
-							var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
-							if (generalTimer != "0")
-							{
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + generalTimer + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
-							}	
-						}
-
-						rW.WriteLine("</TABLE>");
-						rW.WriteLine("<HR>");
-					}
-
-					//Analog Meters
-					if (checkBox_AnalogMeters.Checked)
-					{
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
-
-						for (int i = 1; i <= 8; i++)
-						{
-							var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
-
-							if (meter != "0")
-							{
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
-							}
-
-						}
-						rW.WriteLine("</TABLE>");
-
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-						for (int i = 1; i <= 8; i++)
-						{
-							var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
-							if (meterAlarm != "0")
-							{
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" +ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
-							}
-						}
-						rW.WriteLine("</TABLE><HR>");
-					}
-
-					//Alarms
-					if (checkBox_Alarms.Checked)
-					{
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
-
-						for (int i = 1; i <= 5; i++)
+						var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
+						if (messageMacro != "" && messageMacro != "NONE STORED")
 						{
 							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) +"</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
+							rW.WriteLine("<TD>" + messageMacro +"</TD></TR>");
 						}
+					}
+					
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-						rW.WriteLine("</TABLE><HR>");
+				//General Timers
+				if (checkBox_GeneralTimers.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
+
+					for (int i = 1; i <= 6; i++)
+					{
+						var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
+						if (generalTimer != "0")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + generalTimer + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
+						}	
 					}
 
-					//DTMF Memories
-					if (checkBox_DTMFMemories.Checked)
+					rW.WriteLine("</TABLE>");
+					rW.WriteLine("<HR>");
+				}
+
+				//Analog Meters
+				if (checkBox_AnalogMeters.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
+
+					for (int i = 1; i <= 8; i++)
+					{
+						var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
+
+						if (meter != "0")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
+						}
+
+					}
+					rW.WriteLine("</TABLE>");
+
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
+
+					for (int i = 1; i <= 8; i++)
+					{
+						var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
+						if (meterAlarm != "0")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" +ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
+						}
+					}
+					rW.WriteLine("</TABLE><HR>");
+				}
+
+				//Alarms
+				if (checkBox_Alarms.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
+
+					for (int i = 1; i <= 5; i++)
+					{
+						rW.WriteLine("<TR><TD>" + i + "</TD>");
+						rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) +"</TD>");
+						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
+						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
+					}
+
+					rW.WriteLine("</TABLE><HR>");
+				}
+
+				//DTMF Memories
+				if (checkBox_DTMFMemories.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
+
+					int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
+					for (int i = 1; i <= dtmfMemoryCount; i++)
+					{
+						var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
+						if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
+						}
+					}
+
+					rW.WriteLine("</TABLE><HR>");
+				}
+
+				//Remote Base Memories
+				if (checkBox_RemoteBaseMemories.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
+					int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
+					for (int i = 1; i <= remoteBaseMemories; i++)
+					{
+						var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
+						if (freqString != "" && freqString != "0" && freqString != "NONE")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
+							rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
+							rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
+						}
+					}
+					rW.WriteLine("</TABLE><HR>");
+				}
+
+				//AutoPatch Settings
+				if (checkBox_APSettings.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 aling=center");
+					rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
+						            "</TD>");
+					rW.WriteLine("<TD><B>Answer Code:</B> " +
+						            ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
+					rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
+					rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
+					rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
+					rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
+						
+					rW.WriteLine("<TR><TD valign=top>");
+
+					//AutoPatch Memories
+					if (checkBox_APMemories.Checked)
 					{
 						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
 						rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
 
-						int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
-						for (int i = 1; i <= dtmfMemoryCount; i++)
+						for (int i = 1; i <= 200; i++)
 						{
-							var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
-							if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
+							var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
+							if (autoDial.Length > 0)
 							{
 								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
 							}
 						}
 
-						rW.WriteLine("</TABLE><HR>");
+						rW.WriteLine("</TABLE>");
 					}
 
-					//Remote Base Memories
-					if (checkBox_RemoteBaseMemories.Checked)
+					rW.WriteLine("</TD><TD valign=top>");
+
+					//AutoPatch Toll Restrictions
+					if (checkBox_APTollRestrictions.Checked)
 					{
 						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
-						int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
-						for (int i = 1; i <= remoteBaseMemories; i++)
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
+
+						for (int i = 1; i <= 100; i++)
 						{
-							var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
-							if (freqString != "" && freqString != "0" && freqString != "NONE")
+							var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
+							if (apTollRestriction.Length > 0)
 							{
 								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
-								rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
-								rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
-								rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
 							}
 						}
-						rW.WriteLine("</TABLE><HR>");
+
+						rW.WriteLine("</TABLE>");
 					}
 
-					//AutoPatch Settings
-					if (checkBox_APSettings.Checked)
-					{
-						rW.WriteLine("<TABLE border=1 aling=center");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
-						            "</TD>");
-						rW.WriteLine("<TD><B>Answer Code:</B> " +
-						            ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
-						rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
-						rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
-						
-						rW.WriteLine("<TR><TD valign=top>");
-
-						//AutoPatch Memories
-						if (checkBox_APMemories.Checked)
-						{
-							rW.WriteLine("<TABLE border=1 align=center>");
-							rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
-							rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
-
-							for (int i = 1; i <= 200; i++)
-							{
-								var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
-								if (autoDial.Length > 0)
-								{
-									rW.WriteLine("<TR><TD>" + i + "</TD>");
-									rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
-								}
-							}
-
-							rW.WriteLine("</TABLE>");
-						}
-
-						rW.WriteLine("</TD><TD valign=top>");
-
-						//AutoPatch Toll Restrictions
-						if (checkBox_APTollRestrictions.Checked)
-						{
-							rW.WriteLine("<TABLE border=1 align=center>");
-							rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
-							rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
-
-							for (int i = 1; i <= 100; i++)
-							{
-								var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
-								if (apTollRestriction.Length > 0)
-								{
-									rW.WriteLine("<TR><TD>" + i + "</TD>");
-									rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
-								}
-							}
-
-							rW.WriteLine("</TABLE>");
-						}
-
-						rW.WriteLine("</TD></TR>");
-						rW.WriteLine("</TABLE><HR>");
-					}
-
-					rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
-					rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
-                			rW.WriteLine("Modifed by Robert P. Norris - AK5U: ak5u@arrl.net");
-                			rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
-
-					var dr = MessageBox.Show(
-						string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
-						@"Report created",
-						MessageBoxButtons.YesNo,
-						MessageBoxIcon.Information
-						);
-				
-					if (dr == DialogResult.Yes) Process.Start(_reportFilename);
+					rW.WriteLine("</TD></TR>");
+					rW.WriteLine("</TABLE><HR>");
 				}
+
+				rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
+				rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
+				rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
+
+				var dr = MessageBox.Show(
+					string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
+					@"Report created",
+					MessageBoxButtons.YesNo,
+					MessageBoxIcon.Information
+					);
+				
+				if (dr == DialogResult.Yes) Process.Start(_reportFilename);
 			}
 		}
-        
-        	#endregion Generate Report
 
-        	#region Load AutoPatch
 
-        	private void Load_AutoPatch()
+		#endregion Generate Report
+
+		#region Load AutoPatch
+
+		private void Load_AutoPatch()
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1196,7 +1196,6 @@ namespace RC210_DataAssistant_V2
 					RepeaterMode = (datFile.IniReadValue("PortSwitches", string.Format("FDup({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechIdOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechIDOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
-					
 					//AccessMode = datFile.IniReadValue("PortSwitches", string.Format("P{0}MessageNum(3)", i)),
 					DtmfEnable = (datFile.IniReadValue("PortSwitches", string.Format("DTMFEnable({0})", i)) == "0") ? "Disabled" : "Enabled",
 					DtmfRequireTone = (datFile.IniReadValue("PortSwitches", string.Format("DTMFNeedPL({0})", i)) == "0") ? "Disabled" : "Enabled",
@@ -1206,19 +1205,20 @@ namespace RC210_DataAssistant_V2
 					KerchunkFilter = (datFile.IniReadValue("PortSwitches", string.Format("Kerchunk({0})", i)) == "0") ? "Disabled" : "Enabled",
 
 				};
-                
-                		if (fwVersion < 7.02)                       //Added this code to handle HangTimer
-                		{                                           //changed in v7.00
-                    			portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
-                		}
-                		else
-                		{
-                    			portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
-                    			portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
-                    			portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
-                		}
 
-                		if (portName != string.Empty)
+				if (fwVersion < 7.00)
+				{
+					portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime({0})", i));
+				}
+				else
+				{
+					portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
+					portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
+					portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
+				}
+
+
+				if (portName != string.Empty)
 					portItem.PortName = portName;
 
 				_ports.Add(i, portItem);
@@ -1299,46 +1299,46 @@ namespace RC210_DataAssistant_V2
 			}
 		}
 
-        	private void Load_ExtendedMacros()          //Supports change with v7.39
-        	{
-            		IniFile datFile = new IniFile(_datFilename);
+        private void Load_ExtendedMacros()
+        {
+            IniFile datFile = new IniFile(_datFilename);
 
-            		_extendedMacros.Clear();
+            _extendedMacros.Clear();
 
-            		for (int i = 1; i <= 15; i++)
-            		{
-                		string extendedMacro = datFile.IniReadValue("Macros", string.Format("ExtendedMacro({0})", i));
-                		string extendedMacroCode = datFile.IniReadValue("Macros", string.Format("ExtendedMacroCode({0})", i));
-                		string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 90));
+            for (int i = 1; i <= 15; i++)
+            {
+                string extendedMacro = datFile.IniReadValue("Macros", string.Format("ExtendedMacro({0})", i));
+                string extendedMacroCode = datFile.IniReadValue("Macros", string.Format("ExtendedMacroCode({0})", i));
+                string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 90));
 
-                		Macro extendedMacroItem = new Macro
-                		{
-                    			MacroNumber = i + 90,
-                    			//MacroCodes = extendedMacro,
-                   			AccessCode = extendedMacroCode,
-                    			ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), extendedMacro),
-                    			AllowedPorts = allowedPorts
-                		};
+                Macro extendedMacroItem = new Macro
+                {
+                    MacroNumber = i + 90,
+                    //MacroCodes = extendedMacro,
+                    AccessCode = extendedMacroCode,
+                    ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), extendedMacro),
+                    AllowedPorts = allowedPorts
+                };
 
-                		char[] splitChar = { ' ' };
-                		string[] macroCodes = extendedMacro.Split(splitChar);
+                char[] splitChar = { ' ' };
+                string[] macroCodes = extendedMacro.Split(splitChar);
 
-                		foreach (string code in macroCodes)
-                		{
-                    			extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
-                		}
+                foreach (string code in macroCodes)
+                {
+                    extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
+                }
 
-                		extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes.Substring(1);
+                extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes.Substring(1);
 
-                		_extendedMacros.Add(i, extendedMacroItem);
-           		}
-        	}
+                _extendedMacros.Add(i, extendedMacroItem);
+            }
+        }
 
-        	#endregion Load Macros/ShortMacros/ExtendedMacros
+        #endregion Load Macros/ShortMacros/ExtendedMacros
 
-        	#region Load Message Macros
+        #region Load Message Macros
 
-        	private void Load_MessageMacros()
+        private void Load_MessageMacros()
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1358,7 +1358,7 @@ namespace RC210_DataAssistant_V2
 
 		#region ToolStripMenu Even Handlers
 
-		private void SaveToolStripMenuItem_Click(object sender, EventArgs e)
+		private void saveToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			var result = MessageBox.Show(@"This will overwrite any existing options, are you sure ?",
 				@"Warning - Overwrite Options", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
@@ -1369,7 +1369,7 @@ namespace RC210_DataAssistant_V2
 			Settings.Default.Save();
 		}
 		
-		private void ResetToolStripMenuItem_Click(object sender, EventArgs e)
+		private void resetToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			var result = MessageBox.Show(@"This is a global reset of options that cannot be undone, are you sure ?",
 				@"Warning - Options Reset", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
@@ -1380,7 +1380,7 @@ namespace RC210_DataAssistant_V2
 			Settings.Default.Reset();
 		}
 
-		private void RecallToolStripMenuItem_Click(object sender, EventArgs e)
+		private void recallToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			var result = MessageBox.Show(@"This will repopulate the options to match the saved options, are you sure ?",
 				@"Warning - Overwrite Options", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
@@ -1391,7 +1391,7 @@ namespace RC210_DataAssistant_V2
 			Settings.Default.Reload();
 		}
 
-		private void OpenToolStripMenuItem_Click(object sender, EventArgs e)
+		private void openToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			viewReportToolStripMenuItem.Enabled = openReportFolderToolStripMenuItem.Enabled = false;
 			OpenFileDialog resultOpenFileDialog = new OpenFileDialog
@@ -1410,7 +1410,7 @@ namespace RC210_DataAssistant_V2
 			generateReportToolStripMenuItem1.Enabled = true;
 		}
 
-		private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
+		private void closeToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			generateReportToolStripMenuItem1.Enabled = false;
 			viewReportToolStripMenuItem.Enabled = openReportFolderToolStripMenuItem.Enabled = false;
@@ -1419,7 +1419,7 @@ namespace RC210_DataAssistant_V2
 			Text = @"RC210 Data Assistant V2";
 		}
 
-		private void Port1ToolStripMenuItem_Click(object sender, EventArgs e)
+		private void port1ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string value = Settings.Default.Port1Name;
 			var result = InputBox(@"Port 1 name", "Port 1 name:", ref value);
@@ -1431,7 +1431,7 @@ namespace RC210_DataAssistant_V2
 			groupBox_Port1.Text = @"Port 1 - " + value;
 		}
 
-		private void Port2ToolStripMenuItem_Click(object sender, EventArgs e)
+		private void port2ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string value = Settings.Default.Port2Name;
 			var result = InputBox(@"Port 2 name", "Port 2 name:", ref value);
@@ -1443,7 +1443,7 @@ namespace RC210_DataAssistant_V2
 			groupBox_Port2.Text = @"Port 2 - " + value;
 		}
 
-		private void Port3ToolStripMenuItem_Click(object sender, EventArgs e)
+		private void port3ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string value = Settings.Default.Port3Name;
 			var result = InputBox(@"Port 3 name", "Port 3 name:", ref value);
@@ -1455,19 +1455,19 @@ namespace RC210_DataAssistant_V2
 			groupBox_Port3.Text = @"Port 3 - " + value;
 		}
 
-		private void AboutToolStripMenuItem_Click(object sender, EventArgs e)
+		private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			FormAbout aboutDialog = new FormAbout();
 			aboutDialog.ShowDialog();
 		}
 
-		private void GenerateReportToolStripMenuItem_Click(object sender, EventArgs e)
+		private void generateReportToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			Generate_Report();
 			viewReportToolStripMenuItem.Enabled = openReportFolderToolStripMenuItem.Enabled = true;
 		}
 
-		private void ViewReportToolStripMenuItem_Click(object sender, EventArgs e)
+		private void viewReportToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			if (!File.Exists(_reportFilename))
 			{
@@ -1480,7 +1480,7 @@ namespace RC210_DataAssistant_V2
 			Process.Start(_reportFilename);
 		}
 
-		private void OpenReportFolderToolStripMenuItem_Click(object sender, EventArgs e)
+		private void openReportFolderToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			if (_reportFilename != null)
 				return;
@@ -1489,14 +1489,14 @@ namespace RC210_DataAssistant_V2
 				Process.Start(Path.GetDirectoryName(_reportFilename));
 		}
 
-		private void VersionToolStripMenuItem_Click(object sender, EventArgs e)
+		private void versionToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			MessageBox.Show(
 				string.Format("Macro Definitions\n\nLocal file: {0}\nRemote file: {1}", _localXmlVersion, _remoteXmlVersion),
 				@"Macro Definitions", MessageBoxButtons.OK, MessageBoxIcon.Information);
 		}
 
-		private void UpdateToolStripMenuItem_Click(object sender, EventArgs e)
+		private void updateToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			//FetchDefXml(true);
 			UpdateXml();
@@ -1550,9 +1550,9 @@ namespace RC210_DataAssistant_V2
 
 		#endregion InputBox
 
-		private void XMLFilePathToolStripMenuItem_Click(object sender, EventArgs e)
+		private void xMLFilePathToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";			
+			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";
 			MessageBox.Show("I look for .xml files at the following location:\n\n" + filepath);
 		}
 	}

--- a/Form1.cs
+++ b/Form1.cs
@@ -31,7 +31,9 @@ namespace RC210_DataAssistant_V2
 		{
 			public string PortName;
 			public string PortCode;
-			public string HangTimer;
+			public string HangTimer1;
+			public string HangTimer2;
+			public string HangTimer3;
 			public string TimeoutTimer;
 			public string InitialIdTimer;
 			public string PendingIdTimer;
@@ -105,13 +107,14 @@ namespace RC210_DataAssistant_V2
 		private readonly Dictionary<int, Port> _ports = new Dictionary<int, Port>();
 		private readonly Dictionary<int, Macro> _macros = new Dictionary<int, Macro>();
 		private readonly Dictionary<int, Macro> _shortMacros = new Dictionary<int, Macro>();
-		private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
+        private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();
+        private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
+        
+        #endregion Private Members
 
-		#endregion Private Members
+        #region Initialization
 
-		#region Initialization
-
-		public Form1()
+        public Form1()
 		{
 			InitializeComponent();
 		}
@@ -237,11 +240,23 @@ namespace RC210_DataAssistant_V2
 
 		}
 
+		
 		private void FetchDefXml()
 		{
-			if (File.Exists(_localXmlDocumentFile))
+			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";
+			DirectoryInfo d = new DirectoryInfo(filepath);
+
+			foreach (var file in d.GetFiles("*.xml"))
 			{
-				_localXmlDocument.Load(_localXmlDocumentFile);
+				LoadXMLFile(filepath + file.Name);
+			}
+		}
+
+		private void LoadXMLFile(string file)
+		{
+			if (File.Exists(file))
+			{
+				_localXmlDocument.Load(file);
 
 				var localXmlElement = _localXmlDocument["macros"];
 				if (localXmlElement != null)
@@ -255,7 +270,7 @@ namespace RC210_DataAssistant_V2
 				UpdateXml();
 			}
 
-			if (!File.Exists(_localXmlDocumentFile))
+			if (!File.Exists(file))
 			{
 				MessageBox.Show(
 					@"Something has gone terribly wrong, unable to locate an xml file for Macro definitions, please consult the support group for help.",
@@ -264,8 +279,8 @@ namespace RC210_DataAssistant_V2
 				return;
 			}
 
-			//Load the regulat macro definitions
-			_localXmlDocument.Load(_localXmlDocumentFile);
+			//Load the regular macro definitions
+			_localXmlDocument.Load(file);
 
 			foreach (XmlNode node in _localXmlDocument.ChildNodes)
 			{
@@ -300,702 +315,804 @@ namespace RC210_DataAssistant_V2
 		{
 			if (_datFilename == string.Empty || !File.Exists(_datFilename))
 				return;
-			Load_Ports();
 			Load_MessageMacros();
 			Load_Macros();
 			Load_ShortMacros();
+            Load_ExtendedMacros();
 			Load_AutoPatch();
 		}
+
+        #endregion Load .dat file
+
+        #region Generate Report
+
+        private void Generate_Report()
+        {
+            double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);
+            Load_Ports(fwVersion);
+
+            if (!File.Exists(_datFilename))
+            {
+                MessageBox.Show(@"Unable to locate .dat file: " + _datFilename);
+                return;
+            }
+
+            SaveFileDialog result = new SaveFileDialog
+            {
+                Filter = @"HTML File (*.html)|*.html",
+                InitialDirectory = Path.GetDirectoryName(_reportFilename)
+            };
+
+            if (result.ShowDialog() != DialogResult.OK)
+                return;
+
+            _reportFilename = result.FileName;
+
+            //Load the dat file
+            Load_datFile();
+
+            IniFile datFile = new IniFile(_datFilename);
+
+            //Create the file. 
+            using (StreamWriter rW = new StreamWriter(_reportFilename))
+            {
+                //Date Header
+                if (checkBox_DateHeader.Checked)
+                    rW.WriteLine("<CENTER><H2>" + DateTime.Now + "</H2></CENTER>");
+
+                //Custom Header
+                if (checkBox_CustomHeader.Checked)
+                    rW.WriteLine("<CENTER><H2>" + textBox_CustomHeader.Text + "</H2></CENTER><HR>");
+
+                //PreAccess Prefix
+                if (checkBox_PreAccessPrefix.Checked)
+                    rW.WriteLine("<CENTER><B>PreAccess Prefix:</B> " + datFile.IniReadValue("PreAccess", "PreAccessPrefix") + "</CENTER>");
+
+                //Global Lock Code
+                if (checkBox_GlobalLockCode.Checked)
+                    rW.WriteLine("<CENTER><B>Global Lock Code:</B> " + datFile.IniReadValue("Unlock", "Lock") + "</CENTER>");
+
+                //Terminator Digit
+                if (checkBox_TerminatorDigit.Checked)
+                    rW.WriteLine("<CENTER><B>Terminator Digit:</B> " + datFile.IniReadValue("Unlock", "Terminator") + "</CENTER>");
+
+                //DTMF Test pad code
+                if (checkBox_DTMFTestPadCode.Checked)
+                    rW.WriteLine("<CENTER><B>DTMF Pad Test:</B> " + datFile.IniReadValue("PadTest", "DTMFTestPrefix") + "</CENTER>");
+
+                //Add the <HR> tag if needed
+                if (checkBox_PreAccessPrefix.Checked || checkBox_GlobalLockCode.Checked || checkBox_TerminatorDigit.Checked || checkBox_DTMFTestPadCode.Checked)
+                    rW.WriteLine("<CENTER><HR></CENTER>");
+
+                //Port1
+                if (checkBox_P1UnlockCode.Checked || checkBox_P1IDs.Checked || checkBox_P1TailMessages.Checked ||
+                    checkBox_P1Timers.Checked)
+                {
+                    string port1Header = _ports[1].PortName != string.Empty ? "Port 1 - " + _ports[1].PortName : "Port 1";
+                    rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
+                    rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port1Header + "</H2></TD></TR>");
+                    rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+                    rW.WriteLine("<TR>");
+
+                    //Unlock Code
+                    string port1UnlockCode = checkBox_P1UnlockCode.Checked ? _ports[1].PortCode : "Not Displayed";
+                    rW.WriteLine("<TD valign=top>" + port1UnlockCode + "</TD>");
+
+                    //Voice IDs
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P1IDs.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[1].VoiceId1 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[1].VoiceId2 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[1].VoiceId3 + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //CW IDs
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P1IDs.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[1].Cwid1 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[1].Cwid2 + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //Tail Messages
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P1TailMessages.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[1].TailMessage == "0") ? "Disabled" : _ports[1].TailMessage) + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[1].TailMessageCounter + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[1].TailMessageTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[1].TailMessage1Macro + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[1].TailMessage2Macro + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[1].TailMessage3Macro + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //Timers
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P1Timers.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+
+                        if (fwVersion < 7.00)           //Added 3 hangtimers per port with v7.00
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                        }
+                        else
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
+                        }
+
+                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[1].InitialIdTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[1].PendingIdTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[1].PendingIdSpeechTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[1].InactivityTimer + " (" + _ports[1].InactivityTimerMacro + ")</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMuteTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[1].EncoderTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[1].KerchunkTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[1].AuxAudioTimer + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD><TD>");
+
+                    //Switches
+                    if (checkBox_P1Switches.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[1].TransmitterEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[1].ReceiverEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[1].DisableInactivityTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[1].RepeaterMode + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[1].SpeechOverride + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[1].SpeechIdOverride + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[1].DtmfEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMute + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[1].DtmfRequireTone + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[1].DtmfCoverTone + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[1].MonitorMix + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[1].KerchunkFilter + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    rW.WriteLine("</TR></TABLE><HR>");
+                }
+
+                //Port2
+                if (checkBox_P2UnlockCode.Checked || checkBox_P2IDs.Checked || checkBox_P2TailMessages.Checked ||
+                    checkBox_P2Timers.Checked)
+                {
+                    string port2Header = _ports[2].PortName != string.Empty ? "Port 2 - " + _ports[2].PortName : "Port 2";
+                    rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
+                    rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port2Header + "</H2></TD></TR>");
+                    rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+                    rW.WriteLine("<TR>");
+
+                    //Unlock Code
+                    string port2UnlockCode = checkBox_P2UnlockCode.Checked ? _ports[2].PortCode : "Not Displayed";
+                    rW.WriteLine("<TD valign=top>" + port2UnlockCode + "</TD>");
+
+                    //Voice IDs
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P2IDs.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[2].VoiceId1 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[2].VoiceId2 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[2].VoiceId3 + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //CW IDs
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P2IDs.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[2].Cwid1 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[2].Cwid2 + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //Tail Messages
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P2TailMessages.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[2].TailMessage == "0") ? "Disabled" : _ports[2].TailMessage) + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[2].TailMessageCounter + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[2].TailMessageTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[2].TailMessage1Macro + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[2].TailMessage2Macro + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[2].TailMessage3Macro + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //Timers
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P2Timers.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+
+                        if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[2].HangTimer1 + "</TD></TR>");
+                        }
+                        else
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[2].HangTimer1 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[2].HangTimer2 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[2].HangTimer3 + "</TD></TR>");
+                        }
+
+                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[2].InitialIdTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[2].PendingIdTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[2].PendingIdSpeechTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[2].InactivityTimer + " (" + _ports[2].InactivityTimerMacro + ")</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMuteTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[2].EncoderTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[2].KerchunkTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[2].AuxAudioTimer + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD><TD>");
+
+                    //Switches
+                    if (checkBox_P1Switches.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[2].TransmitterEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[2].ReceiverEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[2].DisableInactivityTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[2].RepeaterMode + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[2].SpeechOverride + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[2].SpeechIdOverride + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[2].DtmfEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMute + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[2].DtmfRequireTone + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[2].DtmfCoverTone + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[2].MonitorMix + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[2].KerchunkFilter + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    rW.WriteLine("</TR></TABLE><HR>");
+                }
+
+                //Port3
+                if (checkBox_P3UnlockCode.Checked || checkBox_P3IDs.Checked || checkBox_P3TailMessages.Checked ||
+                    checkBox_P3Timers.Checked)
+                {
+                    string port3Header = _ports[3].PortName != string.Empty ? "Port 3 - " + _ports[3].PortName : "Port 3";
+                    rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
+                    rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port3Header + "</H2></TD></TR>");
+                    rW.WriteLine(
+                        "<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+                    rW.WriteLine("<TR>");
+
+                    //Unlock Code
+                    string port3UnlockCode = checkBox_P3UnlockCode.Checked ? _ports[3].PortCode : "Not Displayed";
+                    rW.WriteLine("<TD valign=top>" + port3UnlockCode + "</TD>");
+
+                    //Voice IDs
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P3IDs.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[3].VoiceId1 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[3].VoiceId2 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[3].VoiceId3 + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //CW IDs
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P3IDs.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[3].Cwid1 + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[3].Cwid2 + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //Tail Messages
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P3TailMessages.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" +
+                                     ((_ports[3].TailMessage == "0") ? "Disabled" : _ports[3].TailMessage) + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[3].TailMessageCounter + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[3].TailMessageTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[3].TailMessage1Macro + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[3].TailMessage2Macro + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[3].TailMessage3Macro + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    //Timers
+                    rW.WriteLine("<TD valign=top>");
+
+                    if (checkBox_P3Timers.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+
+                        if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[3].HangTimer1 + "</TD></TR>");
+                        }
+                        else
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[3].HangTimer1 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[3].HangTimer2 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[3].HangTimer3 + "</TD></TR>");
+                        }
+
+                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[3].InactivityTimer + " (" +
+                                     _ports[3].InactivityTimerMacro + ")</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMuteTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[3].EncoderTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[3].KerchunkTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[3].AuxAudioTimer + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD><TD>");
+
+                    //Switches
+                    if (checkBox_P1Switches.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=0>");
+                        rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[3].TransmitterEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[3].ReceiverEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[3].DisableInactivityTimer + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[3].RepeaterMode + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[3].SpeechOverride + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[3].SpeechIdOverride + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[3].DtmfEnable + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMute + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[3].DtmfRequireTone + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[3].DtmfCoverTone + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[3].MonitorMix + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[3].KerchunkFilter + "</TD></TR>");
+                        rW.WriteLine("</TABLE>");
+                    }
+
+                    rW.WriteLine("</TD>");
+
+                    rW.WriteLine("</TR></TABLE><HR>");
+                }
+
+                //Macros
+                if (checkBox_Macros.Checked || checkBox_MacroCodes.Checked)
+                {
+                    rW.WriteLine("<TABLE align=center border=1 width=75%>");
+                    rW.WriteLine("<TR><TD align=center colspan=4><H2>Macros</H2></TD></TR>");
+                    rW.WriteLine("<TR><TD><B>Macro #</B></TD><TD><B>Code</B></TD><TD><B>Ports allowed</B></TD><TD><B>Actions</B></TD></TR>");
+
+                    foreach (KeyValuePair<int, Macro> macro in _macros)
+                    {
+                        rW.WriteLine("<TR><TD valign=top>" + macro.Value.MacroNumber + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro)+ "</TD></TR>");
+                        rW.WriteLine("<TD>");
+                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+                        rW.WriteLine("</TD></TR>");
+                    }
+
+
+                    //ShortMacros
+
+                    foreach (KeyValuePair<int, Macro> macro in _shortMacros)
+                    {
+                        rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 40).ToString(CultureInfo.InvariantCulture) + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
+                        rW.WriteLine("<TD>");
+                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+                        rW.WriteLine("</TD></TR>");
+                    }
+
+                    //ExtendedMacros
+
+                    foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
+                    {
+                        rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
+                        rW.WriteLine("<TD>");
+                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+                        rW.WriteLine("</TD></TR>");
+                    }
+
+                    rW.WriteLine("</TABLE><HR>");
+                }
+
+                //Setpoints
+                if (checkBox_SetpointsScheduler.Checked)
+                {
+                    rW.WriteLine("<TABLE border=1 align=center width=75%>");
+
+                    if (fwVersion < 7.32)       //Reinstated Month of Year with v7.32
+                    {
+                        rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
+                    }
+                    else
+                    {
+                        rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
+                    }
+
+                    if (fwVersion < 7.36)
+                    {
+                        for (int i = 1; i <= 20; i++)
+                        {
+                            rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+
+                            if (fwVersion > 7.00)
+                            {
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                            }
+
+                            rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+
+                            //if they want to
+                            var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            rW.WriteLine("<TR><TD colspan=7>");
+
+                            rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+
+                            rW.WriteLine("</TD></TR>");
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 1; i <= 40; i++)
+
+                        {
+                            rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+
+                            if (fwVersion > 7.00)
+                            {
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                            }
+
+                            rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+
+                            //if they want to
+                            var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            rW.WriteLine("<TR><TD colspan=7>");
+
+                            rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+
+                            rW.WriteLine("</TD></TR>");
+                        }
+
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+                    //CT MSG Macros
+                    if (checkBox_CTMessageMacros.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
+
+                        for (int i = 1; i <= 3; i++)
+                        {
+                            for (int j = 1; j <= 10; j++)
+                            {
+                                var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
+
+                                if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
+                                    continue;
+
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + j + "</TD>");
+                                rW.WriteLine("<TD>" + tone1 + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
+                            }
+
+                            if (fwVersion >= 7.02) //From version 7.02 there is a single pool of Courtesy Tones @ P1Tone1 - P1Tone10
+                                break;
+                        }
+
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    //Messages
+                    if (checkBox_MessageMacros.Checked)
+                    {
+
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
+
+                        int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
+                        for (int i = 1; i <= lastMessage; i++)
+                        {
+                            var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
+                            if (messageMacro != "" && messageMacro != "NONE STORED")
+                            {
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + messageMacro + "</TD></TR>");
+                            }
+                        }
+
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    //General Timers
+                    if (checkBox_GeneralTimers.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
+
+                        for (int i = 1; i <= 6; i++)
+                        {
+                            var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
+                            if (generalTimer != "0")
+                            {
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + generalTimer + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
+                            }
+                        }
+
+                        rW.WriteLine("</TABLE>");
+                        rW.WriteLine("<HR>");
+                    }
+
+                    //Analog Meters
+                    if (checkBox_AnalogMeters.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
+
+                        for (int i = 1; i <= 8; i++)
+                        {
+                            var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
+
+                            if (meter != "0")
+                            {
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
+                            }
+
+                        }
+                        rW.WriteLine("</TABLE>");
+
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
+
+                        for (int i = 1; i <= 8; i++)
+                        {
+                            var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
+                            if (meterAlarm != "0")
+                            {
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
+                            }
+                        }
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    //Alarms
+                    if (checkBox_Alarms.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
+
+                        for (int i = 1; i <= 5; i++)
+                        {
+                            rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
+                            rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
+                        }
+
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    //DTMF Memories
+                    if (checkBox_DTMFMemories.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
+
+                        int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
+                        for (int i = 1; i <= dtmfMemoryCount; i++)
+                        {
+                            var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
+                            if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
+                            {
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
+                            }
+                        }
+
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    //Remote Base Memories
+                    if (checkBox_RemoteBaseMemories.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 align=center>");
+                        rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
+                        int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
+                        for (int i = 1; i <= remoteBaseMemories; i++)
+                        {
+                            var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
+                            if (freqString != "" && freqString != "0" && freqString != "NONE")
+                            {
+                                rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
+                                rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
+                                rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
+                                rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
+                                rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
+                            }
+                        }
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    //AutoPatch Settings
+                    if (checkBox_APSettings.Checked)
+                    {
+                        rW.WriteLine("<TABLE border=1 aling=center");
+                        rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
+                                        "</TD>");
+                        rW.WriteLine("<TD><B>Answer Code:</B> " +
+                                        ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
+                        rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
+                        rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
+                        rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
+
+                        rW.WriteLine("<TR><TD valign=top>");
+
+                        //AutoPatch Memories
+                        if (checkBox_APMemories.Checked)
+                        {
+                            rW.WriteLine("<TABLE border=1 align=center>");
+                            rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
+
+                            for (int i = 1; i <= 200; i++)
+                            {
+                                var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
+                                if (autoDial.Length > 0)
+                                {
+                                    rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                    rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
+                                }
+                            }
+
+                            rW.WriteLine("</TABLE>");
+                        }
+
+                        rW.WriteLine("</TD><TD valign=top>");
+
+                        //AutoPatch Toll Restrictions
+                        if (checkBox_APTollRestrictions.Checked)
+                        {
+                            rW.WriteLine("<TABLE border=1 align=center>");
+                            rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
+
+                            for (int i = 1; i <= 100; i++)
+                            {
+                                var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
+                                if (apTollRestriction.Length > 0)
+                                {
+                                    rW.WriteLine("<TR><TD>" + i + "</TD>");
+                                    rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
+                                }
+                            }
+
+                            rW.WriteLine("</TABLE>");
+                        }
+
+                        rW.WriteLine("</TD></TR>");
+                        rW.WriteLine("</TABLE><HR>");
+                    }
+
+                    rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
+                    rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
+                    rW.WriteLine("Modifed by Robert P. Norris - AK5U: ak5u@arrl.net");
+                    rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
+
+                    var dr = MessageBox.Show(
+                        string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
+                        @"Report created",
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Information
+                        );
+
+                    if (dr == DialogResult.Yes) Process.Start(_reportFilename);
+                }
+            }
+        }
 		
-		#endregion Load .dat file
-
-		#region Generate Report
-
-		private void Generate_Report()
-		{
-			if (!File.Exists(_datFilename))
-				return;
-
-			SaveFileDialog result = new SaveFileDialog
-			{
-				Filter = @"HTML File (*.html)|*.html",
-				InitialDirectory = Path.GetDirectoryName(_reportFilename)
-			};
-
-			if (result.ShowDialog() != DialogResult.OK)
-				return;
-
-			_reportFilename = result.FileName;
-
-			//Load the dat file
-			Load_datFile();
-
-			IniFile datFile = new IniFile(_datFilename);
-
-			//Create the file. 
-			using (StreamWriter rW = new StreamWriter(_reportFilename))
-			{
-				//Date Header
-				if (checkBox_DateHeader.Checked)
-					rW.WriteLine("<CENTER><H2>" + DateTime.Now + "</H2></CENTER>");
-
-				//Custom Header
-				if (checkBox_CustomHeader.Checked)
-					rW.WriteLine("<CENTER><H2>" + textBox_CustomHeader.Text + "</H2></CENTER><HR>");
-
-				//PreAccess Prefix
-				if (checkBox_PreAccessPrefix.Checked)
-					rW.WriteLine("<CENTER><B>PreAccess Prefix:</B> " + datFile.IniReadValue("PreAccess", "PreAccessPrefix") + "</CENTER>");
-
-				//Global Lock Code
-				if (checkBox_GlobalLockCode.Checked)
-					rW.WriteLine("<CENTER><B>Global Lock Code:</B> " + datFile.IniReadValue("Unlock", "Lock") + "</CENTER>");
-
-				//Terminator Digit
-				if (checkBox_TerminatorDigit.Checked)
-					rW.WriteLine("<CENTER><B>Terminator Digit:</B> " + datFile.IniReadValue("Unlock", "Terminator") + "</CENTER>");
-
-				//DTMF Test pad code
-				if (checkBox_DTMFTestPadCode.Checked)
-					rW.WriteLine("<CENTER><B>DTMF Pad Test:</B> " + datFile.IniReadValue("PadTest", "DTMFTestPrefix") + "</CENTER>");
-
-				//Add the <HR> tag if needed
-				if (checkBox_PreAccessPrefix.Checked || checkBox_GlobalLockCode.Checked || checkBox_TerminatorDigit.Checked || checkBox_DTMFTestPadCode.Checked)
-					rW.WriteLine("<CENTER><HR></CENTER>");
-
-				//Port1
-				if (checkBox_P1UnlockCode.Checked || checkBox_P1IDs.Checked || checkBox_P1TailMessages.Checked ||
-				    checkBox_P1Timers.Checked)
-				{
-					string port1Header = _ports[1].PortName != string.Empty ? "Port 1 - " + _ports[1].PortName : "Port 1";
-					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port1Header + "</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
-					rW.WriteLine("<TR>");
-
-					//Unlock Code
-					string port1UnlockCode = checkBox_P1UnlockCode.Checked ? _ports[1].PortCode : "Not Displayed";
-					rW.WriteLine("<TD valign=top>" + port1UnlockCode + "</TD>");
-
-					//Voice IDs
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P1IDs.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[1].VoiceId1 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[1].VoiceId2 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[1].VoiceId3 + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//CW IDs
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P1IDs.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[1].Cwid1 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[1].Cwid2 + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//Tail Messages
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P1TailMessages.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[1].TailMessage == "0") ? "Disabled" : _ports[1].TailMessage) + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[1].TailMessageCounter + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[1].TailMessageTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[1].TailMessage1Macro + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[1].TailMessage2Macro + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[1].TailMessage3Macro + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//Timers
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P1Timers.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[1].InitialIdTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[1].PendingIdTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[1].PendingIdSpeechTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[1].InactivityTimer + " (" + _ports[1].InactivityTimerMacro + ")</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMuteTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[1].EncoderTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[1].KerchunkTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[1].AuxAudioTimer + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-					
-					rW.WriteLine("</TD><TD>");
-
-					//Switches
-					if (checkBox_P1Switches.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[1].TransmitterEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[1].ReceiverEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[1].DisableInactivityTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[1].RepeaterMode + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[1].SpeechOverride + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[1].SpeechIdOverride + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[1].DtmfEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMute + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[1].DtmfRequireTone + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[1].DtmfCoverTone + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[1].MonitorMix + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[1].KerchunkFilter + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					rW.WriteLine("</TR></TABLE><HR>");
-				}
-
-				//Port2
-				if (checkBox_P2UnlockCode.Checked || checkBox_P2IDs.Checked || checkBox_P2TailMessages.Checked ||
-					checkBox_P2Timers.Checked)
-				{
-					string port2Header = _ports[2].PortName != string.Empty ? "Port 2 - " + _ports[2].PortName : "Port 2";
-					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port2Header + "</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
-					rW.WriteLine("<TR>");
-
-					//Unlock Code
-					string port2UnlockCode = checkBox_P2UnlockCode.Checked ? _ports[2].PortCode : "Not Displayed";
-					rW.WriteLine("<TD valign=top>" + port2UnlockCode + "</TD>");
-
-					//Voice IDs
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P2IDs.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[2].VoiceId1 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[2].VoiceId2 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[2].VoiceId3 + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//CW IDs
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P2IDs.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[2].Cwid1 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[2].Cwid2 + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//Tail Messages
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P2TailMessages.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[2].TailMessage == "0") ? "Disabled" : _ports[2].TailMessage) + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[2].TailMessageCounter + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[2].TailMessageTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[2].TailMessage1Macro + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[2].TailMessage2Macro + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[2].TailMessage3Macro + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//Timers
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P2Timers.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[2].HangTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[2].InitialIdTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[2].PendingIdTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[2].PendingIdSpeechTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[2].InactivityTimer + " (" + _ports[2].InactivityTimerMacro + ")</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMuteTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[2].EncoderTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[2].KerchunkTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[2].AuxAudioTimer + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD><TD>");
-
-					//Switches
-					if (checkBox_P1Switches.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[2].TransmitterEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[2].ReceiverEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[2].DisableInactivityTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[2].RepeaterMode + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[2].SpeechOverride + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[2].SpeechIdOverride + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[2].DtmfEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMute + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[2].DtmfRequireTone + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[2].DtmfCoverTone + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[2].MonitorMix + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[2].KerchunkFilter + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					rW.WriteLine("</TR></TABLE><HR>");
-				}
-
-				//Port3
-				if (checkBox_P3UnlockCode.Checked || checkBox_P3IDs.Checked || checkBox_P3TailMessages.Checked ||
-				    checkBox_P3Timers.Checked)
-				{
-					string port3Header = _ports[3].PortName != string.Empty ? "Port 3 - " + _ports[3].PortName : "Port 3";
-					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port3Header + "</H2></TD></TR>");
-					rW.WriteLine(
-						"<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
-					rW.WriteLine("<TR>");
-
-					//Unlock Code
-					string port3UnlockCode = checkBox_P3UnlockCode.Checked ? _ports[3].PortCode : "Not Displayed";
-					rW.WriteLine("<TD valign=top>" + port3UnlockCode + "</TD>");
-
-					//Voice IDs
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P3IDs.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[3].VoiceId1 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[3].VoiceId2 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[3].VoiceId3 + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//CW IDs
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P3IDs.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[3].Cwid1 + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[3].Cwid2 + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//Tail Messages
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P3TailMessages.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" +
-						             ((_ports[3].TailMessage == "0") ? "Disabled" : _ports[3].TailMessage) + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[3].TailMessageCounter + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[3].TailMessageTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[3].TailMessage1Macro + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[3].TailMessage2Macro + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[3].TailMessage3Macro + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					//Timers
-					rW.WriteLine("<TD valign=top>");
-
-					if (checkBox_P3Timers.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[3].HangTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[3].InactivityTimer + " (" +
-						             _ports[3].InactivityTimerMacro + ")</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMuteTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[3].EncoderTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[3].KerchunkTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[3].AuxAudioTimer + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD><TD>");
-
-					//Switches
-					if (checkBox_P1Switches.Checked)
-					{
-						rW.WriteLine("<TABLE border=0>");
-						rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[3].TransmitterEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[3].ReceiverEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[3].DisableInactivityTimer + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[3].RepeaterMode + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[3].SpeechOverride + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[3].SpeechIdOverride + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[3].DtmfEnable + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMute + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[3].DtmfRequireTone + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[3].DtmfCoverTone + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[3].MonitorMix + "</TD></TR>");
-						rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[3].KerchunkFilter + "</TD></TR>");
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD>");
-
-					rW.WriteLine("</TR></TABLE><HR>");
-				}
-
-				//Macros
-				if (checkBox_Macros.Checked || checkBox_MacroCodes.Checked)
-				{
-					rW.WriteLine("<TABLE align=center border=1 width=75%>");
-					rW.WriteLine("<TR><TD align=center colspan=4><H2>Macros</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Macro #</B></TD><TD><B>Code</B></TD><TD><B>Ports allowed</B></TD><TD><B>Actions</B></TD></TR>");
-
-					foreach (KeyValuePair<int, Macro> macro in _macros)
-					{
-						rW.WriteLine("<TR><TD valign=top>" + macro.Value.MacroNumber + "</TD>");
-						rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-						rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-						//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro)+ "</TD></TR>");
-						rW.WriteLine("<TD>");
-						rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-						rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-						rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-						rW.WriteLine("</TD></TR>");
-					}
-
-
-					//ShortMacros
-
-					foreach (KeyValuePair<int, Macro> macro in _shortMacros)
-					{
-						rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 40).ToString(CultureInfo.InvariantCulture) + "</TD>");
-						rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-						rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-						//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
-						rW.WriteLine("<TD>");
-						rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-						rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-						rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-						rW.WriteLine("</TD></TR>");
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Setpoints
-				if (checkBox_SetpointsScheduler.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center width=75%>");
-					rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-					for (int i = 1; i <= 20; i++)
-					{
-						rW.WriteLine("<TR><TD>" + i + "</TD>");
-						rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
-						rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
-						rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
-
-						//if they want to
-						var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-						rW.WriteLine("<TR><TD colspan=7>");
-
-						rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
-
-						rW.WriteLine("</TD></TR>");
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//CT MSG Macros
-				if (checkBox_CTMessageMacros.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
-
-					for (int i = 1; i <= 3; i++)
-					{
-						for (int j = 1; j <= 10; j++)
-						{
-							var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
-								
-							if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
-								continue;
-
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + j + "</TD>");
-							rW.WriteLine("<TD>" + tone1 + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
-						}
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Messages
-				if (checkBox_MessageMacros.Checked)
-				{
-
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
-
-					int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
-					for (int i = 1; i <= lastMessage; i++)
-					{
-						var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
-						if (messageMacro != "" && messageMacro != "NONE STORED")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + messageMacro +"</TD></TR>");
-						}
-					}
-					
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//General Timers
-				if (checkBox_GeneralTimers.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-					for (int i = 1; i <= 6; i++)
-					{
-						var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
-						if (generalTimer != "0")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + generalTimer + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
-						}	
-					}
-
-					rW.WriteLine("</TABLE>");
-					rW.WriteLine("<HR>");
-				}
-
-				//Analog Meters
-				if (checkBox_AnalogMeters.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
-
-					for (int i = 1; i <= 8; i++)
-					{
-						var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
-
-						if (meter != "0")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
-						}
-
-					}
-					rW.WriteLine("</TABLE>");
-
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-					for (int i = 1; i <= 8; i++)
-					{
-						var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
-						if (meterAlarm != "0")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" +ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
-						}
-					}
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Alarms
-				if (checkBox_Alarms.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
-
-					for (int i = 1; i <= 5; i++)
-					{
-						rW.WriteLine("<TR><TD>" + i + "</TD>");
-						rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) +"</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//DTMF Memories
-				if (checkBox_DTMFMemories.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
-
-					int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
-					for (int i = 1; i <= dtmfMemoryCount; i++)
-					{
-						var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
-						if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
-						}
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Remote Base Memories
-				if (checkBox_RemoteBaseMemories.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
-					int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
-					for (int i = 1; i <= remoteBaseMemories; i++)
-					{
-						var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
-						if (freqString != "" && freqString != "0" && freqString != "NONE")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
-							rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
-							rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
-						}
-					}
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//AutoPatch Settings
-				if (checkBox_APSettings.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 aling=center");
-					rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
-						            "</TD>");
-					rW.WriteLine("<TD><B>Answer Code:</B> " +
-						            ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
-					rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
-					rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
-					rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
-					rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
-						
-					rW.WriteLine("<TR><TD valign=top>");
-
-					//AutoPatch Memories
-					if (checkBox_APMemories.Checked)
-					{
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
-
-						for (int i = 1; i <= 200; i++)
-						{
-							var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
-							if (autoDial.Length > 0)
-							{
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
-							}
-						}
-
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD><TD valign=top>");
-
-					//AutoPatch Toll Restrictions
-					if (checkBox_APTollRestrictions.Checked)
-					{
-						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
-
-						for (int i = 1; i <= 100; i++)
-						{
-							var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
-							if (apTollRestriction.Length > 0)
-							{
-								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
-							}
-						}
-
-						rW.WriteLine("</TABLE>");
-					}
-
-					rW.WriteLine("</TD></TR>");
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
-				rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
-				rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
-
-				var dr = MessageBox.Show(
-					string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
-					@"Report created",
-					MessageBoxButtons.YesNo,
-					MessageBoxIcon.Information
-					);
-				
-				if (dr == DialogResult.Yes) Process.Start(_reportFilename);
-			}
-		}
-
-
 		#endregion Generate Report
 
 		#region Load AutoPatch
@@ -1030,7 +1147,7 @@ namespace RC210_DataAssistant_V2
 
 		#region Load Ports
 
-		private void Load_Ports()
+		private void Load_Ports(double fwVersion)
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1050,7 +1167,6 @@ namespace RC210_DataAssistant_V2
 				Port portItem = new Port
 				{
 					PortCode = datFile.IniReadValue("Unlock", string.Format("CurrentPortUnlock({0})", i)),
-					HangTimer  = datFile.IniReadValue("Timers", string.Format("HangTime({0})", i)),
 					TimeoutTimer = datFile.IniReadValue("Timers", string.Format("TimeOut({0})", i)),
 					InitialIdTimer = datFile.IniReadValue("Timers", string.Format("IIDTime({0})", i)),
 					PendingIdTimer = datFile.IniReadValue("Timers", string.Format("PIDTime({0})", i)),
@@ -1080,7 +1196,8 @@ namespace RC210_DataAssistant_V2
 					RepeaterMode = (datFile.IniReadValue("PortSwitches", string.Format("FDup({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechIdOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechIDOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
-					//AccessMode = datFile.IniReadValue("PortSwitches", string.Format("P{0}MessageNum(3)", i)),
+					
+                    //AccessMode = datFile.IniReadValue("PortSwitches", string.Format("P{0}MessageNum(3)", i)),
 					DtmfEnable = (datFile.IniReadValue("PortSwitches", string.Format("DTMFEnable({0})", i)) == "0") ? "Disabled" : "Enabled",
 					DtmfRequireTone = (datFile.IniReadValue("PortSwitches", string.Format("DTMFNeedPL({0})", i)) == "0") ? "Disabled" : "Enabled",
 					DtmfMute = (datFile.IniReadValue("PortSwitches", string.Format("DTMFMute({0})", i)) == "0") ? "Disabled" : "Enabled",
@@ -1089,6 +1206,18 @@ namespace RC210_DataAssistant_V2
 					KerchunkFilter = (datFile.IniReadValue("PortSwitches", string.Format("Kerchunk({0})", i)) == "0") ? "Disabled" : "Enabled",
 
 				};
+
+				if (fwVersion < 7.02)
+				{
+					portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime({0})", i));
+				}
+				else
+				{
+					portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
+					portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
+					portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
+				}
+
 
 				if (portName != string.Empty)
 					portItem.PortName = portName;
@@ -1099,7 +1228,7 @@ namespace RC210_DataAssistant_V2
 
 		#endregion Load Ports
 
-		#region Load Macros/ShortMacros
+		#region Load Macros/ShortMacros/ExtendedMacros
 
 		private void Load_Macros()
 		{
@@ -1136,42 +1265,82 @@ namespace RC210_DataAssistant_V2
 			}
 		}
 
-		private void Load_ShortMacros()
-		{
-			IniFile datFile = new IniFile(_datFilename);
 
-			_shortMacros.Clear();
 
-			for (int i = 1; i <= 50; i++)
-			{
-				string shortMacro = datFile.IniReadValue("Macros", string.Format("ShortMacro({0})", i));
-				string shortMacroCode = datFile.IniReadValue("Macros", string.Format("ShortMacroCode({0})", i));
-				string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 40));
 
-				Macro shortMacroItem = new Macro
-				{
-					MacroNumber = i + 40,
-					//MacroCodes = shortMacro,
-					AccessCode = shortMacroCode,
-					ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), shortMacro),
-					AllowedPorts = allowedPorts
-				};
 
-				char[] splitChar = { ' ' };
-				string[] macroCodes = shortMacro.Split(splitChar);
 
-				foreach (string code in macroCodes)
-				{
-					shortMacroItem.MacroCodes = shortMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
-				}
+        private void Load_ShortMacros()
+        {
+            IniFile datFile = new IniFile(_datFilename);
 
-				shortMacroItem.MacroCodes = shortMacroItem.MacroCodes.Substring(1);
+            _shortMacros.Clear();
 
-				_shortMacros.Add(i, shortMacroItem);
-			}
-		}
+            for (int i = 1; i <= 50; i++)
+            {
+                string shortMacro = datFile.IniReadValue("Macros", string.Format("ShortMacro({0})", i));
+                string shortMacroCode = datFile.IniReadValue("Macros", string.Format("ShortMacroCode({0})", i));
+                string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 40));
 
-		#endregion Load Macros/ShortMacros
+                Macro shortMacroItem = new Macro
+                {
+                    MacroNumber = i + 40,
+                    //MacroCodes = shortMacro,
+                    AccessCode = shortMacroCode,
+                    ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), shortMacro),
+                    AllowedPorts = allowedPorts
+                };
+
+                char[] splitChar = { ' ' };
+                string[] macroCodes = shortMacro.Split(splitChar);
+
+                foreach (string code in macroCodes)
+                {
+                    shortMacroItem.MacroCodes = shortMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
+                }
+
+                shortMacroItem.MacroCodes = shortMacroItem.MacroCodes.Substring(1);
+
+                _shortMacros.Add(i, shortMacroItem);
+            }
+        }
+
+        private void Load_ExtendedMacros()
+        {
+            IniFile datFile = new IniFile(_datFilename);
+
+            _extendedMacros.Clear();
+
+            for (int i = 1; i <= 15; i++)
+            {
+                string extendedMacro = datFile.IniReadValue("Macros", string.Format("ExtendedMacro({0})", i));
+                string extendedMacroCode = datFile.IniReadValue("Macros", string.Format("ExtendedMacroCode({0})", i));
+                string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 90));
+
+                Macro extendedMacroItem = new Macro
+                {
+                    MacroNumber = i + 90,
+                    //MacroCodes = extendedMacro,
+                    AccessCode = extendedMacroCode,
+                    ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), extendedMacro),
+                    AllowedPorts = allowedPorts
+                };
+
+                char[] splitChar = { ' ' };
+                string[] macroCodes = extendedMacro.Split(splitChar);
+
+                foreach (string code in macroCodes)
+                {
+                    extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
+                }
+
+                extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes.Substring(1);
+
+                _extendedMacros.Add(i, extendedMacroItem);
+            }
+        }
+
+		#endregion Load Macros/ShortMacros/ExtendedMacros
 
 		#region Load Message Macros
 
@@ -1193,7 +1362,7 @@ namespace RC210_DataAssistant_V2
 
 		#endregion Private Methods
 
-		#region ToolStripMenu Even Handlers
+		#region ToolStripMenu Event Handlers
 
 		private void saveToolStripMenuItem_Click(object sender, EventArgs e)
 		{
@@ -1387,6 +1556,11 @@ namespace RC210_DataAssistant_V2
 
 		#endregion InputBox
 
-		
-	}
+		private void xMLFilePathToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";
+
+			MessageBox.Show("I look for .xml files at the following location:\n\n" + filepath);
+		}
+    }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -31,9 +31,9 @@ namespace RC210_DataAssistant_V2
 		{
 			public string PortName;
 			public string PortCode;
-			public string HangTimer1;
-			public string HangTimer2;
-			public string HangTimer3;
+			public string HangTimer1;                   //Added by v7.00
+            public string HangTimer2;                   //Added by v7.00
+            public string HangTimer3;                   //Added by v7.00
 			public string TimeoutTimer;
 			public string InitialIdTimer;
 			public string PendingIdTimer;
@@ -103,18 +103,18 @@ namespace RC210_DataAssistant_V2
 		private string _datFilename;
 		private string _reportFilename;
 
-		private readonly AutoPatch _autoPatch = new AutoPatch();
+        private readonly AutoPatch _autoPatch = new AutoPatch();
 		private readonly Dictionary<int, Port> _ports = new Dictionary<int, Port>();
 		private readonly Dictionary<int, Macro> _macros = new Dictionary<int, Macro>();
 		private readonly Dictionary<int, Macro> _shortMacros = new Dictionary<int, Macro>();
-        private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();
-        private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
-        
-        #endregion Private Members
+        private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();     //Added by v7.39
+		private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
 
-        #region Initialization
+		#endregion Private Members
 
-        public Form1()
+		#region Initialization
+
+		public Form1()
 		{
 			InitializeComponent();
 		}
@@ -240,21 +240,21 @@ namespace RC210_DataAssistant_V2
 
 		}
 
-		
 		private void FetchDefXml()
 		{
-			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";
-			DirectoryInfo d = new DirectoryInfo(filepath);
+            string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";      //Added to acommadate multiple XML version files
+            DirectoryInfo d = new DirectoryInfo(filepath);
 
-			foreach (var file in d.GetFiles("*.xml"))
-			{
-				LoadXMLFile(filepath + file.Name);
-			}
-		}
+            foreach (var file in d.GetFiles("*.xml"))
+            {
+                LoadXMLFile(filepath + file.Name);
+            }
+        }
 
-		private void LoadXMLFile(string file)
-		{
-			if (File.Exists(file))
+        private void LoadXMLFile(string file)
+        {
+
+            if (File.Exists(file))
 			{
 				_localXmlDocument.Load(file);
 
@@ -321,14 +321,14 @@ namespace RC210_DataAssistant_V2
             Load_ExtendedMacros();
 			Load_AutoPatch();
 		}
-
+                
         #endregion Load .dat file
 
         #region Generate Report
 
         private void Generate_Report()
-        {
-            double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);
+		{
+            double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);   //Added to acommodate option changes per version
             Load_Ports(fwVersion);
 
             if (!File.Exists(_datFilename))
@@ -338,120 +338,234 @@ namespace RC210_DataAssistant_V2
             }
 
             SaveFileDialog result = new SaveFileDialog
-            {
-                Filter = @"HTML File (*.html)|*.html",
-                InitialDirectory = Path.GetDirectoryName(_reportFilename)
-            };
+			{
+				Filter = @"HTML File (*.html)|*.html",
+				InitialDirectory = Path.GetDirectoryName(_reportFilename)
+			};
 
-            if (result.ShowDialog() != DialogResult.OK)
-                return;
+			if (result.ShowDialog() != DialogResult.OK)
+				return;
 
-            _reportFilename = result.FileName;
+			_reportFilename = result.FileName;
 
-            //Load the dat file
-            Load_datFile();
+			//Load the dat file
+			Load_datFile();
 
-            IniFile datFile = new IniFile(_datFilename);
+			IniFile datFile = new IniFile(_datFilename);
 
-            //Create the file. 
-            using (StreamWriter rW = new StreamWriter(_reportFilename))
-            {
-                //Date Header
-                if (checkBox_DateHeader.Checked)
-                    rW.WriteLine("<CENTER><H2>" + DateTime.Now + "</H2></CENTER>");
+			//Create the file. 
+			using (StreamWriter rW = new StreamWriter(_reportFilename))
+			{
+				//Date Header
+				if (checkBox_DateHeader.Checked)
+					rW.WriteLine("<CENTER><H2>" + DateTime.Now + "</H2></CENTER>");
 
-                //Custom Header
-                if (checkBox_CustomHeader.Checked)
-                    rW.WriteLine("<CENTER><H2>" + textBox_CustomHeader.Text + "</H2></CENTER><HR>");
+				//Custom Header
+				if (checkBox_CustomHeader.Checked)
+					rW.WriteLine("<CENTER><H2>" + textBox_CustomHeader.Text + "</H2></CENTER><HR>");
 
-                //PreAccess Prefix
-                if (checkBox_PreAccessPrefix.Checked)
-                    rW.WriteLine("<CENTER><B>PreAccess Prefix:</B> " + datFile.IniReadValue("PreAccess", "PreAccessPrefix") + "</CENTER>");
+				//PreAccess Prefix
+				if (checkBox_PreAccessPrefix.Checked)
+					rW.WriteLine("<CENTER><B>PreAccess Prefix:</B> " + datFile.IniReadValue("PreAccess", "PreAccessPrefix") + "</CENTER>");
 
-                //Global Lock Code
-                if (checkBox_GlobalLockCode.Checked)
-                    rW.WriteLine("<CENTER><B>Global Lock Code:</B> " + datFile.IniReadValue("Unlock", "Lock") + "</CENTER>");
+				//Global Lock Code
+				if (checkBox_GlobalLockCode.Checked)
+					rW.WriteLine("<CENTER><B>Global Lock Code:</B> " + datFile.IniReadValue("Unlock", "Lock") + "</CENTER>");
 
-                //Terminator Digit
-                if (checkBox_TerminatorDigit.Checked)
-                    rW.WriteLine("<CENTER><B>Terminator Digit:</B> " + datFile.IniReadValue("Unlock", "Terminator") + "</CENTER>");
+				//Terminator Digit
+				if (checkBox_TerminatorDigit.Checked)
+					rW.WriteLine("<CENTER><B>Terminator Digit:</B> " + datFile.IniReadValue("Unlock", "Terminator") + "</CENTER>");
 
-                //DTMF Test pad code
-                if (checkBox_DTMFTestPadCode.Checked)
-                    rW.WriteLine("<CENTER><B>DTMF Pad Test:</B> " + datFile.IniReadValue("PadTest", "DTMFTestPrefix") + "</CENTER>");
+				//DTMF Test pad code
+				if (checkBox_DTMFTestPadCode.Checked)
+					rW.WriteLine("<CENTER><B>DTMF Pad Test:</B> " + datFile.IniReadValue("PadTest", "DTMFTestPrefix") + "</CENTER>");
 
-                //Add the <HR> tag if needed
-                if (checkBox_PreAccessPrefix.Checked || checkBox_GlobalLockCode.Checked || checkBox_TerminatorDigit.Checked || checkBox_DTMFTestPadCode.Checked)
-                    rW.WriteLine("<CENTER><HR></CENTER>");
+				//Add the <HR> tag if needed
+				if (checkBox_PreAccessPrefix.Checked || checkBox_GlobalLockCode.Checked || checkBox_TerminatorDigit.Checked || checkBox_DTMFTestPadCode.Checked)
+					rW.WriteLine("<CENTER><HR></CENTER>");
 
-                //Port1
-                if (checkBox_P1UnlockCode.Checked || checkBox_P1IDs.Checked || checkBox_P1TailMessages.Checked ||
-                    checkBox_P1Timers.Checked)
-                {
-                    string port1Header = _ports[1].PortName != string.Empty ? "Port 1 - " + _ports[1].PortName : "Port 1";
-                    rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
-                    rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port1Header + "</H2></TD></TR>");
-                    rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
-                    rW.WriteLine("<TR>");
+				//Port1
+				if (checkBox_P1UnlockCode.Checked || checkBox_P1IDs.Checked || checkBox_P1TailMessages.Checked ||
+				    checkBox_P1Timers.Checked)
+				{
+					string port1Header = _ports[1].PortName != string.Empty ? "Port 1 - " + _ports[1].PortName : "Port 1";
+					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port1Header + "</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+					rW.WriteLine("<TR>");
 
-                    //Unlock Code
-                    string port1UnlockCode = checkBox_P1UnlockCode.Checked ? _ports[1].PortCode : "Not Displayed";
-                    rW.WriteLine("<TD valign=top>" + port1UnlockCode + "</TD>");
+					//Unlock Code
+					string port1UnlockCode = checkBox_P1UnlockCode.Checked ? _ports[1].PortCode : "Not Displayed";
+					rW.WriteLine("<TD valign=top>" + port1UnlockCode + "</TD>");
 
-                    //Voice IDs
-                    rW.WriteLine("<TD valign=top>");
+					//Voice IDs
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P1IDs.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[1].VoiceId1 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[1].VoiceId2 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[1].VoiceId3 + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					if (checkBox_P1IDs.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[1].VoiceId1 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[1].VoiceId2 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[1].VoiceId3 + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    //CW IDs
-                    rW.WriteLine("<TD valign=top>");
+					//CW IDs
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P1IDs.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[1].Cwid1 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[1].Cwid2 + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					if (checkBox_P1IDs.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[1].Cwid1 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[1].Cwid2 + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    //Tail Messages
-                    rW.WriteLine("<TD valign=top>");
+					//Tail Messages
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P1TailMessages.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[1].TailMessage == "0") ? "Disabled" : _ports[1].TailMessage) + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[1].TailMessageCounter + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[1].TailMessageTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[1].TailMessage1Macro + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[1].TailMessage2Macro + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[1].TailMessage3Macro + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					if (checkBox_P1TailMessages.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[1].TailMessage == "0") ? "Disabled" : _ports[1].TailMessage) + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[1].TailMessageCounter + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[1].TailMessageTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[1].TailMessage1Macro + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[1].TailMessage2Macro + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[1].TailMessage3Macro + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    //Timers
-                    rW.WriteLine("<TD valign=top>");
+					//Timers
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P1Timers.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
+					if (checkBox_P1Timers.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
 
-                        if (fwVersion < 7.00)           //Added 3 hangtimers per port with v7.00
+                        if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
                         {
-                            rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                        }
+                        else
+                        {
+                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
+                        }
+                        
+                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[1].InitialIdTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[1].PendingIdTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[1].PendingIdSpeechTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[1].InactivityTimer + " (" + _ports[1].InactivityTimerMacro + ")</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMuteTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[1].EncoderTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[1].KerchunkTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[1].AuxAudioTimer + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
+					
+					rW.WriteLine("</TD><TD>");
+
+					//Switches
+					if (checkBox_P1Switches.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[1].TransmitterEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[1].ReceiverEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[1].DisableInactivityTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[1].RepeaterMode + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[1].SpeechOverride + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[1].SpeechIdOverride + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[1].DtmfEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMute + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[1].DtmfRequireTone + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[1].DtmfCoverTone + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[1].MonitorMix + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[1].KerchunkFilter + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
+
+					rW.WriteLine("</TD>");
+
+					rW.WriteLine("</TR></TABLE><HR>");
+				}
+
+				//Port2
+				if (checkBox_P2UnlockCode.Checked || checkBox_P2IDs.Checked || checkBox_P2TailMessages.Checked ||
+					checkBox_P2Timers.Checked)
+				{
+					string port2Header = _ports[2].PortName != string.Empty ? "Port 2 - " + _ports[2].PortName : "Port 2";
+					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port2Header + "</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+					rW.WriteLine("<TR>");
+
+					//Unlock Code
+					string port2UnlockCode = checkBox_P2UnlockCode.Checked ? _ports[2].PortCode : "Not Displayed";
+					rW.WriteLine("<TD valign=top>" + port2UnlockCode + "</TD>");
+
+					//Voice IDs
+					rW.WriteLine("<TD valign=top>");
+
+					if (checkBox_P2IDs.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[2].VoiceId1 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[2].VoiceId2 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[2].VoiceId3 + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
+
+					rW.WriteLine("</TD>");
+
+					//CW IDs
+					rW.WriteLine("<TD valign=top>");
+
+					if (checkBox_P2IDs.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[2].Cwid1 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[2].Cwid2 + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
+
+					rW.WriteLine("</TD>");
+
+					//Tail Messages
+					rW.WriteLine("<TD valign=top>");
+
+					if (checkBox_P2TailMessages.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[2].TailMessage == "0") ? "Disabled" : _ports[2].TailMessage) + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[2].TailMessageCounter + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[2].TailMessageTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[2].TailMessage1Macro + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[2].TailMessage2Macro + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[2].TailMessage3Macro + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
+
+					rW.WriteLine("</TD>");
+
+					//Timers
+					rW.WriteLine("<TD valign=top>");
+
+					if (checkBox_P2Timers.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+
+                        if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
+                        {
+						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
                         }
                         else
                         {
@@ -460,335 +574,221 @@ namespace RC210_DataAssistant_V2
                             rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
                         }
 
-                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[1].InitialIdTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[1].PendingIdTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[1].PendingIdSpeechTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[1].InactivityTimer + " (" + _ports[1].InactivityTimerMacro + ")</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMuteTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[1].EncoderTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[1].KerchunkTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[1].AuxAudioTimer + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
-
-                    rW.WriteLine("</TD><TD>");
-
-                    //Switches
-                    if (checkBox_P1Switches.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[1].TransmitterEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[1].ReceiverEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[1].DisableInactivityTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[1].RepeaterMode + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[1].SpeechOverride + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[1].SpeechIdOverride + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[1].DtmfEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[1].DtmfMute + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[1].DtmfRequireTone + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[1].DtmfCoverTone + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[1].MonitorMix + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[1].KerchunkFilter + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
-
-                    rW.WriteLine("</TD>");
-
-                    rW.WriteLine("</TR></TABLE><HR>");
-                }
-
-                //Port2
-                if (checkBox_P2UnlockCode.Checked || checkBox_P2IDs.Checked || checkBox_P2TailMessages.Checked ||
-                    checkBox_P2Timers.Checked)
-                {
-                    string port2Header = _ports[2].PortName != string.Empty ? "Port 2 - " + _ports[2].PortName : "Port 2";
-                    rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
-                    rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port2Header + "</H2></TD></TR>");
-                    rW.WriteLine("<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
-                    rW.WriteLine("<TR>");
-
-                    //Unlock Code
-                    string port2UnlockCode = checkBox_P2UnlockCode.Checked ? _ports[2].PortCode : "Not Displayed";
-                    rW.WriteLine("<TD valign=top>" + port2UnlockCode + "</TD>");
-
-                    //Voice IDs
-                    rW.WriteLine("<TD valign=top>");
-
-                    if (checkBox_P2IDs.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[2].VoiceId1 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[2].VoiceId2 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[2].VoiceId3 + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
-
-                    rW.WriteLine("</TD>");
-
-                    //CW IDs
-                    rW.WriteLine("<TD valign=top>");
-
-                    if (checkBox_P2IDs.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[2].Cwid1 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[2].Cwid2 + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
-
-                    rW.WriteLine("</TD>");
-
-                    //Tail Messages
-                    rW.WriteLine("<TD valign=top>");
-
-                    if (checkBox_P2TailMessages.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" + ((_ports[2].TailMessage == "0") ? "Disabled" : _ports[2].TailMessage) + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[2].TailMessageCounter + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[2].TailMessageTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[2].TailMessage1Macro + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[2].TailMessage2Macro + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[2].TailMessage3Macro + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
-
-                    rW.WriteLine("</TD>");
-
-                    //Timers
-                    rW.WriteLine("<TD valign=top>");
-
-                    if (checkBox_P2Timers.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-
-                        if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
-                        {
-                            rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[2].HangTimer1 + "</TD></TR>");
-                        }
-                        else
-                        {
-                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[2].HangTimer1 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[2].HangTimer2 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[2].HangTimer3 + "</TD></TR>");
-                        }
-
                         rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[2].InitialIdTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[2].PendingIdTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[2].PendingIdSpeechTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[2].InactivityTimer + " (" + _ports[2].InactivityTimerMacro + ")</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMuteTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[2].EncoderTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[2].KerchunkTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[2].AuxAudioTimer + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[2].InitialIdTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[2].PendingIdTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[2].PendingIdSpeechTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[2].InactivityTimer + " (" + _ports[2].InactivityTimerMacro + ")</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMuteTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[2].EncoderTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[2].KerchunkTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[2].AuxAudioTimer + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD><TD>");
+					rW.WriteLine("</TD><TD>");
 
-                    //Switches
-                    if (checkBox_P1Switches.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[2].TransmitterEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[2].ReceiverEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[2].DisableInactivityTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[2].RepeaterMode + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[2].SpeechOverride + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[2].SpeechIdOverride + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[2].DtmfEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMute + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[2].DtmfRequireTone + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[2].DtmfCoverTone + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[2].MonitorMix + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[2].KerchunkFilter + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					//Switches
+					if (checkBox_P1Switches.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[2].TransmitterEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[2].ReceiverEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[2].DisableInactivityTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[2].RepeaterMode + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[2].SpeechOverride + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[2].SpeechIdOverride + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[2].DtmfEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[2].DtmfMute + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[2].DtmfRequireTone + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[2].DtmfCoverTone + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[2].MonitorMix + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[2].KerchunkFilter + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    rW.WriteLine("</TR></TABLE><HR>");
-                }
+					rW.WriteLine("</TR></TABLE><HR>");
+				}
 
-                //Port3
-                if (checkBox_P3UnlockCode.Checked || checkBox_P3IDs.Checked || checkBox_P3TailMessages.Checked ||
-                    checkBox_P3Timers.Checked)
-                {
-                    string port3Header = _ports[3].PortName != string.Empty ? "Port 3 - " + _ports[3].PortName : "Port 3";
-                    rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
-                    rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port3Header + "</H2></TD></TR>");
-                    rW.WriteLine(
-                        "<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
-                    rW.WriteLine("<TR>");
+				//Port3
+				if (checkBox_P3UnlockCode.Checked || checkBox_P3IDs.Checked || checkBox_P3TailMessages.Checked ||
+				    checkBox_P3Timers.Checked)
+				{
+					string port3Header = _ports[3].PortName != string.Empty ? "Port 3 - " + _ports[3].PortName : "Port 3";
+					rW.WriteLine("<CENTER><TABLE border=1 cellpadding=5>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>" + port3Header + "</H2></TD></TR>");
+					rW.WriteLine(
+						"<TR><TD><B>Unlock Code</B></TD><TD><B>Voice IDs</B></TD><TD><B>CW IDs</B></TD><TD><B>Tail Messages</B></TD><TD><B>Timers</B></TD><TD><B>Switches</B></TD></TR>");
+					rW.WriteLine("<TR>");
 
-                    //Unlock Code
-                    string port3UnlockCode = checkBox_P3UnlockCode.Checked ? _ports[3].PortCode : "Not Displayed";
-                    rW.WriteLine("<TD valign=top>" + port3UnlockCode + "</TD>");
+					//Unlock Code
+					string port3UnlockCode = checkBox_P3UnlockCode.Checked ? _ports[3].PortCode : "Not Displayed";
+					rW.WriteLine("<TD valign=top>" + port3UnlockCode + "</TD>");
 
-                    //Voice IDs
-                    rW.WriteLine("<TD valign=top>");
+					//Voice IDs
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P3IDs.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[3].VoiceId1 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[3].VoiceId2 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[3].VoiceId3 + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					if (checkBox_P3IDs.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Voice ID 1:</B></TD><TD>" + _ports[3].VoiceId1 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Voice ID 2:</B></TD><TD>" + _ports[3].VoiceId2 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Voice ID 3:</B></TD><TD>" + _ports[3].VoiceId3 + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    //CW IDs
-                    rW.WriteLine("<TD valign=top>");
+					//CW IDs
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P3IDs.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[3].Cwid1 + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[3].Cwid2 + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					if (checkBox_P3IDs.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>CW ID 1:</B></TD><TD>" + _ports[3].Cwid1 + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>CW ID 2:</B></TD><TD>" + _ports[3].Cwid2 + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    //Tail Messages
-                    rW.WriteLine("<TD valign=top>");
+					//Tail Messages
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P3TailMessages.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" +
-                                     ((_ports[3].TailMessage == "0") ? "Disabled" : _ports[3].TailMessage) + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[3].TailMessageCounter + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[3].TailMessageTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[3].TailMessage1Macro + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[3].TailMessage2Macro + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[3].TailMessage3Macro + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					if (checkBox_P3TailMessages.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Message:</B></TD><TD>" +
+						             ((_ports[3].TailMessage == "0") ? "Disabled" : _ports[3].TailMessage) + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Counter:</B></TD><TD>" + _ports[3].TailMessageCounter + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Timer:</B></TD><TD>" + _ports[3].TailMessageTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 1:</B></TD><TD>" + _ports[3].TailMessage1Macro + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 2:</B></TD><TD>" + _ports[3].TailMessage2Macro + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message 3:</B></TD><TD>" + _ports[3].TailMessage3Macro + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    //Timers
-                    rW.WriteLine("<TD valign=top>");
+					//Timers
+					rW.WriteLine("<TD valign=top>");
 
-                    if (checkBox_P3Timers.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
+					if (checkBox_P3Timers.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
 
-                        if (fwVersion < 7.00)       //Added 3 hangtimers per port with v7.00
+                        if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
                         {
-                            rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[3].HangTimer1 + "</TD></TR>");
+						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
                         }
                         else
                         {
-                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[3].HangTimer1 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[3].HangTimer2 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[3].HangTimer3 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
                         }
 
                         rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[3].InactivityTimer + " (" +
-                                     _ports[3].InactivityTimerMacro + ")</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMuteTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[3].EncoderTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[3].KerchunkTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[3].AuxAudioTimer + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Inactivity (Macro):</B></TD><TD>" + _ports[3].InactivityTimer + " (" +
+						             _ports[3].InactivityTimerMacro + ")</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMuteTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Encoder:</B></TD><TD>" + _ports[3].EncoderTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Kerchunck:</B></TD><TD>" + _ports[3].KerchunkTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>AUX Audio:</B></TD><TD>" + _ports[3].AuxAudioTimer + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD><TD>");
+					rW.WriteLine("</TD><TD>");
 
-                    //Switches
-                    if (checkBox_P1Switches.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=0>");
-                        rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[3].TransmitterEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[3].ReceiverEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[3].DisableInactivityTimer + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[3].RepeaterMode + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[3].SpeechOverride + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[3].SpeechIdOverride + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[3].DtmfEnable + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMute + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[3].DtmfRequireTone + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[3].DtmfCoverTone + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[3].MonitorMix + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[3].KerchunkFilter + "</TD></TR>");
-                        rW.WriteLine("</TABLE>");
-                    }
+					//Switches
+					if (checkBox_P1Switches.Checked)
+					{
+						rW.WriteLine("<TABLE border=0>");
+						rW.WriteLine("<TR><TD><B>Transmitter:</B></TD><TD>" + _ports[3].TransmitterEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Receiver:</B></TD><TD>" + _ports[3].ReceiverEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Disable Inactivity Timer:</B></TD><TD>" + _ports[3].DisableInactivityTimer + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Repeater Mode:</B></TD><TD>" + _ports[3].RepeaterMode + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Speech Override:</B></TD><TD>" + _ports[3].SpeechOverride + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Speech ID Override:</B></TD><TD>" + _ports[3].SpeechIdOverride + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Enable:</B></TD><TD>" + _ports[3].DtmfEnable + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Mute:</B></TD><TD>" + _ports[3].DtmfMute + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Require Tone:</B></TD><TD>" + _ports[3].DtmfRequireTone + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>DTMF Covertone:</B></TD><TD>" + _ports[3].DtmfCoverTone + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Monitor Mix:</B></TD><TD>" + _ports[3].MonitorMix + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Kerchunk Filter:</B></TD><TD>" + _ports[3].KerchunkFilter + "</TD></TR>");
+						rW.WriteLine("</TABLE>");
+					}
 
-                    rW.WriteLine("</TD>");
+					rW.WriteLine("</TD>");
 
-                    rW.WriteLine("</TR></TABLE><HR>");
-                }
+					rW.WriteLine("</TR></TABLE><HR>");
+				}
 
-                //Macros
-                if (checkBox_Macros.Checked || checkBox_MacroCodes.Checked)
-                {
-                    rW.WriteLine("<TABLE align=center border=1 width=75%>");
-                    rW.WriteLine("<TR><TD align=center colspan=4><H2>Macros</H2></TD></TR>");
-                    rW.WriteLine("<TR><TD><B>Macro #</B></TD><TD><B>Code</B></TD><TD><B>Ports allowed</B></TD><TD><B>Actions</B></TD></TR>");
+				//Macros
+				if (checkBox_Macros.Checked || checkBox_MacroCodes.Checked)
+				{
+					rW.WriteLine("<TABLE align=center border=1 width=75%>");
+					rW.WriteLine("<TR><TD align=center colspan=4><H2>Macros</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Macro #</B></TD><TD><B>Code</B></TD><TD><B>Ports allowed</B></TD><TD><B>Actions</B></TD></TR>");
 
-                    foreach (KeyValuePair<int, Macro> macro in _macros)
-                    {
-                        rW.WriteLine("<TR><TD valign=top>" + macro.Value.MacroNumber + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro)+ "</TD></TR>");
-                        rW.WriteLine("<TD>");
-                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-                        rW.WriteLine("</TD></TR>");
-                    }
+					foreach (KeyValuePair<int, Macro> macro in _macros)
+					{
+						rW.WriteLine("<TR><TD valign=top>" + macro.Value.MacroNumber + "</TD>");
+						rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+						rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+						//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro)+ "</TD></TR>");
+						rW.WriteLine("<TD>");
+						rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+						rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+						rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+						rW.WriteLine("</TD></TR>");
+					}
 
 
-                    //ShortMacros
+					//ShortMacros
 
-                    foreach (KeyValuePair<int, Macro> macro in _shortMacros)
-                    {
-                        rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 40).ToString(CultureInfo.InvariantCulture) + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
-                        rW.WriteLine("<TD>");
-                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-                        rW.WriteLine("</TD></TR>");
-                    }
+					foreach (KeyValuePair<int, Macro> macro in _shortMacros)
+					{
+						rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 40).ToString(CultureInfo.InvariantCulture) + "</TD>");
+						rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+						rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+						//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
+						rW.WriteLine("<TD>");
+						rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+						rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+						rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+						rW.WriteLine("</TD></TR>");
+					}
 
-                    //ExtendedMacros
+                    //ExtendedMacros            Added 15 Macro positions 91 - 105 with 20 slots in each position with v7.39
 
-                    foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
-                    {
-                        rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
-                        rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
-                        //rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
-                        rW.WriteLine("<TD>");
-                        rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
-                        rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
-                        rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
-                        rW.WriteLine("</TD></TR>");
-                    }
+					foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
+					{
+						rW.WriteLine("<TR><TD valign=top>" + (macro.Key + 90).ToString(CultureInfo.InvariantCulture) + "</TD>");
+						rW.WriteLine("<TD valign=top>" + macro.Value.AccessCode + "</TD>");
+						rW.WriteLine("<TD valign=top>" + macro.Value.AllowedPorts + "</TD>");
+						//rW.WriteLine("<TD>" + ((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : macro.Value.ParsedMacro) + "</TD></TR>");
+						rW.WriteLine("<TD>");
+						rW.WriteLine(((checkBox_Macros.Checked) ? macro.Value.ParsedMacro : ""));
+						rW.WriteLine((checkBox_Macros.Checked && checkBox_MacroCodes.Checked) ? "<HR>" : "");
+						rW.WriteLine(((checkBox_MacroCodes.Checked) ? macro.Value.MacroCodes : ""));
+						rW.WriteLine("</TD></TR>");
+					}
 
-                    rW.WriteLine("</TABLE><HR>");
-                }
+					rW.WriteLine("</TABLE><HR>");
+				}
 
                 //Setpoints
                 if (checkBox_SetpointsScheduler.Checked)
                 {
                     rW.WriteLine("<TABLE border=1 align=center width=75%>");
 
-                    if (fwVersion < 7.32)       //Reinstated Month of Year with v7.32
+                    if (fwVersion < 7.32)       //Reinstated Month of Run with v7.32. Added 8th column
                     {
                         rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
                         rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
@@ -799,14 +799,14 @@ namespace RC210_DataAssistant_V2
                         rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
                     }
 
-                    if (fwVersion < 7.36)
+                    if (fwVersion < 7.361)      //added 20 more Setpoints with v7.361
                     {
                         for (int i = 1; i <= 20; i++)
                         {
                             rW.WriteLine("<TR><TD>" + i + "</TD>");
                             rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
 
-                            if (fwVersion > 7.00)
+                            if (fwVersion > 7.00)   //Month To Run actually added at v7.01
                             {
                                 rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
                             }
@@ -818,17 +818,19 @@ namespace RC210_DataAssistant_V2
                             rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
 
                             //if they want to
-                            var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            rW.WriteLine("<TR><TD colspan=7>");
+                            //var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            //rW.WriteLine("<TR><TD colspan=7>");
 
-                            rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+                            //rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
 
-                            rW.WriteLine("</TD></TR>");
+                            //rW.WriteLine("</TD></TR>");
                         }
+
+                        rW.WriteLine("</TABLE><HR>");
                     }
                     else
                     {
-                        for (int i = 1; i <= 40; i++)
+                        for (int i = 1; i <= 40; i++)       //added 20 additional Setpoints with v.7.361
 
                         {
                             rW.WriteLine("<TR><TD>" + i + "</TD>");
@@ -846,278 +848,279 @@ namespace RC210_DataAssistant_V2
                             rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
 
                             //if they want to
-                            var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            rW.WriteLine("<TR><TD colspan=7>");
+                            //var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            //rW.WriteLine("<TR><TD colspan=7>");
 
-                            rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+                            //rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
 
-                            rW.WriteLine("</TD></TR>");
+                            //rW.WriteLine("</TD></TR>");
                         }
 
                         rW.WriteLine("</TABLE><HR>");
                     }
-                    //CT MSG Macros
-                    if (checkBox_CTMessageMacros.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
+                }
+                //CT MSG Macros
+                if (checkBox_CTMessageMacros.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
 
-                        for (int i = 1; i <= 3; i++)
-                        {
-                            for (int j = 1; j <= 10; j++)
-                            {
-                                var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
+					for (int i = 1; i <= 3; i++)
+					{
+						for (int j = 1; j <= 10; j++)
+						{
+							var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
+								
+							if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
+								continue;
 
-                                if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
-                                    continue;
-
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + j + "</TD>");
-                                rW.WriteLine("<TD>" + tone1 + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
-                            }
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + j + "</TD>");
+							rW.WriteLine("<TD>" + tone1 + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
+						}
 
                             if (fwVersion >= 7.02) //From version 7.02 there is a single pool of Courtesy Tones @ P1Tone1 - P1Tone10
                                 break;
-                        }
-
-                        rW.WriteLine("</TABLE><HR>");
                     }
 
-                    //Messages
-                    if (checkBox_MessageMacros.Checked)
-                    {
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
+				//Messages
+				if (checkBox_MessageMacros.Checked)
+				{
 
-                        int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
-                        for (int i = 1; i <= lastMessage; i++)
-                        {
-                            var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
-                            if (messageMacro != "" && messageMacro != "NONE STORED")
-                            {
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + messageMacro + "</TD></TR>");
-                            }
-                        }
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
 
-                        rW.WriteLine("</TABLE><HR>");
-                    }
+					int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
+					for (int i = 1; i <= lastMessage; i++)
+					{
+						var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
+						if (messageMacro != "" && messageMacro != "NONE STORED")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + messageMacro +"</TD></TR>");
+						}
+					}
+					
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                    //General Timers
-                    if (checkBox_GeneralTimers.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
+				//General Timers
+				if (checkBox_GeneralTimers.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
 
-                        for (int i = 1; i <= 6; i++)
-                        {
-                            var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
-                            if (generalTimer != "0")
-                            {
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + generalTimer + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
-                            }
-                        }
+					for (int i = 1; i <= 6; i++)        //Added 3 additional General Times at v6.044
+					{
+						var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
+						if (generalTimer != "0")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + generalTimer + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
+						}	
+					}
 
-                        rW.WriteLine("</TABLE>");
-                        rW.WriteLine("<HR>");
-                    }
+					rW.WriteLine("</TABLE>");
+					rW.WriteLine("<HR>");
+				}
 
-                    //Analog Meters
-                    if (checkBox_AnalogMeters.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
+				//Analog Meters
+				if (checkBox_AnalogMeters.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
 
-                        for (int i = 1; i <= 8; i++)
-                        {
-                            var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
+					for (int i = 1; i <= 8; i++)
+					{
+						var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
 
-                            if (meter != "0")
-                            {
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
-                            }
+						if (meter != "0")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
+						}
 
-                        }
-                        rW.WriteLine("</TABLE>");
+					}
+					rW.WriteLine("</TABLE>");
 
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
 
-                        for (int i = 1; i <= 8; i++)
-                        {
-                            var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
-                            if (meterAlarm != "0")
-                            {
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
-                            }
-                        }
-                        rW.WriteLine("</TABLE><HR>");
-                    }
+					for (int i = 1; i <= 8; i++)
+					{
+						var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
+						if (meterAlarm != "0")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" +ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
+						}
+					}
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                    //Alarms
-                    if (checkBox_Alarms.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
+				//Alarms
+				if (checkBox_Alarms.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
 
-                        for (int i = 1; i <= 5; i++)
-                        {
-                            rW.WriteLine("<TR><TD>" + i + "</TD>");
-                            rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
-                        }
+					for (int i = 1; i <= 5; i++)
+					{
+						rW.WriteLine("<TR><TD>" + i + "</TD>");
+						rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) +"</TD>");
+						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
+						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
+					}
 
-                        rW.WriteLine("</TABLE><HR>");
-                    }
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                    //DTMF Memories
-                    if (checkBox_DTMFMemories.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
+				//DTMF Memories
+				if (checkBox_DTMFMemories.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
 
-                        int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
-                        for (int i = 1; i <= dtmfMemoryCount; i++)
-                        {
-                            var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
-                            if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
-                            {
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
-                            }
-                        }
+					int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
+					for (int i = 1; i <= dtmfMemoryCount; i++)
+					{
+						var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
+						if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
+						}
+					}
 
-                        rW.WriteLine("</TABLE><HR>");
-                    }
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                    //Remote Base Memories
-                    if (checkBox_RemoteBaseMemories.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 align=center>");
-                        rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
-                        int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
-                        for (int i = 1; i <= remoteBaseMemories; i++)
-                        {
-                            var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
-                            if (freqString != "" && freqString != "0" && freqString != "NONE")
-                            {
-                                rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
-                                rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
-                                rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
-                                rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
-                            }
-                        }
-                        rW.WriteLine("</TABLE><HR>");
-                    }
+				//Remote Base Memories
+				if (checkBox_RemoteBaseMemories.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 align=center>");
+					rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
+					int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
+					for (int i = 1; i <= remoteBaseMemories; i++)
+					{
+						var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
+						if (freqString != "" && freqString != "0" && freqString != "NONE")
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
+							rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
+							rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
+						}
+					}
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                    //AutoPatch Settings
-                    if (checkBox_APSettings.Checked)
-                    {
-                        rW.WriteLine("<TABLE border=1 aling=center");
-                        rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
-                                        "</TD>");
-                        rW.WriteLine("<TD><B>Answer Code:</B> " +
-                                        ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
-                        rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
-                        rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
+				//AutoPatch Settings
+				if (checkBox_APSettings.Checked)
+				{
+					rW.WriteLine("<TABLE border=1 aling=center");
+					rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
+					rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
+						            "</TD>");
+					rW.WriteLine("<TD><B>Answer Code:</B> " +
+						            ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
+					rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
+					rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
+					rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
+					rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
+						
+					rW.WriteLine("<TR><TD valign=top>");
 
-                        rW.WriteLine("<TR><TD valign=top>");
+					//AutoPatch Memories
+					if (checkBox_APMemories.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
 
-                        //AutoPatch Memories
-                        if (checkBox_APMemories.Checked)
-                        {
-                            rW.WriteLine("<TABLE border=1 align=center>");
-                            rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
+						for (int i = 1; i <= 200; i++)
+						{
+							var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
+							if (autoDial.Length > 0)
+							{
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
+							}
+						}
 
-                            for (int i = 1; i <= 200; i++)
-                            {
-                                var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
-                                if (autoDial.Length > 0)
-                                {
-                                    rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                    rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
-                                }
-                            }
+						rW.WriteLine("</TABLE>");
+					}
 
-                            rW.WriteLine("</TABLE>");
-                        }
+					rW.WriteLine("</TD><TD valign=top>");
 
-                        rW.WriteLine("</TD><TD valign=top>");
+					//AutoPatch Toll Restrictions
+					if (checkBox_APTollRestrictions.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
 
-                        //AutoPatch Toll Restrictions
-                        if (checkBox_APTollRestrictions.Checked)
-                        {
-                            rW.WriteLine("<TABLE border=1 align=center>");
-                            rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
+						for (int i = 1; i <= 100; i++)
+						{
+							var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
+							if (apTollRestriction.Length > 0)
+							{
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
+							}
+						}
 
-                            for (int i = 1; i <= 100; i++)
-                            {
-                                var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
-                                if (apTollRestriction.Length > 0)
-                                {
-                                    rW.WriteLine("<TR><TD>" + i + "</TD>");
-                                    rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
-                                }
-                            }
+						rW.WriteLine("</TABLE>");
+					}
 
-                            rW.WriteLine("</TABLE>");
-                        }
+					rW.WriteLine("</TD></TR>");
+					rW.WriteLine("</TABLE><HR>");
+				}
 
-                        rW.WriteLine("</TD></TR>");
-                        rW.WriteLine("</TABLE><HR>");
-                    }
+				rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
+				rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
+                rW.WriteLine("Modifed by Robert P. Norris - AK5U: ak5u@arrl.net");
+                rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
 
-                    rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
-                    rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
-                    rW.WriteLine("Modifed by Robert P. Norris - AK5U: ak5u@arrl.net");
-                    rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
+				var dr = MessageBox.Show(
+					string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
+					@"Report created",
+					MessageBoxButtons.YesNo,
+					MessageBoxIcon.Information
+					);
+				
+				if (dr == DialogResult.Yes) Process.Start(_reportFilename);
+			}
+		}
 
-                    var dr = MessageBox.Show(
-                        string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
-                        @"Report created",
-                        MessageBoxButtons.YesNo,
-                        MessageBoxIcon.Information
-                        );
+        
+        #endregion Generate Report
 
-                    if (dr == DialogResult.Yes) Process.Start(_reportFilename);
-                }
-            }
-        }
-		
-		#endregion Generate Report
+        #region Load AutoPatch
 
-		#region Load AutoPatch
-
-		private void Load_AutoPatch()
+        private void Load_AutoPatch()
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1196,8 +1199,7 @@ namespace RC210_DataAssistant_V2
 					RepeaterMode = (datFile.IniReadValue("PortSwitches", string.Format("FDup({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechIdOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechIDOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
-					
-                    //AccessMode = datFile.IniReadValue("PortSwitches", string.Format("P{0}MessageNum(3)", i)),
+					//AccessMode = datFile.IniReadValue("PortSwitches", string.Format("P{0}MessageNum(3)", i)),
 					DtmfEnable = (datFile.IniReadValue("PortSwitches", string.Format("DTMFEnable({0})", i)) == "0") ? "Disabled" : "Enabled",
 					DtmfRequireTone = (datFile.IniReadValue("PortSwitches", string.Format("DTMFNeedPL({0})", i)) == "0") ? "Disabled" : "Enabled",
 					DtmfMute = (datFile.IniReadValue("PortSwitches", string.Format("DTMFMute({0})", i)) == "0") ? "Disabled" : "Enabled",
@@ -1206,20 +1208,19 @@ namespace RC210_DataAssistant_V2
 					KerchunkFilter = (datFile.IniReadValue("PortSwitches", string.Format("Kerchunk({0})", i)) == "0") ? "Disabled" : "Enabled",
 
 				};
+                
+                if (fwVersion < 7.00)                                                                           //Added this code to handle HangTimer
+                {                                                                                               //change in v7.00
+                    portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
+                }
+                else
+                {
+                    portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
+                    portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
+                    portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
+                }
 
-				if (fwVersion < 7.02)
-				{
-					portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime({0})", i));
-				}
-				else
-				{
-					portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
-					portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
-					portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
-				}
-
-
-				if (portName != string.Empty)
+                if (portName != string.Empty)
 					portItem.PortName = portName;
 
 				_ports.Add(i, portItem);
@@ -1265,47 +1266,42 @@ namespace RC210_DataAssistant_V2
 			}
 		}
 
+		private void Load_ShortMacros()
+		{
+			IniFile datFile = new IniFile(_datFilename);
 
+			_shortMacros.Clear();
 
+			for (int i = 1; i <= 50; i++)
+			{
+				string shortMacro = datFile.IniReadValue("Macros", string.Format("ShortMacro({0})", i));
+				string shortMacroCode = datFile.IniReadValue("Macros", string.Format("ShortMacroCode({0})", i));
+				string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 40));
 
+				Macro shortMacroItem = new Macro
+				{
+					MacroNumber = i + 40,
+					//MacroCodes = shortMacro,
+					AccessCode = shortMacroCode,
+					ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), shortMacro),
+					AllowedPorts = allowedPorts
+				};
 
+				char[] splitChar = { ' ' };
+				string[] macroCodes = shortMacro.Split(splitChar);
 
-        private void Load_ShortMacros()
-        {
-            IniFile datFile = new IniFile(_datFilename);
+				foreach (string code in macroCodes)
+				{
+					shortMacroItem.MacroCodes = shortMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
+				}
 
-            _shortMacros.Clear();
+				shortMacroItem.MacroCodes = shortMacroItem.MacroCodes.Substring(1);
 
-            for (int i = 1; i <= 50; i++)
-            {
-                string shortMacro = datFile.IniReadValue("Macros", string.Format("ShortMacro({0})", i));
-                string shortMacroCode = datFile.IniReadValue("Macros", string.Format("ShortMacroCode({0})", i));
-                string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 40));
+				_shortMacros.Add(i, shortMacroItem);
+			}
+		}
 
-                Macro shortMacroItem = new Macro
-                {
-                    MacroNumber = i + 40,
-                    //MacroCodes = shortMacro,
-                    AccessCode = shortMacroCode,
-                    ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), shortMacro),
-                    AllowedPorts = allowedPorts
-                };
-
-                char[] splitChar = { ' ' };
-                string[] macroCodes = shortMacro.Split(splitChar);
-
-                foreach (string code in macroCodes)
-                {
-                    shortMacroItem.MacroCodes = shortMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
-                }
-
-                shortMacroItem.MacroCodes = shortMacroItem.MacroCodes.Substring(1);
-
-                _shortMacros.Add(i, shortMacroItem);
-            }
-        }
-
-        private void Load_ExtendedMacros()
+        private void Load_ExtendedMacros()          //Supports change with v7.39
         {
             IniFile datFile = new IniFile(_datFilename);
 
@@ -1340,11 +1336,11 @@ namespace RC210_DataAssistant_V2
             }
         }
 
-		#endregion Load Macros/ShortMacros/ExtendedMacros
+        #endregion Load Macros/ShortMacros/ExtendedMacros
 
-		#region Load Message Macros
+        #region Load Message Macros
 
-		private void Load_MessageMacros()
+        private void Load_MessageMacros()
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1362,9 +1358,9 @@ namespace RC210_DataAssistant_V2
 
 		#endregion Private Methods
 
-		#region ToolStripMenu Event Handlers
+		#region ToolStripMenu Even Handlers
 
-		private void saveToolStripMenuItem_Click(object sender, EventArgs e)
+		private void SaveToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			var result = MessageBox.Show(@"This will overwrite any existing options, are you sure ?",
 				@"Warning - Overwrite Options", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
@@ -1375,7 +1371,7 @@ namespace RC210_DataAssistant_V2
 			Settings.Default.Save();
 		}
 		
-		private void resetToolStripMenuItem_Click(object sender, EventArgs e)
+		private void ResetToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			var result = MessageBox.Show(@"This is a global reset of options that cannot be undone, are you sure ?",
 				@"Warning - Options Reset", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
@@ -1386,7 +1382,7 @@ namespace RC210_DataAssistant_V2
 			Settings.Default.Reset();
 		}
 
-		private void recallToolStripMenuItem_Click(object sender, EventArgs e)
+		private void RecallToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			var result = MessageBox.Show(@"This will repopulate the options to match the saved options, are you sure ?",
 				@"Warning - Overwrite Options", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
@@ -1397,7 +1393,7 @@ namespace RC210_DataAssistant_V2
 			Settings.Default.Reload();
 		}
 
-		private void openToolStripMenuItem_Click(object sender, EventArgs e)
+		private void OpenToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			viewReportToolStripMenuItem.Enabled = openReportFolderToolStripMenuItem.Enabled = false;
 			OpenFileDialog resultOpenFileDialog = new OpenFileDialog
@@ -1416,7 +1412,7 @@ namespace RC210_DataAssistant_V2
 			generateReportToolStripMenuItem1.Enabled = true;
 		}
 
-		private void closeToolStripMenuItem_Click(object sender, EventArgs e)
+		private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			generateReportToolStripMenuItem1.Enabled = false;
 			viewReportToolStripMenuItem.Enabled = openReportFolderToolStripMenuItem.Enabled = false;
@@ -1425,7 +1421,7 @@ namespace RC210_DataAssistant_V2
 			Text = @"RC210 Data Assistant V2";
 		}
 
-		private void port1ToolStripMenuItem_Click(object sender, EventArgs e)
+		private void Port1ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string value = Settings.Default.Port1Name;
 			var result = InputBox(@"Port 1 name", "Port 1 name:", ref value);
@@ -1437,7 +1433,7 @@ namespace RC210_DataAssistant_V2
 			groupBox_Port1.Text = @"Port 1 - " + value;
 		}
 
-		private void port2ToolStripMenuItem_Click(object sender, EventArgs e)
+		private void Port2ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string value = Settings.Default.Port2Name;
 			var result = InputBox(@"Port 2 name", "Port 2 name:", ref value);
@@ -1449,7 +1445,7 @@ namespace RC210_DataAssistant_V2
 			groupBox_Port2.Text = @"Port 2 - " + value;
 		}
 
-		private void port3ToolStripMenuItem_Click(object sender, EventArgs e)
+		private void Port3ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string value = Settings.Default.Port3Name;
 			var result = InputBox(@"Port 3 name", "Port 3 name:", ref value);
@@ -1461,19 +1457,19 @@ namespace RC210_DataAssistant_V2
 			groupBox_Port3.Text = @"Port 3 - " + value;
 		}
 
-		private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
+		private void AboutToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			FormAbout aboutDialog = new FormAbout();
 			aboutDialog.ShowDialog();
 		}
 
-		private void generateReportToolStripMenuItem_Click(object sender, EventArgs e)
+		private void GenerateReportToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			Generate_Report();
 			viewReportToolStripMenuItem.Enabled = openReportFolderToolStripMenuItem.Enabled = true;
 		}
 
-		private void viewReportToolStripMenuItem_Click(object sender, EventArgs e)
+		private void ViewReportToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			if (!File.Exists(_reportFilename))
 			{
@@ -1486,7 +1482,7 @@ namespace RC210_DataAssistant_V2
 			Process.Start(_reportFilename);
 		}
 
-		private void openReportFolderToolStripMenuItem_Click(object sender, EventArgs e)
+		private void OpenReportFolderToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			if (_reportFilename != null)
 				return;
@@ -1495,14 +1491,14 @@ namespace RC210_DataAssistant_V2
 				Process.Start(Path.GetDirectoryName(_reportFilename));
 		}
 
-		private void versionToolStripMenuItem_Click(object sender, EventArgs e)
+		private void VersionToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			MessageBox.Show(
 				string.Format("Macro Definitions\n\nLocal file: {0}\nRemote file: {1}", _localXmlVersion, _remoteXmlVersion),
 				@"Macro Definitions", MessageBoxButtons.OK, MessageBoxIcon.Information);
 		}
 
-		private void updateToolStripMenuItem_Click(object sender, EventArgs e)
+		private void UpdateToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			//FetchDefXml(true);
 			UpdateXml();
@@ -1556,11 +1552,6 @@ namespace RC210_DataAssistant_V2
 
 		#endregion InputBox
 
-		private void xMLFilePathToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";
-
-			MessageBox.Show("I look for .xml files at the following location:\n\n" + filepath);
-		}
-    }
+		
+	}
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -32,8 +32,8 @@ namespace RC210_DataAssistant_V2
 			public string PortName;
 			public string PortCode;
 			public string HangTimer1;                   //Added by v7.00
-            public string HangTimer2;                   //Added by v7.00
-            public string HangTimer3;                   //Added by v7.00
+            		public string HangTimer2;                   //Added by v7.00
+            		public string HangTimer3;                   //Added by v7.00
 			public string TimeoutTimer;
 			public string InitialIdTimer;
 			public string PendingIdTimer;
@@ -103,11 +103,11 @@ namespace RC210_DataAssistant_V2
 		private string _datFilename;
 		private string _reportFilename;
 
-        private readonly AutoPatch _autoPatch = new AutoPatch();
+        	private readonly AutoPatch _autoPatch = new AutoPatch();
 		private readonly Dictionary<int, Port> _ports = new Dictionary<int, Port>();
 		private readonly Dictionary<int, Macro> _macros = new Dictionary<int, Macro>();
 		private readonly Dictionary<int, Macro> _shortMacros = new Dictionary<int, Macro>();
-        private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();     //Added by v7.39
+        	private readonly Dictionary<int, Macro> _extendedMacros = new Dictionary<int, Macro>();     //Added by v7.39
 		private readonly Dictionary<int, string> _messageMacros = new Dictionary<int, string>();
 
 		#endregion Private Members
@@ -242,19 +242,18 @@ namespace RC210_DataAssistant_V2
 
 		private void FetchDefXml()
 		{
-            string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";      //Added to acommadate multiple XML version files
-            DirectoryInfo d = new DirectoryInfo(filepath);
+            		string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";      //Added to acommadate multiple XML version files
+            		DirectoryInfo d = new DirectoryInfo(filepath);
 
-            foreach (var file in d.GetFiles("*.xml"))
-            {
-                LoadXMLFile(filepath + file.Name);
-            }
-        }
+            		foreach (var file in d.GetFiles("*.xml"))
+            		{
+                		LoadXMLFile(filepath + file.Name);
+            		}
+        	}
 
-        private void LoadXMLFile(string file)
-        {
-
-            if (File.Exists(file))
+        	private void LoadXMLFile(string file)
+        	{
+            		if (File.Exists(file))
 			{
 				_localXmlDocument.Load(file);
 
@@ -318,26 +317,26 @@ namespace RC210_DataAssistant_V2
 			Load_MessageMacros();
 			Load_Macros();
 			Load_ShortMacros();
-            Load_ExtendedMacros();
+            		Load_ExtendedMacros();
 			Load_AutoPatch();
 		}
                 
-        #endregion Load .dat file
+        	#endregion Load .dat file
 
-        #region Generate Report
+        	#region Generate Report
 
-        private void Generate_Report()
+        	private void Generate_Report()
 		{
-            double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);   //Added to acommodate option changes per version
-            Load_Ports(fwVersion);
+            		double fwVersion = Convert.ToDouble(comboBox_FwVersion.SelectedItem);   //Added to acommodate option changes per version
+            		Load_Ports(fwVersion);
 
-            if (!File.Exists(_datFilename))
-            {
-                MessageBox.Show(@"Unable to locate .dat file: " + _datFilename);
-                return;
-            }
+            		if (!File.Exists(_datFilename))
+            		{
+               			MessageBox.Show(@"Unable to locate .dat file: " + _datFilename);
+                		return;
+            		}
 
-            SaveFileDialog result = new SaveFileDialog
+           		SaveFileDialog result = new SaveFileDialog
 			{
 				Filter = @"HTML File (*.html)|*.html",
 				InitialDirectory = Path.GetDirectoryName(_reportFilename)
@@ -449,18 +448,18 @@ namespace RC210_DataAssistant_V2
 					{
 						rW.WriteLine("<TABLE border=0>");
 
-                        if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
-                        {
+                        			if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
+                        			{
 						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                        }
-                        else
-                        {
-                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
-                        }
+                        			}
+                        			else
+                        			{
+                            				rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                            				rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+                            				rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
+                        			}
                         
-                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
+                        			rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[1].TimeoutTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[1].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[1].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[1].PendingIdSpeechTimer + "</TD></TR>");
@@ -563,18 +562,18 @@ namespace RC210_DataAssistant_V2
 					{
 						rW.WriteLine("<TABLE border=0>");
 
-                        if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
-                        {
-						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                        }
-                        else
-                        {
-                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
-                        }
+                        			if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
+                        			{
+							rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                        			}
+                        			else
+                        			{
+                            				rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                            				rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+                            				rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
+                        			}
 
-                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
+                        			rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[2].TimeoutTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[2].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[2].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[2].PendingIdSpeechTimer + "</TD></TR>");
@@ -679,18 +678,18 @@ namespace RC210_DataAssistant_V2
 					{
 						rW.WriteLine("<TABLE border=0>");
 
-                        if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
-                        {
-						    rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                        }
-                        else
-                        {
-                            rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
-                            rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
-                        }
+                        			if (fwVersion < 7.00)           //Added 3 HangTimers per port with v7.00
+                        			{
+			    				rW.WriteLine("<TR><TD><B>Hang:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                        			}
+                        			else
+                        			{
+                            				rW.WriteLine("<TR><TD><B>Hang 1:</B></TD><TD>" + _ports[1].HangTimer1 + "</TD></TR>");
+                            				rW.WriteLine("<TR><TD><B>Hang 2:</B></TD><TD>" + _ports[1].HangTimer2 + "</TD></TR>");
+                            				rW.WriteLine("<TR><TD><B>Hang 3:</B></TD><TD>" + _ports[1].HangTimer3 + "</TD></TR>");
+                        			}
 
-                        rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
+                       				rW.WriteLine("<TR><TD><B>Timeout:</B></TD><TD>" + _ports[3].TimeoutTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Initial ID:</B></TD><TD>" + _ports[3].InitialIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending ID:</B></TD><TD>" + _ports[3].PendingIdTimer + "</TD></TR>");
 						rW.WriteLine("<TR><TD><B>Pending Speech ID:</B></TD><TD>" + _ports[3].PendingIdSpeechTimer + "</TD></TR>");
@@ -765,7 +764,7 @@ namespace RC210_DataAssistant_V2
 						rW.WriteLine("</TD></TR>");
 					}
 
-                    //ExtendedMacros            Added 15 Macro positions 91 - 105 with 20 slots in each position with v7.39
+                    			//ExtendedMacros            Added 15 Macro positions 91 - 105 with 20 slots in each position with v7.39
 
 					foreach (KeyValuePair<int, Macro> macro in _extendedMacros)
 					{
@@ -783,344 +782,342 @@ namespace RC210_DataAssistant_V2
 					rW.WriteLine("</TABLE><HR>");
 				}
 
-                //Setpoints
-                if (checkBox_SetpointsScheduler.Checked)
-                {
-                    rW.WriteLine("<TABLE border=1 align=center width=75%>");
+                		//Setpoints
+                		if (checkBox_SetpointsScheduler.Checked)
+                		{
+                    			rW.WriteLine("<TABLE border=1 align=center width=75%>");
 
-                    if (fwVersion < 7.32)       //Reinstated Month of Run with v7.32. Added 8th column
-                    {
-                        rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
-                    }
-                    else
-                    {
-                        rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
-                        rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
-                    }
+                    			if (fwVersion < 7.32)       //Reinstated Month of Run with v7.32. Added 8th column
+                    			{
+                        			rW.WriteLine("<TR><TD align=center colspan=7><H2>Scheduler Setpoints</H2></TD></TR>");
+                        			rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
+                    			}
+                    			else
+                    			{
+                        			rW.WriteLine("<TR><TD align=center colspan=8><H2>Scheduler Setpoints</H2></TD></TR>");
+                       				rW.WriteLine("<TR><TD><B>Setpoint #</B></TD><TD><B>Day of week</B></TD><TD><B>Month To Run</B></TD><TD><B>Monthly</B></TD><TD><B>Week of month</B>(if monthly)</TD><TD><B>Start Hour</B></TD><TD><B>Start Minutes</B></TD><TD><B>Macro to run</B></TD></TR>");
+                    			}
 
-                    if (fwVersion < 7.361)      //added 20 more Setpoints with v7.361
-                    {
-                        for (int i = 1; i <= 20; i++)
-                        {
-                            rW.WriteLine("<TR><TD>" + i + "</TD>");
-                            rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+                    			if (fwVersion < 7.36)      //added 20 more Setpoints with v7.36
+                    			{
+                        			for (int i = 1; i <= 20; i++)
+                        			{
+                            				rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            				rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
 
-                            if (fwVersion > 7.00)   //Month To Run actually added at v7.01
-                            {
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
-                            }
+                            				if (fwVersion > 7.00)   //Month To Run actually added at v7.01
+                            				{
+                                				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                            				}
 
-                            rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+                            				rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+                            				rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
 
-                            //if they want to
-                            //var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            //rW.WriteLine("<TR><TD colspan=7>");
+                            				//if they want to
+                            				var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            				rW.WriteLine("<TR><TD colspan=7>");
 
-                            //rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+                            				rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
 
-                            //rW.WriteLine("</TD></TR>");
-                        }
+                            				rW.WriteLine("</TD></TR>");
+                        			}
+                        			rW.WriteLine("</TABLE><HR>");
+                    			}
+                    			else
+                    			{
+		        			for (int i = 1; i <= 40; i++)       //added 20 additional Setpoints with v.7.361
 
-                        rW.WriteLine("</TABLE><HR>");
-                    }
-                    else
-                    {
-                        for (int i = 1; i <= 40; i++)       //added 20 additional Setpoints with v.7.361
+                        			{
+                           				rW.WriteLine("<TR><TD>" + i + "</TD>");
+                            				rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
 
-                        {
-                            rW.WriteLine("<TR><TD>" + i + "</TD>");
-                            rW.WriteLine("<TD>" + ParseDow(datFile.IniReadValue("Scheduler", "DOW(" + i + ")")) + "</TD>");
+                            				if (fwVersion > 7.00)
+                            				{
+                                				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
+                            				}
 
-                            if (fwVersion > 7.00)
-                            {
-                                rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MonthToRun(" + i + ")") + "</TD>");
-                            }
+                            				rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
+                            				rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
+                           				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
+                            				rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
 
-                            rW.WriteLine("<TD>" + ParseMonthly(datFile.IniReadValue("Scheduler", "Monthly(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Week(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + ParseHours(datFile.IniReadValue("Scheduler", "Hours(" + i + ")")) + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "Minutes(" + i + ")") + "</TD>");
-                            rW.WriteLine("<TD>" + datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")") + "</TD></TR>");
+                            				//if they want to
+                            				var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
+                            				rW.WriteLine("<TR><TD colspan=7>");
 
-                            //if they want to
-                            //var macroNum = Convert.ToInt32(datFile.IniReadValue("Scheduler", "MacroToRun(" + i + ")"));
-                            //rW.WriteLine("<TR><TD colspan=7>");
+                            				rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
 
-                            //rW.WriteLine(macroNum < 41 ? _macros[macroNum].ParsedMacro + "<HR>" + _macros[macroNum].MacroCodes : _shortMacros[macroNum - 40].ParsedMacro + "<HR>" + _shortMacros[macroNum - 40].MacroCodes);
+                            				rW.WriteLine("</TD></TR>");
+                        			}
 
-                            //rW.WriteLine("</TD></TR>");
-                        }
-
-                        rW.WriteLine("</TABLE><HR>");
-                    }
-                }
-                //CT MSG Macros
-                if (checkBox_CTMessageMacros.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
-
-					for (int i = 1; i <= 3; i++)
-					{
-						for (int j = 1; j <= 10; j++)
-						{
-							var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
-								
-							if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
-								continue;
-
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + j + "</TD>");
-							rW.WriteLine("<TD>" + tone1 + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
-						}
-
-                            if (fwVersion >= 7.02) //From version 7.02 there is a single pool of Courtesy Tones @ P1Tone1 - P1Tone10
-                                break;
-                    }
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Messages
-				if (checkBox_MessageMacros.Checked)
-				{
-
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
-
-					int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
-					for (int i = 1; i <= lastMessage; i++)
-					{
-						var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
-						if (messageMacro != "" && messageMacro != "NONE STORED")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + messageMacro +"</TD></TR>");
-						}
-					}
-					
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//General Timers
-				if (checkBox_GeneralTimers.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-					for (int i = 1; i <= 6; i++)        //Added 3 additional General Times at v6.044
-					{
-						var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
-						if (generalTimer != "0")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + generalTimer + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
-						}	
-					}
-
-					rW.WriteLine("</TABLE>");
-					rW.WriteLine("<HR>");
-				}
-
-				//Analog Meters
-				if (checkBox_AnalogMeters.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
-
-					for (int i = 1; i <= 8; i++)
-					{
-						var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
-
-						if (meter != "0")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
-						}
-
-					}
-					rW.WriteLine("</TABLE>");
-
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
-
-					for (int i = 1; i <= 8; i++)
-					{
-						var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
-						if (meterAlarm != "0")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" +ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
-						}
-					}
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Alarms
-				if (checkBox_Alarms.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
-
-					for (int i = 1; i <= 5; i++)
-					{
-						rW.WriteLine("<TR><TD>" + i + "</TD>");
-						rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) +"</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
-						rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//DTMF Memories
-				if (checkBox_DTMFMemories.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
-
-					int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
-					for (int i = 1; i <= dtmfMemoryCount; i++)
-					{
-						var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
-						if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
-						}
-					}
-
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//Remote Base Memories
-				if (checkBox_RemoteBaseMemories.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 align=center>");
-					rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
-					int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
-					for (int i = 1; i <= remoteBaseMemories; i++)
-					{
-						var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
-						if (freqString != "" && freqString != "0" && freqString != "NONE")
-						{
-							rW.WriteLine("<TR><TD>" + i + "</TD>");
-							rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
-							rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
-							rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
-							rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
-							rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
-						}
-					}
-					rW.WriteLine("</TABLE><HR>");
-				}
-
-				//AutoPatch Settings
-				if (checkBox_APSettings.Checked)
-				{
-					rW.WriteLine("<TABLE border=1 aling=center");
-					rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
-					rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
-						            "</TD>");
-					rW.WriteLine("<TD><B>Answer Code:</B> " +
-						            ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
-					rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
-					rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
-					rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
-					rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
-						
-					rW.WriteLine("<TR><TD valign=top>");
-
-					//AutoPatch Memories
-					if (checkBox_APMemories.Checked)
+                        			rW.WriteLine("</TABLE><HR>");
+                    			}
+                    			//CT MSG Macros
+                    			if (checkBox_CTMessageMacros.Checked)
 					{
 						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
+						rW.WriteLine("<TR><TD align=center colspan=4><H2>Courtesty Tone Message Macros</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Port</B></TD><TD><B>Tone</B></TD><TD><B>Message Macro</B></TD><TD><B>Macro Contents</B></TD></TR>");
+
+						for (int i = 1; i <= 3; i++)
+						{
+							for (int j = 1; j <= 10; j++)
+							{
+								var tone1 = datFile.IniReadValue("Courtesy", "P" + i + "Tone1(" + j + ")");
+								
+								if ((Convert.ToInt32(tone1) > 40) || (Convert.ToInt32(tone1) == 0))
+									continue;
+
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" + j + "</TD>");
+								rW.WriteLine("<TD>" + tone1 + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("MessageMacros", "MessageMacro(" + tone1 + ")") + "</TD></TR>");
+							}
+
+                            				if (fwVersion >= 7.02) //From version 7.02 there is a single pool of Courtesy Tones @ P1Tone1 - P1Tone10
+                               			 		break;
+                    				}
+
+						rW.WriteLine("</TABLE><HR>");
+					}
+
+					//Messages
+					if (checkBox_MessageMacros.Checked)
+					{
+
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>Message Macros</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Message Macro</B></TD><TD><B>Words spoken</B></TD></TR>");
+
+						int lastMessage = checkBox_RTCOption.Checked ? 70 : 40;
+						for (int i = 1; i <= lastMessage; i++)
+						{
+							var messageMacro = datFile.IniReadValue("MessageMacros", "MessageMacro(" + i + ")");
+							if (messageMacro != "" && messageMacro != "NONE STORED")
+							{
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" + messageMacro +"</TD></TR>");
+							}
+						}
+					
+						rW.WriteLine("</TABLE><HR>");
+					}
+
+					//General Timers
+					if (checkBox_GeneralTimers.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=3><H2>General Timers</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Timer</B></TD><TD><B>Time (seconds)</B></TD><TD><B>Macro to run</B></TD></TR>");
+
+						for (int i = 1; i <= 6; i++)        //Added 3 additional General Times at v6.044
+						{
+							var generalTimer = datFile.IniReadValue("Alarms", "GeneralTimer(" + i + ")"); // != 0
+							if (generalTimer != "0")
+							{
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" + generalTimer + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "GeneralTimerMacro(" + i + ")") + "</TD></TR>");
+							}	
+						}
+
+						rW.WriteLine("</TABLE>");
+						rW.WriteLine("<HR>");
+					}
+
+					//Analog Meters
+					if (checkBox_AnalogMeters.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=6><H2>Analog Meters</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Meter #</B></TD><TD><B>Meter Type</B></TD><TD><B>Actual Low</B></TD><TD><B>Meter Low</B></TD><TD><B>Actual High</B></TD><TD><B>Meter High</B></TD></TR>");
+
+						for (int i = 1; i <= 8; i++)
+						{
+							var meter = datFile.IniReadValue("Analog", "Meter(" + i + ")");
+
+							if (meter != "0")
+							{
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" + ParseMeter(meter) + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealLow(" + i + ")") + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterLow(" + i + ")") + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "RealHigh(" + i + ")") + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterHigh(" + i + ")") + "</TD></TR>");
+							}
+
+						}
+						rW.WriteLine("</TABLE>");
+
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=5><H2>Analog Meter Alarms</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Alarm Type</B></TD><TD><B>Meter #</B></TD><TD><B>Meter Set Point</B></TD><TD><B>Macro to run</B></TD></TR>");
+
+						for (int i = 1; i <= 8; i++)
+						{
+							var meterAlarm = datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")");
+							if (meterAlarm != "0")
+							{
+								rW.WriteLine("<TR><TD>" + i + "</TD>");
+								rW.WriteLine("<TD>" +ParseMeterAlarmType(datFile.IniReadValue("Analog", "MeterAlarmType(" + i + ")")) + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterNum(" + i + ")") + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterSetPoint(" + i + ")") + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Analog", "MeterMacro(" + i + ")") + "</TD></TR>");
+							}
+						}
+						rW.WriteLine("</TABLE><HR>");
+					}
+
+					//Alarms
+					if (checkBox_Alarms.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=4><H2>Alarms</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Alarm #</B></TD><TD><B>Status</B></TD><TD><B>High to Low macro</B></TD><TD><B>Low to High macro</B></TD></TR>");
+
+						for (int i = 1; i <= 5; i++)
+						{
+							rW.WriteLine("<TR><TD>" + i + "</TD>");
+							rW.WriteLine("<TD>" + ParseAlarm(datFile.IniReadValue("PortSwitches", "Alarm(" + i + ")")) +"</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmLowMacroNum(" + i + ")") + "</TD>");
+							rW.WriteLine("<TD>" + datFile.IniReadValue("Alarms", "AlarmHighMacroNum(" + i + ")") + "</TD></TR>");
+						}
+
+						rW.WriteLine("</TABLE><HR>");
+					}
+
+					//DTMF Memories
+					if (checkBox_DTMFMemories.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 align=center>");
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>DTMF Memories</H2></TD></TR>");
 						rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
 
-						for (int i = 1; i <= 200; i++)
+						int dtmfMemoryCount = (checkBox_RTCOption.Checked) ? 50 : 20;
+						for (int i = 1; i <= dtmfMemoryCount; i++)
 						{
-							var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
-							if (autoDial.Length > 0)
+							var dtmfMemory = datFile.IniReadValue("DTMF", "DTMF(" + i + ")");
+							if (dtmfMemory != "" && dtmfMemory != "NONE STORED")
 							{
 								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("DTMF", "DTMF(" + i + ")") + "</TD></TR>");
 							}
 						}
 
-						rW.WriteLine("</TABLE>");
+						rW.WriteLine("</TABLE><HR>");
 					}
 
-					rW.WriteLine("</TD><TD valign=top>");
-
-					//AutoPatch Toll Restrictions
-					if (checkBox_APTollRestrictions.Checked)
+					//Remote Base Memories
+					if (checkBox_RemoteBaseMemories.Checked)
 					{
 						rW.WriteLine("<TABLE border=1 align=center>");
-						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
-						rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
-
-						for (int i = 1; i <= 100; i++)
+						rW.WriteLine("<TR><TD align=center colspan=6><H2>Remote Base Memories</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>Frequency</B></TD><TD><B>Offset</B></TD><TD><B>CTCSS</B></TD><TD><B>CTCSS Mode</B></TD><TD><B>Radio Mode</B></TD></TR>");
+						int remoteBaseMemories = (checkBox_RTCOption.Checked) ? 40 : 10;
+						for (int i = 1; i <= remoteBaseMemories; i++)
 						{
-							var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
-							if (apTollRestriction.Length > 0)
+							var freqString = datFile.IniReadValue("Remote", "FreqString(" + i + ")");
+							if (freqString != "" && freqString != "0" && freqString != "NONE")
 							{
 								rW.WriteLine("<TR><TD>" + i + "</TD>");
-								rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
+								rW.WriteLine("<TD>" + freqString.Substring(0, freqString.Length - 1) + "</TD>");
+								rW.WriteLine("<TD>" + ParseRemoteOffset(freqString.Substring(freqString.Length - 1, 1)) + "</TD>");
+								rW.WriteLine("<TD>" + datFile.IniReadValue("Remote", "CTCSS(" + i + ")") + "</TD>");
+								rW.WriteLine("<TD>" + ParseCtcssMode(datFile.IniReadValue("Remote", "CTCSSMode(" + i + ")")) + "</TD>");
+								rW.WriteLine("<TD>" + ParseRadioMode(datFile.IniReadValue("Remote", "RadioMode(" + i + ")")) + "</TD></TR>");
 							}
 						}
-
-						rW.WriteLine("</TABLE>");
+						rW.WriteLine("</TABLE><HR>");
 					}
 
-					rW.WriteLine("</TD></TR>");
-					rW.WriteLine("</TABLE><HR>");
-				}
+					//AutoPatch Settings
+					if (checkBox_APSettings.Checked)
+					{
+						rW.WriteLine("<TABLE border=1 aling=center");
+						rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Settings</H2></TD></TR>");
+						rW.WriteLine("<TR><TD><B>Prefix:</B> " + ((checkBox_APPrefix.Checked) ? _autoPatch.Prefix : "Not Displayed") +
+						            "</TD>");
+						rW.WriteLine("<TD><B>Answer Code:</B> " +
+						            ((checkBox_APAnswerCode.Checked) ? _autoPatch.AnswerCode : "Not Displayed") + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Ring Count:</B> " + _autoPatch.RingCount + "</TD>");
+						rW.WriteLine("<TD><B>Timeout:</B> " + _autoPatch.TimeOut + "</TD></TR>");
+						rW.WriteLine("<TR><TD><B>Allowed Ports:</B> " + _autoPatch.Ports + "</TD>");
+						rW.WriteLine("<TD><B>Patch Mute:</B> " + _autoPatch.PatchMute + "</TD></TR>");
+						
+						rW.WriteLine("<TR><TD valign=top>");
 
-				rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
-				rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
-                rW.WriteLine("Modifed by Robert P. Norris - AK5U: ak5u@arrl.net");
-                rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
+						//AutoPatch Memories
+						if (checkBox_APMemories.Checked)
+						{
+							rW.WriteLine("<TABLE border=1 align=center>");
+							rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Memories</H2></TD></TR>");
+							rW.WriteLine("<TR><TD><B>Memory</B></TD><TD><B>DTMF String</B></TD></TR>");
 
-				var dr = MessageBox.Show(
-					string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
-					@"Report created",
-					MessageBoxButtons.YesNo,
-					MessageBoxIcon.Information
-					);
+							for (int i = 1; i <= 200; i++)
+							{
+								var autoDial = datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")");
+								if (autoDial.Length > 0)
+								{
+									rW.WriteLine("<TR><TD>" + i + "</TD>");
+									rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "AutoDial(" + i + ")") + "</TD></TR>");
+								}
+							}
+
+							rW.WriteLine("</TABLE>");
+						}
+
+						rW.WriteLine("</TD><TD valign=top>");
+
+						//AutoPatch Toll Restrictions
+						if (checkBox_APTollRestrictions.Checked)
+						{
+							rW.WriteLine("<TABLE border=1 align=center>");
+							rW.WriteLine("<TR><TD align=center colspan=2><H2>AutoPatch Toll Restrictions</H2></TD></TR>");
+							rW.WriteLine("<TR><TD><B>Entry</B></TD><TD><B>Toll</B></TD></TR>");
+
+							for (int i = 1; i <= 100; i++)
+							{
+								var apTollRestriction = datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")");
+								if (apTollRestriction.Length > 0)
+								{
+									rW.WriteLine("<TR><TD>" + i + "</TD>");
+									rW.WriteLine("<TD>" + datFile.IniReadValue("AutoPatch", "TollRestrict(" + i + ")") + "</TD></TR>");
+								}
+							}
+
+							rW.WriteLine("</TABLE>");
+						}
+
+						rW.WriteLine("</TD></TR>");
+						rW.WriteLine("</TABLE><HR>");
+					}
+
+					rW.WriteLine("F/W Target Version: " + comboBox_FwVersion.SelectedItem + "<BR>");
+					rW.WriteLine("This file was generated by Data Assistant V2 written by James M. Bolding - KC5TDG: bolwire@cableone.net<br>");
+                			rW.WriteLine("Modifed by Robert P. Norris - AK5U: ak5u@arrl.net");
+                			rW.WriteLine("Please join the Data Assistant Group at: <a href=https://groups.google.com/forum/#!forum/rc210_data_assistant>https://groups.google.com/forum/#!forum/rc210_data_assistant</a>");
+
+					var dr = MessageBox.Show(
+						string.Format("Your report has been created at:\n\n{0}\n\nWould you like to open it now?", _reportFilename),
+						@"Report created",
+						MessageBoxButtons.YesNo,
+						MessageBoxIcon.Information
+						);
 				
-				if (dr == DialogResult.Yes) Process.Start(_reportFilename);
+					if (dr == DialogResult.Yes) Process.Start(_reportFilename);
+				}
 			}
 		}
-
         
-        #endregion Generate Report
+        	#endregion Generate Report
 
-        #region Load AutoPatch
+        	#region Load AutoPatch
 
-        private void Load_AutoPatch()
+        	private void Load_AutoPatch()
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1199,6 +1196,7 @@ namespace RC210_DataAssistant_V2
 					RepeaterMode = (datFile.IniReadValue("PortSwitches", string.Format("FDup({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
 					SpeechIdOverride = (datFile.IniReadValue("PortSwitches", string.Format("SpeechIDOverride({0})", i)) == "0") ? "Disabled" : "Enabled",
+					
 					//AccessMode = datFile.IniReadValue("PortSwitches", string.Format("P{0}MessageNum(3)", i)),
 					DtmfEnable = (datFile.IniReadValue("PortSwitches", string.Format("DTMFEnable({0})", i)) == "0") ? "Disabled" : "Enabled",
 					DtmfRequireTone = (datFile.IniReadValue("PortSwitches", string.Format("DTMFNeedPL({0})", i)) == "0") ? "Disabled" : "Enabled",
@@ -1209,18 +1207,18 @@ namespace RC210_DataAssistant_V2
 
 				};
                 
-                if (fwVersion < 7.00)                                                                           //Added this code to handle HangTimer
-                {                                                                                               //change in v7.00
-                    portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
-                }
-                else
-                {
-                    portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
-                    portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
-                    portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
-                }
+                		if (fwVersion < 7.02)                       //Added this code to handle HangTimer
+                		{                                           //changed in v7.00
+                    			portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
+                		}
+                		else
+                		{
+                    			portItem.HangTimer1 = datFile.IniReadValue("Timers", string.Format("HangTime1({0})", i));
+                    			portItem.HangTimer2 = datFile.IniReadValue("Timers", string.Format("HangTime2({0})", i));
+                    			portItem.HangTimer3 = datFile.IniReadValue("Timers", string.Format("HangTime3({0})", i));
+                		}
 
-                if (portName != string.Empty)
+                		if (portName != string.Empty)
 					portItem.PortName = portName;
 
 				_ports.Add(i, portItem);
@@ -1301,46 +1299,46 @@ namespace RC210_DataAssistant_V2
 			}
 		}
 
-        private void Load_ExtendedMacros()          //Supports change with v7.39
-        {
-            IniFile datFile = new IniFile(_datFilename);
+        	private void Load_ExtendedMacros()          //Supports change with v7.39
+        	{
+            		IniFile datFile = new IniFile(_datFilename);
 
-            _extendedMacros.Clear();
+            		_extendedMacros.Clear();
 
-            for (int i = 1; i <= 15; i++)
-            {
-                string extendedMacro = datFile.IniReadValue("Macros", string.Format("ExtendedMacro({0})", i));
-                string extendedMacroCode = datFile.IniReadValue("Macros", string.Format("ExtendedMacroCode({0})", i));
-                string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 90));
+            		for (int i = 1; i <= 15; i++)
+            		{
+                		string extendedMacro = datFile.IniReadValue("Macros", string.Format("ExtendedMacro({0})", i));
+                		string extendedMacroCode = datFile.IniReadValue("Macros", string.Format("ExtendedMacroCode({0})", i));
+                		string allowedPorts = datFile.IniReadValue("Macros", string.Format("PortToAllow({0})", i + 90));
 
-                Macro extendedMacroItem = new Macro
-                {
-                    MacroNumber = i + 90,
-                    //MacroCodes = extendedMacro,
-                    AccessCode = extendedMacroCode,
-                    ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), extendedMacro),
-                    AllowedPorts = allowedPorts
-                };
+                		Macro extendedMacroItem = new Macro
+                		{
+                    			MacroNumber = i + 90,
+                    			//MacroCodes = extendedMacro,
+                   			AccessCode = extendedMacroCode,
+                    			ParsedMacro = _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), extendedMacro),
+                    			AllowedPorts = allowedPorts
+                		};
 
-                char[] splitChar = { ' ' };
-                string[] macroCodes = extendedMacro.Split(splitChar);
+                		char[] splitChar = { ' ' };
+                		string[] macroCodes = extendedMacro.Split(splitChar);
 
-                foreach (string code in macroCodes)
-                {
-                    extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
-                }
+                		foreach (string code in macroCodes)
+                		{
+                    			extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes + " " + string.Format("<a title=\"{0}\">{1}</a>", _macroLibrary.ParseMacro(comboBox_FwVersion.SelectedItem.ToString(), code), code);
+                		}
 
-                extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes.Substring(1);
+                		extendedMacroItem.MacroCodes = extendedMacroItem.MacroCodes.Substring(1);
 
-                _extendedMacros.Add(i, extendedMacroItem);
-            }
-        }
+                		_extendedMacros.Add(i, extendedMacroItem);
+           		}
+        	}
 
-        #endregion Load Macros/ShortMacros/ExtendedMacros
+        	#endregion Load Macros/ShortMacros/ExtendedMacros
 
-        #region Load Message Macros
+        	#region Load Message Macros
 
-        private void Load_MessageMacros()
+        	private void Load_MessageMacros()
 		{
 			IniFile datFile = new IniFile(_datFilename);
 
@@ -1552,6 +1550,10 @@ namespace RC210_DataAssistant_V2
 
 		#endregion InputBox
 
-		
+		private void XMLFilePathToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			string filepath = AppDomain.CurrentDomain.BaseDirectory + "xml\\";			
+			MessageBox.Show("I look for .xml files at the following location:\n\n" + filepath);
+		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # RC210_Data_Assistant
 This project supports the Arcom Controllers model RC210 repeater controller by providing the user 
 with english decoded data from the numerical output of the download from the controller. The output
-is in two forms. First is an html file and second is the printed output of that file. 
+is in two forms. First is an html file and second is the printed output of that file.
 
-James Bolding, KC5TDG, is the originator of this project and Bob Norris, AK5U, have been doing 
-updates as changes in firmware have been released over the years.
+F/W up through 7.64 is currently supported by the program and the .xml files. You only need the XML file(s) that support the f/w versions you support. And beginning with the release of version 7.00 f/w the XML files need to be in the XML folder in the same directory as the program file. The versions supported are:
+  Ver5_6_macro.def.xml - 5.281 - 6.045
+  Ver7_macro_def.xml - 7.00 - 7.361
+  Ver8_macro_def.xml - 7.39 - 7.612
+  Ver9_macro_def.xml - 7.63 - 7.64
+
+Current version of the program, ver 2.0.1.5, now currectly displays the Voice IDs as InitialIDs and PendingIDs. this change was actually made with f/w 7.36. Be sure to check the HISTORY.TXT file for the f/w version you have deployed.
+
+James Bolding, KC5TDG, is the originator of this project and Bob Norris, AK5U, has been doing 
+updates as changes in firmware have been released over the past years.

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ This project supports the Arcom Controllers model RC210 repeater controller by p
 with english decoded data from the numerical output of the download from the controller. The output
 is in two forms. First is an html file and second is the printed output of that file. 
 
-James Bolding, KC5 is the originator of this project and Bob Norris has been updates as changes in
-firmware have been released over the years.
+James Bolding, KC5TDG, is the originator of this project and Bob Norris, AK5U, has been doing 
+updates as changes in firmware have been released 2015.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# RC210_Data_Assistant
+This project supports the Arcom Controllers model RC210 repeater controller by providing the user 
+with english decoded data from the numerical output of the download from the controller. The output
+is in two forms. First is an html file and second is the printed output of that file. 
+
+James Bolding, KC5 is the originator of this project and Bob Norris has been updates as changes in
+firmware have been released over the years.

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ This project supports the Arcom Controllers model RC210 repeater controller by p
 with english decoded data from the numerical output of the download from the controller. The output
 is in two forms. First is an html file and second is the printed output of that file. 
 
-James Bolding, KC5TDG, is the originator of this project and Bob Norris, AK5U, has been doing 
-updates as changes in firmware have been released 2015.
+James Bolding, KC5TDG, is the originator of this project and Bob Norris, AK5U, have been doing 
+updates as changes in firmware have been released over the years.

--- a/XML/Ver5_6_macro_def.xml
+++ b/XML/Ver5_6_macro_def.xml
@@ -989,35 +989,35 @@
   <macro id="605" versions="5.360" description="Call Macro 5" />
   <macro id="605" versions="6.000 6.040" description="Speak Current Remote Base Freq and Offset" />
   <macro id="606" versions="5.360" description="Call Macro 6" />
-  <macro id="606" versions="6.040" description="Start General Timer 4" />
+  <macro id="606" versions="6.044" description="Start General Timer 4" />
   <macro id="607" versions="5.360" description="Call Macro 7" />
-  <macro id="607" versions="6.040" description="Start General Timer 5" />
+  <macro id="607" versions="6.044" description="Start General Timer 5" />
   <macro id="608" versions="5.360" description="Call Macro 8" />
-  <macro id="608" versions="6.040" description="Start General Timer 6" />
+  <macro id="608" versions="6.044" description="Start General Timer 6" />
   <macro id="609" versions="5.360" description="Call Macro 9" />
-  <macro id="609" versions="6.040" description="Stop General Timer 4" />
+  <macro id="609" versions="6.044" description="Stop General Timer 4" />
   <macro id="610" versions="5.360" description="Call Macro 10" />
-  <macro id="610" versions="6.040" description="Stop General Timer 5" />
+  <macro id="610" versions="6.044" description="Stop General Timer 5" />
   <macro id="611" versions="5.360" description="Call Macro 11" />
-  <macro id="611" versions="6.040" description="Stop General Timer 6" />
+  <macro id="611" versions="6.044" description="Stop General Timer 6" />
   <macro id="612" versions="5.360" description="Call Macro 12" />
-  <macro id="612" versions="6.040" description="Disable Port 1 Inactivity Timer" />
+  <macro id="612" versions="6.045" description="Disable Port 1 Inactivity Timer" />
   <macro id="613" versions="5.360" description="Call Macro 13" />
-  <macro id="613" versions="6.040" description="Disable Port 2 Inactivity Timer" />
+  <macro id="613" versions="6.045" description="Disable Port 2 Inactivity Timer" />
   <macro id="614" versions="5.360" description="Call Macro 14" />
-  <macro id="614" versions="6.040" description="Disable Port 3 Inactivity Timer" />
+  <macro id="614" versions="6.045" description="Disable Port 3 Inactivity Timer" />
   <macro id="615" versions="5.360" description="Call Macro 15" />
-  <macro id="615" versions="6.040" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="615" versions="6.045" description="Enable Port 1 Inactivity Timer to Programmed Value" />
   <macro id="616" versions="5.360" description="Call Macro 16" />
-  <macro id="616" versions="6.040" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="6.045" description="Enable Port 2 Inactivity Timer to Programmed Value" />
   <macro id="617" versions="5.360" description="Call Macro 17" />
-  <macro id="617" versions="6.040" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="6.045" description="Enable Port 3 Inactivity Timer to Programmed Value" />
   <macro id="618" versions="5.360" description="Call Macro 18" />
-  <macro id="618" versions="6.040" description="1 Second Execution Delay" />
+  <macro id="618" versions="6.045" description="1 Second Execution Delay" />
   <macro id="619" versions="5.360" description="Call Macro 19" />
-  <macro id="619" versions="6.040" description="2 Second Execution Delay" />
+  <macro id="619" versions="6.045" description="2 Second Execution Delay" />
   <macro id="620" versions="5.360" description="Call Macro 20" />
-  <macro id="620" versions="6.040" description="4 Second Execution Delay" />
+  <macro id="620" versions="6.045" description="4 Second Execution Delay" />
   <macro id="621" versions="5.360" description="Call Macro 21" />
   <macro id="622" versions="5.360" description="Call Macro 22" />
   <macro id="623" versions="5.360" description="Call Macro 23" />

--- a/XML/Ver5_6_macro_def.xml
+++ b/XML/Ver5_6_macro_def.xml
@@ -1,0 +1,1221 @@
+<macros version="1.003">
+  <macro id="001" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 CTCSS Access" />
+  <macro id="002" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 CTCSS Access" />
+  <macro id="003" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 CTCSS Access" />
+  <macro id="004" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Carrier Access" />
+  <macro id="005" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Carrier Access" />
+  <macro id="006" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Carrier Access" />
+  <macro id="007" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Covertone ON" />
+  <macro id="008" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Covertone ON" />
+  <macro id="009" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Covertone ON" />
+  <macro id="010" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Covertone OFF" />
+  <macro id="011" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Covertone OFF" />
+  <macro id="012" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Covertone OFF" />
+  <macro id="013" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Enable" />
+  <macro id="014" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Enable" />
+  <macro id="015" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Enable" />
+  <macro id="016" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Disable" />
+  <macro id="017" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Disable" />
+  <macro id="018" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Disable" />
+  <macro id="019" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 1 from Port 2" />
+  <macro id="020" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 1 from Port 3" />
+  <macro id="021" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 1 from Port 2" />
+  <macro id="022" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 1 from Port 3" />
+  <macro id="023" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 2 from Port 1" />
+  <macro id="024" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 2 from Port 3" />
+  <macro id="025" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 2 from Port 1" />
+  <macro id="026" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 2 from Port 3" />
+  <macro id="027" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 3 from Port 1" />
+  <macro id="028" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 3 from Port 2" />
+  <macro id="029" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 3 from Port 1" />
+  <macro id="030" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 3 from Port 2" />
+  <macro id="031" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Monitor Mute" />
+  <macro id="032" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Monitor Mute" />
+  <macro id="033" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Monitor Mute" />
+  <macro id="034" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Monitor Mix" />
+  <macro id="035" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Monitor Mix" />
+  <macro id="036" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Monitor Mix" />
+  <macro id="037" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Repeat ON" />
+  <macro id="038" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Repeat ON" />
+  <macro id="039" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Repeat ON" />
+  <macro id="040" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Repeat OFF" />
+  <macro id="041" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Repeat OFF" />
+  <macro id="042" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Repeat OFF" />
+  <macro id="043" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech OverrideON" />
+  <macro id="044" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech OverrideON" />
+  <macro id="045" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech OverrideON" />
+  <macro id="046" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech Override OFF" />
+  <macro id="047" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech Override OFF" />
+  <macro id="048" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech Override OFF" />
+  <macro id="049" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 1" />
+  <macro id="050" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 2" />
+  <macro id="051" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 3" />
+  <macro id="052" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 4" />
+  <macro id="053" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 5" />
+  <macro id="054" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 6" />
+  <macro id="055" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 7" />
+  <macro id="056" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 8" />
+  <macro id="057" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 9" />
+  <macro id="058" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 10" />
+  <macro id="059" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 1" />
+  <macro id="060" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 2" />
+  <macro id="061" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 3" />
+  <macro id="062" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 4" />
+  <macro id="063" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 5" />
+  <macro id="064" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 6" />
+  <macro id="065" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 7" />
+  <macro id="066" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 8" />
+  <macro id="067" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 9" />
+  <macro id="068" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 10" />
+  <macro id="069" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 1" />
+  <macro id="070" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 2" />
+  <macro id="071" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 3" />
+  <macro id="072" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 4" />
+  <macro id="073" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 5" />
+  <macro id="074" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 6" />
+  <macro id="075" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 7" />
+  <macro id="076" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 8" />
+  <macro id="077" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 9" />
+  <macro id="078" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 10" />
+  <macro id="079" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Muting ON" />
+  <macro id="080" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Muting ON" />
+  <macro id="081" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Muting ON" />
+  <macro id="082" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Muting OFF" />
+  <macro id="083" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Muting OFF" />
+  <macro id="084" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Muting OFF" />
+  <macro id="085" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="086" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="087" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 1" />
+  <macro id="088" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 2" />
+  <macro id="089" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 3" />
+  <macro id="090" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 4" />
+  <macro id="091" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 5" />
+  <macro id="092" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 6" />
+  <macro id="093" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 7" />
+  <macro id="094" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 8" />
+  <macro id="095" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 ON" />
+  <macro id="096" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 ON" />
+  <macro id="097" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 ON" />
+  <macro id="098" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 ON" />
+  <macro id="099" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 ON" />
+  <macro id="100" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 ON" />
+  <macro id="101" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 ON" />
+  <macro id="102" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 OFF" />
+  <macro id="103" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 OFF" />
+  <macro id="104" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 OFF" />
+  <macro id="105" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 OFF" />
+  <macro id="106" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 OFF" />
+  <macro id="107" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 OFF" />
+  <macro id="108" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 OFF" />
+  <macro id="109" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 Pulse" />
+  <macro id="110" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 Pulse" />
+  <macro id="111" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 Pulse" />
+  <macro id="112" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 Pulse" />
+  <macro id="113" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 Pulse" />
+  <macro id="114" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 Pulse" />
+  <macro id="115" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 Pulse" />
+  <macro id="116" versions="5.281 5.285 5.360 6.000 6.040" description="Say Time" />
+  <macro id="117" versions="5.281 5.285 5.360 6.000 6.040" description="Say Date" />
+  <macro id="118" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="5.281 5.285 5.360 6.000 6.040" description="Link All Ports" />
+  <macro id="122" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="5.281 5.285 5.360 6.000 6.040" description="UnLink All Ports" />
+  <macro id="126" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 1" />
+  <macro id="127" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 2" />
+  <macro id="128" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 3" />
+  <macro id="129" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 4" />
+  <macro id="130" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 5" />
+  <macro id="131" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 6" />
+  <macro id="132" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 7" />
+  <macro id="133" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 8" />
+  <macro id="134" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 9" />
+  <macro id="135" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 10" />
+  <macro id="136" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 11" />
+  <macro id="137" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 12" />
+  <macro id="138" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 13" />
+  <macro id="139" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 14" />
+  <macro id="140" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 15" />
+  <macro id="141" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 16" />
+  <macro id="142" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 17" />
+  <macro id="143" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 18" />
+  <macro id="144" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 19" />
+  <macro id="145" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 20" />
+  <macro id="146" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 1 ON" />
+  <macro id="153" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 2 ON" />
+  <macro id="154" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 3 ON" />
+  <macro id="155" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 4 ON" />
+  <macro id="156" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 5 ON" />
+  <macro id="157" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 1 OFF" />
+  <macro id="158" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 2 OFF" />
+  <macro id="159" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 3 OFF" />
+  <macro id="160" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 4 OFF" />
+  <macro id="161" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 5 OFF" />
+  <macro id="162" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 1" />
+  <macro id="163" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 2" />
+  <macro id="164" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 3" />
+  <macro id="165" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out All Ports" />
+  <macro id="169" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 1" />
+  <macro id="170" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 2" />
+  <macro id="171" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 3" />
+  <macro id="172" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 1" />
+  <macro id="173" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 2" />
+  <macro id="174" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 3" />
+  <macro id="175" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 1" />
+  <macro id="188" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 2" />
+  <macro id="189" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 3" />
+  <macro id="190" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 4" />
+  <macro id="191" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 5" />
+  <macro id="192" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 6" />
+  <macro id="193" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 7" />
+  <macro id="194" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 8" />
+  <macro id="195" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 9" />
+  <macro id="196" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 10" />
+  <macro id="197" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 11" />
+  <macro id="198" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 12" />
+  <macro id="199" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 13" />
+  <macro id="200" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 14" />
+  <macro id="201" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 15" />
+  <macro id="202" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 16" />
+  <macro id="203" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 17" />
+  <macro id="204" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 18" />
+  <macro id="205" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 19" />
+  <macro id="206" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 20" />
+  <macro id="207" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 21" />
+  <macro id="208" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 22" />
+  <macro id="209" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 23" />
+  <macro id="210" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 24" />
+  <macro id="211" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 25" />
+  <macro id="212" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 26" />
+  <macro id="213" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 27" />
+  <macro id="214" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 28" />
+  <macro id="215" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 29" />
+  <macro id="216" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 30" />
+  <macro id="217" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 31" />
+  <macro id="218" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 32" />
+  <macro id="219" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 33" />
+  <macro id="220" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 34" />
+  <macro id="221" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 35" />
+  <macro id="222" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 36" />
+  <macro id="223" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 37" />
+  <macro id="224" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 38" />
+  <macro id="225" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 39" />
+  <macro id="226" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 40" />
+  <macro id="227" versions="5.281 5.285 5.360 6.000 6.040" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="5.281 5.285 5.360 6.000 6.040" description="Macro Priority High" />
+  <macro id="229" versions="5.281 5.285 5.360 6.000 6.040" description="Macro Priority Low" />
+  <macro id="230" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 1" />
+  <macro id="237" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 2" />
+  <macro id="238" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 3" />
+  <macro id="239" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 1" />
+  <macro id="240" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 2" />
+  <macro id="241" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 3" />
+  <macro id="242" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="5.281 5.285 5.360 6.000 6.040" description="Force Audio To Entered Port" />
+  <macro id="252" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 1" />
+  <macro id="260" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 2" />
+  <macro id="261" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 3" />
+  <macro id="262" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 4" />
+  <macro id="263" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 5" />
+  <macro id="264" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 6" />
+  <macro id="265" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 7" />
+  <macro id="266" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 8" />
+  <macro id="267" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 9" />
+  <macro id="268" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 10" />
+  <macro id="269" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 11" />
+  <macro id="270" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 12" />
+  <macro id="271" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 13" />
+  <macro id="272" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 14" />
+  <macro id="273" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 15" />
+  <macro id="274" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 16" />
+  <macro id="275" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 17" />
+  <macro id="276" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 18" />
+  <macro id="277" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 19" />
+  <macro id="278" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 20" />
+  <macro id="279" versions="5.281 5.285 5.360 6.000 6.040" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="5.281 5.285 5.360 6.000 6.040" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="5.281 5.285 5.360 6.000 6.040" description="Say year as part of date" />
+  <macro id="308" versions="5.281 5.285 5.360 6.000 6.040" description="Don't say year as part of date" />
+  <macro id="309" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 1" />
+  <macro id="322" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 2" />
+  <macro id="323" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 3" />
+  <macro id="324" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 4" />
+  <macro id="325" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 5" />
+  <macro id="326" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 6" />
+  <macro id="327" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 7" />
+  <macro id="328" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 8" />
+  <macro id="329" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 9" />
+  <macro id="330" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 10" />
+  <macro id="331" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Zero Hang Time Select" />
+  <macro id="334" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Hang Time Revert to Programmed Value" />
+  <macro id="335" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Hang Time Revert to Programmed Value" />
+  <macro id="336" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Hang Time Revert to Programmed Value" />
+  <macro id="337" versions="5.281 5.285 5.360 6.000 6.040" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Autopatch" />
+  <macro id="339" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="5.281 5.285 5.360 6.000 6.040" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="5.281 5.285 5.360 6.000 6.040" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 1" />
+  <macro id="348" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 2" />
+  <macro id="349" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 3" />
+  <macro id="350" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 1" />
+  <macro id="351" versions="5.281" description="Suspend Scheduler Setpoint 1" />
+  <macro id="351" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 2" />
+  <macro id="352" versions="5.281" description="Suspend Scheduler Setpoint 2" />
+  <macro id="352" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 3" />
+  <macro id="353" versions="5.281" description="Suspend Scheduler Setpoint 3" />
+  <macro id="353" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 1" />
+  <macro id="354" versions="5.281" description="Suspend Scheduler Setpoint 4" />
+  <macro id="354" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 2" />
+  <macro id="355" versions="5.281" description="Suspend Scheduler Setpoint 5" />
+  <macro id="355" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 3" />
+  <macro id="356" versions="5.281" description="Suspend Scheduler Setpoint 6" />
+  <macro id="356" versions="5.285 5.360 6.000 6.040" description="Guest Macros Enabled" />
+  <macro id="357" versions="5.281" description="Suspend Scheduler Setpoint 7" />
+  <macro id="357" versions="5.285 5.360 6.000 6.040" description="Guest Macros Disabled" />
+  <macro id="358" versions="5.281" description="Suspend Scheduler Setpoint 8" />
+  <macro id="358" versions="5.285" description="Receiver Is Active Port 1" />
+  <macro id="358" versions="5.360 6.000 6.040" description="Receiver 1 Macros On" />
+  <macro id="359" versions="5.281" description="Suspend Scheduler Setpoint 9" />
+  <macro id="359" versions="5.285" description="Receiver Is Active Port 2" />
+  <macro id="359" versions="5.360 6.000 6.040" description="Receiver 2 Macros On" />
+  <macro id="360" versions="5.281" description="Suspend Scheduler Setpoint 10" />
+  <macro id="360" versions="5.285" description="Receiver Is Active Port 3" />
+  <macro id="360" versions="5.360 6.000 6.040" description="Receiver 3 Macros On" />
+  <macro id="361" versions="5.281" description="Suspend Scheduler Setpoint 11" />
+  <macro id="361" versions="5.285" description="Receiver Is Inactive Port 1" />
+  <macro id="361" versions="5.360 6.000 6.040" description="Receiver 3 Macros Off" />
+  <macro id="362" versions="5.281" description="Suspend Scheduler Setpoint 12" />
+  <macro id="362" versions="5.285" description="Receiver Is Inactive Port 2" />
+  <macro id="362" versions="5.360 6.000 6.040" description="Receiver 3 Macros Off" />
+  <macro id="363" versions="5.281" description="Suspend Scheduler Setpoint 13" />
+  <macro id="363" versions="5.285" description="Receiver Is Inactive Port 3" />
+  <macro id="363" versions="5.360 6.000 6.040" description="Receiver 3 Macros Off" />
+  <macro id="364" versions="5.281" description="Suspend Scheduler Setpoint 14" />
+  <macro id="364" versions="5.285" description="Play Message Macro 41" />
+  <macro id="364" versions="5.360 6.000 6.040" description="Extended Logic 1 Output ON" />
+  <macro id="365" versions="5.281" description="Suspend Scheduler Setpoint 15" />
+  <macro id="365" versions="5.285" description="Play Message Macro 42" />
+  <macro id="365" versions="5.360 6.000 6.040" description="Extended Logic 2 Output ON" />
+  <macro id="366" versions="5.281" description="Suspend Scheduler Setpoint 16" />
+  <macro id="366" versions="5.285" description="Play Message Macro 43" />
+  <macro id="366" versions="5.360 6.000 6.040" description="Extended Logic 3 Output ON" />
+  <macro id="367" versions="5.281" description="Suspend Scheduler Setpoint 17" />
+  <macro id="367" versions="5.285" description="Play Message Macro 44" />
+  <macro id="367" versions="5.360 6.000 6.040" description="Extended Logic 4 Output ON" />
+  <macro id="368" versions="5.281" description="Suspend Scheduler Setpoint 18" />
+  <macro id="368" versions="5.285" description="Play Message Macro 45" />
+  <macro id="368" versions="5.360 6.000 6.040" description="Extended Logic 5 Output ON" />
+  <macro id="369" versions="5.281" description="Suspend Scheduler Setpoint 19" />
+  <macro id="369" versions="5.285" description="Play Message Macro 46" />
+  <macro id="369" versions="5.360 6.000 6.040" description="Extended Logic 6 Output ON" />
+  <macro id="370" versions="5.281" description="Suspend Scheduler Setpoint 20" />
+  <macro id="370" versions="5.285" description="Play Message Macro 47" />
+  <macro id="370" versions="5.360 6.000 6.040" description="Extended Logic 7 Output ON" />
+  <macro id="371" versions="5.281" description="Resume Scheduler Setpoint 1" />
+  <macro id="371" versions="5.285" description="Play Message Macro 48" />
+  <macro id="371" versions="5.360 6.000 6.040" description="Extended Logic 8 Output ON" />
+  <macro id="372" versions="5.281" description="Resume Scheduler Setpoint 2" />
+  <macro id="372" versions="5.285" description="Play Message Macro 49" />
+  <macro id="372" versions="5.360 6.000 6.040" description="Extended Logic 9 Output ON" />
+  <macro id="373" versions="5.281" description="Resume Scheduler Setpoint 3" />
+  <macro id="373" versions="5.285" description="Play Message Macro 50" />
+  <macro id="373" versions="5.360 6.000 6.040" description="Extended Logic 10 Output ON" />
+  <macro id="374" versions="5.281" description="Resume Scheduler Setpoint 4" />
+  <macro id="374" versions="5.285" description="Play Message Macro 51" />
+  <macro id="374" versions="5.360 6.000 6.040" description="Extended Logic 11 Output ON" />
+  <macro id="375" versions="5.281" description="Resume Scheduler Setpoint 5" />
+  <macro id="375" versions="5.285" description="Play Message Macro 52" />
+  <macro id="375" versions="5.360 6.000 6.040" description="Extended Logic 12 Output ON" />
+  <macro id="376" versions="5.281" description="Resume Scheduler Setpoint 6" />
+  <macro id="376" versions="5.285" description="Play Message Macro 53" />
+  <macro id="376" versions="5.360 6.000 6.040" description="Extended Logic 13 Output ON" />
+  <macro id="377" versions="5.281" description="Resume Scheduler Setpoint 7" />
+  <macro id="377" versions="5.285" description="Play Message Macro 54" />
+  <macro id="377" versions="5.360 6.000 6.040" description="Extended Logic 14 Output ON" />
+  <macro id="378" versions="5.281" description="Resume Scheduler Setpoint 8" />
+  <macro id="378" versions="5.285" description="Play Message Macro 55" />
+  <macro id="378" versions="5.360 6.000 6.040" description="Extended Logic 15 Output ON" />
+  <macro id="379" versions="5.281" description="Resume Scheduler Setpoint 9" />
+  <macro id="379" versions="5.285" description="Play Message Macro 56" />
+  <macro id="379" versions="5.360 6.000 6.040" description="Extended Logic 16 Output ON" />
+  <macro id="380" versions="5.281" description="Resume Scheduler Setpoint 10" />
+  <macro id="380" versions="5.285" description="Play Message Macro 57" />
+  <macro id="380" versions="5.360 6.000 6.040" description="Extended Logic 17 Output ON" />
+  <macro id="381" versions="5.281" description="Resume Scheduler Setpoint 11" />
+  <macro id="381" versions="5.285" description="Play Message Macro 58" />
+  <macro id="381" versions="5.360 6.000 6.040" description="Extended Logic 18 Output ON" />
+  <macro id="382" versions="5.281" description="Resume Scheduler Setpoint 12" />
+  <macro id="382" versions="5.285" description="Play Message Macro 59" />
+  <macro id="382" versions="5.360 6.000 6.040" description="Extended Logic 19 Output ON" />
+  <macro id="383" versions="5.281" description="Resume Scheduler Setpoint 13" />
+  <macro id="383" versions="5.285" description="Play Message Macro 60" />
+  <macro id="383" versions="5.360 6.000 6.040" description="Extended Logic 20 Output ON" />
+  <macro id="384" versions="5.281" description="Resume Scheduler Setpoint 14" />
+  <macro id="384" versions="5.285" description="Play Message Macro 61" />
+  <macro id="384" versions="5.360 6.000 6.040" description="Extended Logic 21 Output ON" />
+  <macro id="385" versions="5.281" description="Resume Scheduler Setpoint 15" />
+  <macro id="385" versions="5.285" description="Play Message Macro 62" />
+  <macro id="385" versions="5.360 6.000 6.040" description="Extended Logic 22 Output ON" />
+  <macro id="386" versions="5.281" description="Resume Scheduler Setpoint 16" />
+  <macro id="386" versions="5.285" description="Play Message Macro 63" />
+  <macro id="386" versions="5.360 6.000 6.040" description="Extended Logic 23 Output ON" />
+  <macro id="387" versions="5.281" description="Resume Scheduler Setpoint 17" />
+  <macro id="387" versions="5.285" description="Play Message Macro 64" />
+  <macro id="387" versions="5.360 6.000 6.040" description="Extended Logic 24 Output ON" />
+  <macro id="388" versions="5.281" description="Resume Scheduler Setpoint 18" />
+  <macro id="388" versions="5.285" description="Play Message Macro 65" />
+  <macro id="388" versions="5.360 6.000 6.040" description="Extended Logic 25 Output ON" />
+  <macro id="389" versions="5.281" description="Resume Scheduler Setpoint 19" />
+  <macro id="389" versions="5.285" description="Play Message Macro 66" />
+  <macro id="389" versions="5.360 6.000 6.040" description="Extended Logic 26 Output ON" />
+  <macro id="390" versions="5.281" description="Resume Scheduler Setpoint 20" />
+  <macro id="390" versions="5.285" description="Play Message Macro 67" />
+  <macro id="390" versions="5.360 6.000 6.040" description="Extended Logic 27 Output ON" />
+  <macro id="391" versions="5.281" description="Stop General Timer 1" />
+  <macro id="391" versions="5.285" description="Play Message Macro 68" />
+  <macro id="391" versions="5.360 6.000 6.040" description="Extended Logic 28 Output ON" />
+  <macro id="392" versions="5.281" description="Stop General Timer 2" />
+  <macro id="392" versions="5.285" description="Play Message Macro 69" />
+  <macro id="392" versions="5.360 6.000 6.040" description="Extended Logic 29 Output ON" />
+  <macro id="393" versions="5.281" description="Stop General Timer 3" />
+  <macro id="393" versions="5.285" description="Play Message Macro 70" />
+  <macro id="393" versions="5.360 6.000 6.040" description="Extended Logic 30 Output ON" />
+  <macro id="394" versions="5.285" description="Remote Base Memory 11" />
+  <macro id="394" versions="5.360 6.000 6.040" description="Extended Logic 31 Output ON" />
+  <macro id="395" versions="5.285" description="Remote Base Memory 12" />
+  <macro id="395" versions="5.360 6.000 6.040" description="Extended Logic 32 Output ON" />
+  <macro id="396" versions="5.285" description="Remote Base Memory 13" />
+  <macro id="396" versions="5.360 6.000 6.040" description="Extended Logic 1 Output Pulse" />
+  <macro id="397" versions="5.281" description="Macro Subset Disable" />
+  <macro id="397" versions="5.285" description="Remote Base Memory 14" />
+  <macro id="397" versions="5.360 6.000 6.040" description="Extended Logic 2 Output Pulse" />
+  <macro id="398" versions="5.281" description="Macro Subset Enable" />
+  <macro id="398" versions="5.285" description="Remote Base Memory 15" />
+  <macro id="398" versions="5.360 6.000 6.040" description="Extended Logic 3 Output Pulse" />
+  <macro id="399" versions="5.285" description="Remote Base Memory 16" />
+  <macro id="399" versions="5.360 6.000 6.040" description="Extended Logic 4 Output Pulse" />
+  <macro id="400" versions="5.285" description="Remote Base Memory 17" />
+  <macro id="400" versions="5.360 6.000 6.040" description="Extended Logic 5 Output Pulse" />
+  <macro id="401" versions="5.281" description="Macro 1" />
+  <macro id="401" versions="5.285" description="Remote Base Memory 18" />
+  <macro id="401" versions="5.360 6.000 6.040" description="Extended Logic 6 Output Pulse" />
+  <macro id="402" versions="5.281" description="Macro 2" />
+  <macro id="402" versions="5.285" description="Remote Base Memory 19" />
+  <macro id="402" versions="5.360 6.000 6.040" description="Extended Logic 7 Output Pulse" />
+  <macro id="403" versions="5.281" description="Macro 3" />
+  <macro id="403" versions="5.285" description="Remote Base Memory 20" />
+  <macro id="403" versions="5.360 6.000 6.040" description="Extended Logic 8 Output Pulse" />
+  <macro id="404" versions="5.281" description="Macro 4" />
+  <macro id="404" versions="5.285" description="Remote Base Memory 21" />
+  <macro id="404" versions="5.360 6.000 6.040" description="Extended Logic 9 Output Pulse" />
+  <macro id="405" versions="5.281" description="Macro 5" />
+  <macro id="405" versions="5.285" description="Remote Base Memory 22" />
+  <macro id="405" versions="5.360 6.000 6.040" description="Extended Logic 10 Output Pulse" />
+  <macro id="406" versions="5.281" description="Macro 6" />
+  <macro id="406" versions="5.285" description="Remote Base Memory 23" />
+  <macro id="406" versions="5.360 6.000 6.040" description="Extended Logic 11 Output Pulse" />
+  <macro id="407" versions="5.281" description="Macro 7" />
+  <macro id="407" versions="5.285" description="Remote Base Memory 24" />
+  <macro id="407" versions="5.360 6.000 6.040" description="Extended Logic 12 Output Pulse" />
+  <macro id="408" versions="5.281" description="Macro 8" />
+  <macro id="408" versions="5.285" description="Remote Base Memory 25" />
+  <macro id="408" versions="5.360 6.000 6.040" description="Extended Logic 13 Output Pulse" />
+  <macro id="409" versions="5.281" description="Macro 9" />
+  <macro id="409" versions="5.285" description="Remote Base Memory 26" />
+  <macro id="409" versions="5.360 6.000 6.040" description="Extended Logic 14 Output Pulse" />
+  <macro id="410" versions="5.281" description="Macro 10" />
+  <macro id="410" versions="5.285" description="Remote Base Memory 27" />
+  <macro id="410" versions="5.360 6.000 6.040" description="Extended Logic 15 Output Pulse" />
+  <macro id="411" versions="5.281" description="Macro 11" />
+  <macro id="411" versions="5.285" description="Remote Base Memory 28" />
+  <macro id="411" versions="5.360 6.000 6.040" description="Extended Logic 16 Output Pulse" />
+  <macro id="412" versions="5.281" description="Macro 12" />
+  <macro id="412" versions="5.285" description="Remote Base Memory 29" />
+  <macro id="412" versions="5.360 6.000 6.040" description="Extended Logic 17 Output Pulse" />
+  <macro id="413" versions="5.281" description="Macro 13" />
+  <macro id="413" versions="5.285" description="Remote Base Memory 30" />
+  <macro id="413" versions="5.360 6.000 6.040" description="Extended Logic 18 Output Pulse" />
+  <macro id="414" versions="5.281" description="Macro 14" />
+  <macro id="414" versions="5.285" description="Remote Base Memory 31" />
+  <macro id="414" versions="5.360 6.000 6.040" description="Extended Logic 19 Output Pulse" />
+  <macro id="415" versions="5.281" description="Macro 15" />
+  <macro id="415" versions="5.285" description="Remote Base Memory 32" />
+  <macro id="415" versions="5.360 6.000 6.040" description="Extended Logic 20 Output Pulse" />
+  <macro id="416" versions="5.281" description="Macro 16" />
+  <macro id="416" versions="5.285" description="Remote Base Memory 33" />
+  <macro id="416" versions="5.360 6.000 6.040" description="Extended Logic 21 Output Pulse" />
+  <macro id="417" versions="5.281" description="Macro 17" />
+  <macro id="417" versions="5.285" description="Remote Base Memory 34" />
+  <macro id="417" versions="5.360 6.000 6.040" description="Extended Logic 22 Output Pulse" />
+  <macro id="418" versions="5.281" description="Macro 18" />
+  <macro id="418" versions="5.285" description="Remote Base Memory 35" />
+  <macro id="418" versions="5.360 6.000 6.040" description="Extended Logic 23 Output Pulse" />
+  <macro id="419" versions="5.281" description="Macro 19" />
+  <macro id="419" versions="5.285" description="Remote Base Memory 36" />
+  <macro id="419" versions="5.360 6.000 6.040" description="Extended Logic 24 Output Pulse" />
+  <macro id="420" versions="5.281" description="Macro 20" />
+  <macro id="420" versions="5.285" description="Remote Base Memory 37" />
+  <macro id="420" versions="5.360 6.000 6.040" description="Extended Logic 25 Output Pulse" />
+  <macro id="421" versions="5.281" description="Macro 21" />
+  <macro id="421" versions="5.285" description="Remote Base Memory 38" />
+  <macro id="421" versions="5.360 6.000 6.040" description="Extended Logic 26 Output Pulse" />
+  <macro id="422" versions="5.281" description="Macro 22" />
+  <macro id="422" versions="5.285" description="Remote Base Memory 39" />
+  <macro id="422" versions="5.360 6.000 6.040" description="Extended Logic 27 Output Pulse" />
+  <macro id="423" versions="5.281" description="Macro 23" />
+  <macro id="423" versions="5.285" description="Remote Base Memory 40" />
+  <macro id="423" versions="5.360 6.000 6.040" description="Extended Logic 28 Output Pulse" />
+  <macro id="424" versions="5.281" description="Macro 24" />
+  <macro id="424" versions="5.285" description="Send DTMF Memory 21" />
+  <macro id="424" versions="5.360 6.000 6.040" description="Extended Logic 29 Output Pulse" />
+  <macro id="425" versions="5.281" description="Macro 25" />
+  <macro id="425" versions="5.285" description="Send DTMF Memory 22" />
+  <macro id="425" versions="5.360 6.000 6.040" description="Extended Logic 30 Output Pulse" />
+  <macro id="426" versions="5.281" description="Macro 26" />
+  <macro id="426" versions="5.285" description="Send DTMF Memory 23" />
+  <macro id="426" versions="5.360 6.000 6.040" description="Extended Logic 31 Output Pulse" />
+  <macro id="427" versions="5.281" description="Macro 27" />
+  <macro id="427" versions="5.285" description="Send DTMF Memory 24" />
+  <macro id="427" versions="5.360 6.000 6.040" description="Extended Logic 32 Output Pulse" />
+  <macro id="428" versions="5.281" description="Macro 28" />
+  <macro id="428" versions="5.285" description="Send DTMF Memory 25" />
+  <macro id="428" versions="5.360 6.000 6.040" description="Extended Logic 1 Output OFF" />
+  <macro id="429" versions="5.281" description="Macro 29" />
+  <macro id="429" versions="5.285" description="Send DTMF Memory 26" />
+  <macro id="429" versions="5.360 6.000 6.040" description="Extended Logic 2 Output OFF" />
+  <macro id="430" versions="5.281" description="Macro 30" />
+  <macro id="430" versions="5.285" description="Send DTMF Memory 27" />
+  <macro id="430" versions="5.360 6.000 6.040" description="Extended Logic 3 Output OFF" />
+  <macro id="431" versions="5.281" description="Macro 31" />
+  <macro id="431" versions="5.285" description="Send DTMF Memory 28" />
+  <macro id="431" versions="5.360 6.000 6.040" description="Extended Logic 4 Output OFF" />
+  <macro id="432" versions="5.281" description="Macro 32" />
+  <macro id="432" versions="5.285" description="Send DTMF Memory 29" />
+  <macro id="432" versions="5.360 6.000 6.040" description="Extended Logic 5 Output OFF" />
+  <macro id="433" versions="5.281" description="Macro 33" />
+  <macro id="433" versions="5.285" description="Send DTMF Memory 30" />
+  <macro id="433" versions="5.360 6.000 6.040" description="Extended Logic 6 Output OFF" />
+  <macro id="434" versions="5.281" description="Macro 34" />
+  <macro id="434" versions="5.285" description="Send DTMF Memory 31" />
+  <macro id="434" versions="5.360 6.000 6.040" description="Extended Logic 7 Output OFF" />
+  <macro id="435" versions="5.281" description="Macro 35" />
+  <macro id="435" versions="5.285" description="Send DTMF Memory 32" />
+  <macro id="435" versions="5.360 6.000 6.040" description="Extended Logic 8 Output OFF" />
+  <macro id="436" versions="5.281" description="Macro 36" />
+  <macro id="436" versions="5.285" description="Send DTMF Memory 33" />
+  <macro id="436" versions="5.360 6.000 6.040" description="Extended Logic 9 Output OFF" />
+  <macro id="437" versions="5.281" description="Macro 37" />
+  <macro id="437" versions="5.285" description="Send DTMF Memory 34" />
+  <macro id="437" versions="5.360 6.000 6.040" description="Extended Logic 10 Output OFF" />
+  <macro id="438" versions="5.281" description="Macro 38" />
+  <macro id="438" versions="5.285" description="Send DTMF Memory 35" />
+  <macro id="438" versions="5.360 6.000 6.040" description="Extended Logic 11 Output OFF" />
+  <macro id="439" versions="5.281" description="Macro 39" />
+  <macro id="439" versions="5.285" description="Send DTMF Memory 36" />
+  <macro id="439" versions="5.360 6.000 6.040" description="Extended Logic 12 Output OFF" />
+  <macro id="440" versions="5.281" description="Macro 40" />
+  <macro id="440" versions="5.285" description="Send DTMF Memory 37" />
+  <macro id="440" versions="5.360 6.000 6.040" description="Extended Logic 13 Output OFF" />
+  <macro id="441" versions="5.281" description="Macro 41" />
+  <macro id="441" versions="5.285" description="Send DTMF Memory 38" />
+  <macro id="441" versions="5.360 6.000 6.040" description="Extended Logic 14 Output OFF" />
+  <macro id="442" versions="5.281" description="Macro 42" />
+  <macro id="442" versions="5.285" description="Send DTMF Memory 39" />
+  <macro id="442" versions="5.360 6.000 6.040" description="Extended Logic 15 Output OFF" />
+  <macro id="443" versions="5.281" description="Macro 43" />
+  <macro id="443" versions="5.285" description="Send DTMF Memory 40" />
+  <macro id="443" versions="5.360 6.000 6.040" description="Extended Logic 16 Output OFF" />
+  <macro id="444" versions="5.281" description="Macro 44" />
+  <macro id="444" versions="5.285" description="Send DTMF Memory 41" />
+  <macro id="444" versions="5.360 6.000 6.040" description="Extended Logic 17 Output OFF" />
+  <macro id="445" versions="5.281" description="Macro 45" />
+  <macro id="445" versions="5.285" description="Send DTMF Memory 42" />
+  <macro id="445" versions="5.360 6.000 6.040" description="Extended Logic 18 Output OFF" />
+  <macro id="446" versions="5.281" description="Macro 46" />
+  <macro id="446" versions="5.285" description="Send DTMF Memory 43" />
+  <macro id="446" versions="5.360 6.000 6.040" description="Extended Logic 19 Output OFF" />
+  <macro id="447" versions="5.281" description="Macro 47" />
+  <macro id="447" versions="5.285" description="Send DTMF Memory 44" />
+  <macro id="447" versions="5.360 6.000 6.040" description="Extended Logic 20 Output OFF" />
+  <macro id="448" versions="5.281" description="Macro 48" />
+  <macro id="448" versions="5.285" description="Send DTMF Memory 45" />
+  <macro id="448" versions="5.360 6.000 6.040" description="Extended Logic 21 Output OFF" />
+  <macro id="449" versions="5.281" description="Macro 49" />
+  <macro id="449" versions="5.285" description="Send DTMF Memory 46" />
+  <macro id="449" versions="5.360 6.000 6.040" description="Extended Logic 22 Output OFF" />
+  <macro id="450" versions="5.281" description="Macro 50" />
+  <macro id="450" versions="5.285" description="Send DTMF Memory 47" />
+  <macro id="450" versions="5.360 6.000 6.040" description="Extended Logic 23 Output OFF" />
+  <macro id="451" versions="5.281" description="Macro 51" />
+  <macro id="451" versions="5.285" description="Send DTMF Memory 48" />
+  <macro id="451" versions="5.360 6.000 6.040" description="Extended Logic 24 Output OFF" />
+  <macro id="452" versions="5.281" description="Macro 52" />
+  <macro id="452" versions="5.285" description="Send DTMF Memory 49" />
+  <macro id="452" versions="5.360 6.000 6.040" description="Extended Logic 25 Output OFF" />
+  <macro id="453" versions="5.281" description="Macro 53" />
+  <macro id="453" versions="5.285" description="Send DTMF Memory 50" />
+  <macro id="453" versions="5.360 6.000 6.040" description="Extended Logic 26 Output OFF" />
+  <macro id="454" versions="5.281" description="Macro 54" />
+  <macro id="454" versions="5.285" description="Load RTC Time/Date" />
+  <macro id="454" versions="5.360 6.000 6.040" description="Extended Logic 27 Output OFF" />
+  <macro id="455" versions="5.281" description="Macro 55" />
+  <macro id="455" versions="5.360 6.000 6.040" description="Extended Logic 28 Output OFF" />
+  <macro id="456" versions="5.281" description="Macro 56" />
+  <macro id="456" versions="5.360 6.000 6.040" description="Extended Logic 29 Output OFF" />
+  <macro id="457" versions="5.281" description="Macro 57" />
+  <macro id="457" versions="5.360 6.000 6.040" description="Extended Logic 30 Output OFF" />
+  <macro id="458" versions="5.281" description="Macro 58" />
+  <macro id="458" versions="5.360 6.000 6.040" description="Extended Logic 31 Output OFF" />
+  <macro id="459" versions="5.281" description="Macro 59" />
+  <macro id="459" versions="5.360 6.000 6.040" description="Extended Logic 32 Output OFF" />
+  <macro id="460" versions="5.281" description="Macro 60" />
+  <macro id="460" versions="5.285" description="Suspend Scheduler Setpoint 1" />
+  <macro id="460" versions="5.360 6.000 6.040" description="Play Message Macro 41" />
+  <macro id="461" versions="5.281" description="Macro 61" />
+  <macro id="461" versions="5.285" description="Suspend Scheduler Setpoint 2" />
+  <macro id="461" versions="5.360 6.000 6.040" description="Play Message Macro 42" />
+  <macro id="462" versions="5.281" description="Macro 62" />
+  <macro id="462" versions="5.285" description="Suspend Scheduler Setpoint 3" />
+  <macro id="462" versions="5.360 6.000 6.040" description="Play Message Macro 43" />
+  <macro id="463" versions="5.281" description="Macro 63" />
+  <macro id="463" versions="5.285" description="Suspend Scheduler Setpoint 4" />
+  <macro id="463" versions="5.360 6.000 6.040" description="Play Message Macro 44" />
+  <macro id="464" versions="5.281" description="Macro 64" />
+  <macro id="464" versions="5.285" description="Suspend Scheduler Setpoint 5" />
+  <macro id="464" versions="5.360 6.000 6.040" description="Play Message Macro 45" />
+  <macro id="465" versions="5.281" description="Macro 65" />
+  <macro id="465" versions="5.285" description="Suspend Scheduler Setpoint 6" />
+  <macro id="465" versions="5.360 6.000 6.040" description="Play Message Macro 46" />
+  <macro id="466" versions="5.281" description="Macro 66" />
+  <macro id="466" versions="5.285" description="Suspend Scheduler Setpoint 7" />
+  <macro id="466" versions="5.360 6.000 6.040" description="Play Message Macro 47" />
+  <macro id="467" versions="5.281" description="Macro 67" />
+  <macro id="467" versions="5.285" description="Suspend Scheduler Setpoint 8" />
+  <macro id="467" versions="5.360 6.000 6.040" description="Play Message Macro 48" />
+  <macro id="468" versions="5.281" description="Macro 68" />
+  <macro id="468" versions="5.285" description="Suspend Scheduler Setpoint 9" />
+  <macro id="468" versions="5.360 6.000 6.040" description="Play Message Macro 49" />
+  <macro id="469" versions="5.281" description="Macro 69" />
+  <macro id="469" versions="5.285" description="Suspend Scheduler Setpoint 10" />
+  <macro id="469" versions="5.360 6.000 6.040" description="Play Message Macro 50" />
+  <macro id="470" versions="5.281" description="Macro 70" />
+  <macro id="470" versions="5.285" description="Suspend Scheduler Setpoint 11" />
+  <macro id="470" versions="5.360 6.000 6.040" description="Play Message Macro 51" />
+  <macro id="471" versions="5.281" description="Macro 71" />
+  <macro id="471" versions="5.285" description="Suspend Scheduler Setpoint 12" />
+  <macro id="471" versions="5.360 6.000 6.040" description="Play Message Macro 52" />
+  <macro id="472" versions="5.281" description="Macro 72" />
+  <macro id="472" versions="5.285" description="Suspend Scheduler Setpoint 13" />
+  <macro id="472" versions="5.360 6.000 6.040" description="Play Message Macro 53" />
+  <macro id="473" versions="5.281" description="Macro 73" />
+  <macro id="473" versions="5.285" description="Suspend Scheduler Setpoint 14" />
+  <macro id="473" versions="5.360 6.000 6.040" description="Play Message Macro 54" />
+  <macro id="474" versions="5.281" description="Macro 74" />
+  <macro id="474" versions="5.285" description="Suspend Scheduler Setpoint 15" />
+  <macro id="474" versions="5.360 6.000 6.040" description="Play Message Macro 55" />
+  <macro id="475" versions="5.281" description="Macro 75" />
+  <macro id="475" versions="5.285" description="Suspend Scheduler Setpoint 16" />
+  <macro id="475" versions="5.360 6.000 6.040" description="Play Message Macro 56" />
+  <macro id="476" versions="5.281" description="Macro 76" />
+  <macro id="476" versions="5.285" description="Suspend Scheduler Setpoint 17" />
+  <macro id="476" versions="5.360 6.000 6.040" description="Play Message Macro 57" />
+  <macro id="477" versions="5.281" description="Macro 77" />
+  <macro id="477" versions="5.285" description="Suspend Scheduler Setpoint 18" />
+  <macro id="477" versions="5.360 6.000 6.040" description="Play Message Macro 58" />
+  <macro id="478" versions="5.281" description="Macro 78" />
+  <macro id="478" versions="5.285" description="Suspend Scheduler Setpoint 19" />
+  <macro id="478" versions="5.360 6.000 6.040" description="Play Message Macro 59" />
+  <macro id="479" versions="5.281" description="Macro 79" />
+  <macro id="479" versions="5.285" description="Suspend Scheduler Setpoint 20" />
+  <macro id="479" versions="5.360 6.000 6.040" description="Play Message Macro 60" />
+  <macro id="480" versions="5.281" description="Macro 80" />
+  <macro id="480" versions="5.285" description="Resume Scheduler Setpoint 1" />
+  <macro id="480" versions="5.360 6.000 6.040" description="Play Message Macro 61" />
+  <macro id="481" versions="5.281" description="Macro 81" />
+  <macro id="481" versions="5.285" description="Resume Scheduler Setpoint 2" />
+  <macro id="481" versions="5.360 6.000 6.040" description="Play Message Macro 62" />
+  <macro id="482" versions="5.281" description="Macro 82" />
+  <macro id="482" versions="5.285" description="Resume Scheduler Setpoint 3" />
+  <macro id="482" versions="5.360 6.000 6.040" description="Play Message Macro 63" />
+  <macro id="483" versions="5.281" description="Macro 83" />
+  <macro id="483" versions="5.285" description="Resume Scheduler Setpoint 4" />
+  <macro id="483" versions="5.360 6.000 6.040" description="Play Message Macro 64" />
+  <macro id="484" versions="5.281" description="Macro 84" />
+  <macro id="484" versions="5.285" description="Resume Scheduler Setpoint 5" />
+  <macro id="484" versions="5.360 6.000 6.040" description="Play Message Macro 65" />
+  <macro id="485" versions="5.281" description="Macro 85" />
+  <macro id="485" versions="5.285" description="Resume Scheduler Setpoint 6" />
+  <macro id="485" versions="5.360 6.000 6.040" description="Play Message Macro 66" />
+  <macro id="486" versions="5.281" description="Macro 86" />
+  <macro id="486" versions="5.285" description="Resume Scheduler Setpoint 7" />
+  <macro id="486" versions="5.360 6.000 6.040" description="Play Message Macro 67" />
+  <macro id="487" versions="5.281" description="Macro 87" />
+  <macro id="487" versions="5.285" description="Resume Scheduler Setpoint 8" />
+  <macro id="487" versions="5.360 6.000 6.040" description="Play Message Macro 68" />
+  <macro id="488" versions="5.281" description="Macro 88" />
+  <macro id="488" versions="5.285" description="Resume Scheduler Setpoint 9" />
+  <macro id="488" versions="5.360 6.000 6.040" description="Play Message Macro 69" />
+  <macro id="489" versions="5.281" description="Macro 89" />
+  <macro id="489" versions="5.285" description="Resume Scheduler Setpoint 10" />
+  <macro id="489" versions="5.360 6.000 6.040" description="Play Message Macro 70" />
+  <macro id="490" versions="5.281" description="Macro 90" />
+  <macro id="490" versions="5.285" description="Resume Scheduler Setpoint 11" />
+  <macro id="490" versions="5.360 6.000 6.040" description="Remote Base Memory 11" />
+  <macro id="491" versions="5.285" description="Resume Scheduler Setpoint 12" />
+  <macro id="491" versions="5.360 6.000 6.040" description="Remote Base Memory 12" />
+  <macro id="492" versions="5.285" description="Resume Scheduler Setpoint 13" />
+  <macro id="492" versions="5.360 6.000 6.040" description="Remote Base Memory 13" />
+  <macro id="493" versions="5.285" description="Resume Scheduler Setpoint 14" />
+  <macro id="493" versions="5.360 6.000 6.040" description="Remote Base Memory 14" />
+  <macro id="494" versions="5.285" description="Resume Scheduler Setpoint 15" />
+  <macro id="494" versions="5.360 6.000 6.040" description="Remote Base Memory 15" />
+  <macro id="495" versions="5.285" description="Resume Scheduler Setpoint 16" />
+  <macro id="495" versions="5.360 6.000 6.040" description="Remote Base Memory 16" />
+  <macro id="496" versions="5.285" description="Resume Scheduler Setpoint 17" />
+  <macro id="496" versions="5.360 6.000 6.040" description="Remote Base Memory 17" />
+  <macro id="497" versions="5.285" description="Resume Scheduler Setpoint 18" />
+  <macro id="497" versions="5.360 6.000 6.040" description="Remote Base Memory 18" />
+  <macro id="498" versions="5.285" description="Resume Scheduler Setpoint 19" />
+  <macro id="498" versions="5.360 6.000 6.040" description="Remote Base Memory 19" />
+  <macro id="499" versions="5.285" description="Resume Scheduler Setpoint 20" />
+  <macro id="499" versions="5.360 6.000 6.040" description="Remote Base Memory 20" />
+  <macro id="500" versions="5.360 6.000 6.040" description="Remote Base Memory 21" />
+  <macro id="501" versions="5.285" description="Call Macro 1" />
+  <macro id="501" versions="5.360 6.000 6.040" description="Remote Base Memory 22" />
+  <macro id="502" versions="5.285" description="Call Macro 2" />
+  <macro id="502" versions="5.360 6.000 6.040" description="Remote Base Memory 23" />
+  <macro id="503" versions="5.285" description="Call Macro 3" />
+  <macro id="503" versions="5.360 6.000 6.040" description="Remote Base Memory 24" />
+  <macro id="504" versions="5.285" description="Call Macro 4" />
+  <macro id="504" versions="5.360 6.000 6.040" description="Remote Base Memory 25" />
+  <macro id="505" versions="5.285" description="Call Macro 5" />
+  <macro id="505" versions="5.360 6.000 6.040" description="Remote Base Memory 26" />
+  <macro id="506" versions="5.285" description="Call Macro 6" />
+  <macro id="506" versions="5.360 6.000 6.040" description="Remote Base Memory 27" />
+  <macro id="507" versions="5.285" description="Call Macro 7" />
+  <macro id="507" versions="5.360 6.000 6.040" description="Remote Base Memory 28" />
+  <macro id="508" versions="5.285" description="Call Macro 8" />
+  <macro id="508" versions="5.360 6.000 6.040" description="Remote Base Memory 29" />
+  <macro id="509" versions="5.285" description="Call Macro 9" />
+  <macro id="509" versions="5.360 6.000 6.040" description="Remote Base Memory 30" />
+  <macro id="510" versions="5.285" description="Call Macro 10" />
+  <macro id="511" versions="5.285" description="Call Macro 11" />
+  <macro id="511" versions="5.360 6.000 6.040" description="Remote Base Memory 31" />
+  <macro id="512" versions="5.285" description="Call Macro 12" />
+  <macro id="512" versions="5.360 6.000 6.040" description="Remote Base Memory 32" />
+  <macro id="513" versions="5.285" description="Call Macro 13" />
+  <macro id="513" versions="5.360 6.000 6.040" description="Remote Base Memory 33" />
+  <macro id="514" versions="5.285" description="Call Macro 14" />
+  <macro id="514" versions="5.360 6.000 6.040" description="Remote Base Memory 34" />
+  <macro id="515" versions="5.285" description="Call Macro 15" />
+  <macro id="515" versions="5.360 6.000 6.040" description="Remote Base Memory 35" />
+  <macro id="516" versions="5.285" description="Call Macro 16" />
+  <macro id="516" versions="5.360 6.000 6.040" description="Remote Base Memory 36" />
+  <macro id="517" versions="5.285" description="Call Macro 17" />
+  <macro id="517" versions="5.360 6.000 6.040" description="Remote Base Memory 37" />
+  <macro id="518" versions="5.285" description="Call Macro 18" />
+  <macro id="518" versions="5.360 6.000 6.040" description="Remote Base Memory 38" />
+  <macro id="519" versions="5.285" description="Call Macro 19" />
+  <macro id="519" versions="5.360 6.000 6.040" description="Remote Base Memory 39" />
+  <macro id="520" versions="5.285" description="Call Macro 20" />
+  <macro id="520" versions="5.360 6.000 6.040" description="Remote Base Memory 40" />
+  <macro id="521" versions="5.285" description="Call Macro 21" />
+  <macro id="521" versions="5.360 6.000 6.040" description="Send DTMF Memory 21" />
+  <macro id="522" versions="5.285" description="Call Macro 22" />
+  <macro id="522" versions="5.360 6.000 6.040" description="Send DTMF Memory 22" />
+  <macro id="523" versions="5.285" description="Call Macro 23" />
+  <macro id="523" versions="5.360 6.000 6.040" description="Send DTMF Memory 23" />
+  <macro id="524" versions="5.285" description="Call Macro 24" />
+  <macro id="524" versions="5.360 6.000 6.040" description="Send DTMF Memory 24" />
+  <macro id="525" versions="5.285" description="Call Macro 25" />
+  <macro id="525" versions="5.360 6.000 6.040" description="Send DTMF Memory 25" />
+  <macro id="526" versions="5.285" description="Call Macro 26" />
+  <macro id="526" versions="5.360 6.000 6.040" description="Send DTMF Memory 26" />
+  <macro id="527" versions="5.285" description="Call Macro 27" />
+  <macro id="527" versions="5.360 6.000 6.040" description="Send DTMF Memory 27" />
+  <macro id="528" versions="5.285" description="Call Macro 28" />
+  <macro id="528" versions="5.360 6.000 6.040" description="Send DTMF Memory 28" />
+  <macro id="529" versions="5.285" description="Call Macro 29" />
+  <macro id="529" versions="5.360 6.000 6.040" description="Send DTMF Memory 29" />
+  <macro id="530" versions="5.285" description="Call Macro 30" />
+  <macro id="530" versions="5.360 6.000 6.040" description="Send DTMF Memory 30" />
+  <macro id="531" versions="5.285" description="Call Macro 31" />
+  <macro id="531" versions="5.360 6.000 6.040" description="Send DTMF Memory 31" />
+  <macro id="532" versions="5.285" description="Call Macro 32" />
+  <macro id="532" versions="5.360 6.000 6.040" description="Send DTMF Memory 32" />
+  <macro id="533" versions="5.285" description="Call Macro 33" />
+  <macro id="533" versions="5.360 6.000 6.040" description="Send DTMF Memory 33" />
+  <macro id="534" versions="5.285" description="Call Macro 34" />
+  <macro id="534" versions="5.360 6.000 6.040" description="Send DTMF Memory 34" />
+  <macro id="535" versions="5.285" description="Call Macro 35" />
+  <macro id="535" versions="5.360 6.000 6.040" description="Send DTMF Memory 35" />
+  <macro id="536" versions="5.285" description="Call Macro 36" />
+  <macro id="536" versions="5.360 6.000 6.040" description="Send DTMF Memory 36" />
+  <macro id="537" versions="5.285" description="Call Macro 37" />
+  <macro id="537" versions="5.360 6.000 6.040" description="Send DTMF Memory 37" />
+  <macro id="538" versions="5.285" description="Call Macro 38" />
+  <macro id="538" versions="5.360 6.000 6.040" description="Send DTMF Memory 38" />
+  <macro id="539" versions="5.285" description="Call Macro 39" />
+  <macro id="539" versions="5.360 6.000 6.040" description="Send DTMF Memory 39" />
+  <macro id="540" versions="5.285" description="Call Macro 40" />
+  <macro id="540" versions="5.360 6.000 6.040" description="Send DTMF Memory 40" />
+  <macro id="541" versions="5.285" description="Call Macro 41" />
+  <macro id="541" versions="5.360 6.000 6.040" description="Send DTMF Memory 41" />
+  <macro id="542" versions="5.285" description="Call Macro 42" />
+  <macro id="542" versions="5.360 6.000 6.040" description="Send DTMF Memory 42" />
+  <macro id="543" versions="5.285" description="Call Macro 43" />
+  <macro id="543" versions="5.360 6.000 6.040" description="Send DTMF Memory 43" />
+  <macro id="544" versions="5.285" description="Call Macro 44" />
+  <macro id="544" versions="5.360 6.000 6.040" description="Send DTMF Memory 44" />
+  <macro id="545" versions="5.285" description="Call Macro 45" />
+  <macro id="545" versions="5.360 6.000 6.040" description="Send DTMF Memory 45" />
+  <macro id="546" versions="5.285" description="Call Macro 46" />
+  <macro id="546" versions="5.360 6.000 6.040" description="Send DTMF Memory 46" />
+  <macro id="547" versions="5.285" description="Call Macro 47" />
+  <macro id="547" versions="5.360 6.000 6.040" description="Send DTMF Memory 47" />
+  <macro id="548" versions="5.285" description="Call Macro 48" />
+  <macro id="548" versions="5.360 6.000 6.040" description="Send DTMF Memory 48" />
+  <macro id="549" versions="5.285" description="Call Macro 49" />
+  <macro id="549" versions="5.360 6.000 6.040" description="Send DTMF Memory 49" />
+  <macro id="550" versions="5.285" description="Call Macro 50" />
+  <macro id="550" versions="5.360 6.000 6.040" description="Send DTMF Memory 50" />
+  <macro id="551" versions="5.285" description="Call Macro 51" />
+  <macro id="551" versions="5.360 6.000 6.040" description="Get RTC Time and Date" />
+  <macro id="552" versions="5.285" description="Call Macro 52" />
+  <macro id="552" versions="6.000 6.040" description="CTCSS During ID ON" />
+  <macro id="553" versions="5.285" description="Call Macro 53" />
+  <macro id="553" versions="6.000 6.040" description="CTCSS During ID OFF" />
+  <macro id="554" versions="5.285" description="Call Macro 54" />
+  <macro id="555" versions="5.285" description="Call Macro 55" />
+  <macro id="556" versions="5.285" description="Call Macro 56" />
+  <macro id="557" versions="5.285" description="Call Macro 57" />
+  <macro id="558" versions="5.285" description="Call Macro 58" />
+  <macro id="559" versions="5.285" description="Call Macro 59" />
+  <macro id="560" versions="5.285" description="Call Macro 60" />
+  <macro id="560" versions="5.360" description="Suspend Scheduler Setpoint 1" />
+  <macro id="561" versions="5.285" description="Call Macro 61" />
+  <macro id="561" versions="5.360" description="Suspend Scheduler Setpoint 2" />
+  <macro id="561" versions="6.000 6.040" description="Restart Controller" />
+  <macro id="562" versions="5.285" description="Call Macro 62" />
+  <macro id="562" versions="5.360" description="Suspend Scheduler Setpoint 3" />
+  <macro id="563" versions="5.285" description="Call Macro 63" />
+  <macro id="563" versions="5.360" description="Suspend Scheduler Setpoint 4" />
+  <macro id="564" versions="5.285" description="Call Macro 64" />
+  <macro id="564" versions="5.360" description="Suspend Scheduler Setpoint 5" />
+  <macro id="565" versions="5.285" description="Call Macro 65" />
+  <macro id="565" versions="5.360" description="Suspend Scheduler Setpoint 6" />
+  <macro id="566" versions="5.285" description="Call Macro 66" />
+  <macro id="566" versions="5.360" description="Suspend Scheduler Setpoint 7" />
+  <macro id="567" versions="5.285" description="Call Macro 67" />
+  <macro id="567" versions="5.360" description="Suspend Scheduler Setpoint 8" />
+  <macro id="568" versions="5.285" description="Call Macro 68" />
+  <macro id="568" versions="5.360" description="Suspend Scheduler Setpoint 9" />
+  <macro id="569" versions="5.285" description="Call Macro 69" />
+  <macro id="569" versions="5.360" description="Suspend Scheduler Setpoint 10" />
+  <macro id="570" versions="5.285" description="Call Macro 70" />
+  <macro id="570" versions="5.360" description="Suspend Scheduler Setpoint 11" />
+  <macro id="570" versions="6.000 6.040" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="571" versions="5.285" description="Call Macro 71" />
+  <macro id="571" versions="5.360" description="Suspend Scheduler Setpoint 12" />
+  <macro id="571" versions="6.000 6.040" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="572" versions="5.285" description="Call Macro 72" />
+  <macro id="572" versions="5.360" description="Suspend Scheduler Setpoint 13" />
+  <macro id="572" versions="6.000 6.040" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="573" versions="5.285" description="Call Macro 73" />
+  <macro id="573" versions="5.360" description="Suspend Scheduler Setpoint 14" />
+  <macro id="573" versions="6.000 6.040" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="574" versions="5.285" description="Call Macro 74" />
+  <macro id="574" versions="5.360" description="Suspend Scheduler Setpoint 15" />
+  <macro id="574" versions="6.000 6.040" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="575" versions="5.285" description="Call Macro 75" />
+  <macro id="575" versions="5.360" description="Suspend Scheduler Setpoint 16" />
+  <macro id="575" versions="6.000 6.040" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="576" versions="5.285" description="Call Macro 76" />
+  <macro id="576" versions="5.360" description="Suspend Scheduler Setpoint 17" />
+  <macro id="576" versions="6.000 6.040" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="577" versions="5.285" description="Call Macro 77" />
+  <macro id="577" versions="5.360" description="Suspend Scheduler Setpoint 18" />
+  <macro id="577" versions="6.000 6.040" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="578" versions="5.285" description="Call Macro 78" />
+  <macro id="578" versions="5.360" description="Suspend Scheduler Setpoint 19" />
+  <macro id="578" versions="6.000 6.040" description="Readback A/D Channel 1 Stored High" />
+  <macro id="579" versions="5.285" description="Call Macro 79" />
+  <macro id="579" versions="5.360" description="Suspend Scheduler Setpoint 20" />
+  <macro id="579" versions="6.000 6.040" description="Readback A/D Channel 2 Stored High" />
+  <macro id="580" versions="5.285" description="Call Macro 80" />
+  <macro id="580" versions="5.360" description="Resume Scheduler Setpoint 1" />
+  <macro id="580" versions="6.000 6.040" description="Readback A/D Channel 3 Stored High" />
+  <macro id="581" versions="5.285" description="Call Macro 81" />
+  <macro id="581" versions="5.360" description="Resume Scheduler Setpoint 2" />
+  <macro id="581" versions="6.000 6.040" description="Readback A/D Channel 4 Stored High" />
+  <macro id="582" versions="5.285" description="Call Macro 82" />
+  <macro id="582" versions="5.360" description="Resume Scheduler Setpoint 3" />
+  <macro id="582" versions="6.000 6.040" description="Readback A/D Channel 5 Stored High" />
+  <macro id="583" versions="5.285" description="Call Macro 83" />
+  <macro id="583" versions="5.360" description="Resume Scheduler Setpoint 4" />
+  <macro id="583" versions="6.000 6.040" description="Readback A/D Channel 6 Stored High" />
+  <macro id="584" versions="5.285" description="Call Macro 84" />
+  <macro id="584" versions="5.360" description="Resume Scheduler Setpoint 5" />
+  <macro id="584" versions="6.000 6.040" description="Readback A/D Channel 7 Stored High" />
+  <macro id="585" versions="5.285" description="Call Macro 85" />
+  <macro id="585" versions="5.360" description="Resume Scheduler Setpoint 6" />
+  <macro id="585" versions="6.000 6.040" description="Readback A/D Channel 8 Stored High" />
+  <macro id="586" versions="5.285" description="Call Macro 86" />
+  <macro id="586" versions="5.360" description="Resume Scheduler Setpoint 7" />
+  <macro id="586" versions="6.000 6.040" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="5.285" description="Call Macro 87" />
+  <macro id="587" versions="5.360" description="Resume Scheduler Setpoint 8" />
+  <macro id="587" versions="6.000 6.040" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="5.285" description="Call Macro 88" />
+  <macro id="588" versions="5.360" description="Resume Scheduler Setpoint 9" />
+  <macro id="588" versions="6.000 6.040" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="5.285" description="Call Macro 89" />
+  <macro id="589" versions="5.360" description="Resume Scheduler Setpoint 10" />
+  <macro id="589" versions="6.000 6.040" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="5.285" description="Call Macro 90" />
+  <macro id="590" versions="5.360" description="Resume Scheduler Setpoint 11" />
+  <macro id="590" versions="6.000 6.040" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="5.360" description="Resume Scheduler Setpoint 12" />
+  <macro id="591" versions="6.000 6.040" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="592" versions="5.360" description="Resume Scheduler Setpoint 13" />
+  <macro id="592" versions="6.000 6.040" description="Current wind speed and direction" />
+  <macro id="593" versions="5.360" description="Resume Scheduler Setpoint 14" />
+  <macro id="593" versions="6.000 6.040" description="Current Outdoor temperature" />
+  <macro id="594" versions="5.360" description="Resume Scheduler Setpoint 15" />
+  <macro id="594" versions="6.000 6.040" description="Indoor humidity" />
+  <macro id="595" versions="5.360" description="Resume Scheduler Setpoint 16" />
+  <macro id="595" versions="6.000 6.040" description="Outdoor humidity" />
+  <macro id="596" versions="5.360" description="Resume Scheduler Setpoint 17" />
+  <macro id="596" versions="6.000 6.040" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="597" versions="5.360" description="Resume Scheduler Setpoint 18" />
+  <macro id="597" versions="6.000 6.040" description="Outdoor Temp High (since Midnight)" />
+  <macro id="598" versions="5.360" description="Resume Scheduler Setpoint 19" />
+  <macro id="598" versions="6.000 6.040" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="599" versions="5.360" description="Resume Scheduler Setpoint 20" />
+  <macro id="601" versions="5.360" description="Call Macro 1" />
+  <macro id="602" versions="5.360" description="Call Macro 2" />
+  <macro id="603" versions="5.360" description="Call Macro 3" />
+  <macro id="604" versions="5.360" description="Call Macro 4" />
+  <macro id="605" versions="5.360" description="Call Macro 5" />
+  <macro id="605" versions="6.000 6.040" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="606" versions="5.360" description="Call Macro 6" />
+  <macro id="606" versions="6.040" description="Start General Timer 4" />
+  <macro id="607" versions="5.360" description="Call Macro 7" />
+  <macro id="607" versions="6.040" description="Start General Timer 5" />
+  <macro id="608" versions="5.360" description="Call Macro 8" />
+  <macro id="608" versions="6.040" description="Start General Timer 6" />
+  <macro id="609" versions="5.360" description="Call Macro 9" />
+  <macro id="609" versions="6.040" description="Stop General Timer 4" />
+  <macro id="610" versions="5.360" description="Call Macro 10" />
+  <macro id="610" versions="6.040" description="Stop General Timer 5" />
+  <macro id="611" versions="5.360" description="Call Macro 11" />
+  <macro id="611" versions="6.040" description="Stop General Timer 6" />
+  <macro id="612" versions="5.360" description="Call Macro 12" />
+  <macro id="612" versions="6.040" description="Disable Port 1 Inactivity Timer" />
+  <macro id="613" versions="5.360" description="Call Macro 13" />
+  <macro id="613" versions="6.040" description="Disable Port 2 Inactivity Timer" />
+  <macro id="614" versions="5.360" description="Call Macro 14" />
+  <macro id="614" versions="6.040" description="Disable Port 3 Inactivity Timer" />
+  <macro id="615" versions="5.360" description="Call Macro 15" />
+  <macro id="615" versions="6.040" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="5.360" description="Call Macro 16" />
+  <macro id="616" versions="6.040" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="5.360" description="Call Macro 17" />
+  <macro id="617" versions="6.040" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="618" versions="5.360" description="Call Macro 18" />
+  <macro id="618" versions="6.040" description="1 Second Execution Delay" />
+  <macro id="619" versions="5.360" description="Call Macro 19" />
+  <macro id="619" versions="6.040" description="2 Second Execution Delay" />
+  <macro id="620" versions="5.360" description="Call Macro 20" />
+  <macro id="620" versions="6.040" description="4 Second Execution Delay" />
+  <macro id="621" versions="5.360" description="Call Macro 21" />
+  <macro id="622" versions="5.360" description="Call Macro 22" />
+  <macro id="623" versions="5.360" description="Call Macro 23" />
+  <macro id="624" versions="5.360" description="Call Macro 24" />
+  <macro id="625" versions="5.360" description="Call Macro 25" />
+  <macro id="626" versions="5.360" description="Call Macro 26" />
+  <macro id="627" versions="5.360" description="Call Macro 27" />
+  <macro id="628" versions="5.360" description="Call Macro 28" />
+  <macro id="629" versions="5.360" description="Call Macro 29" />
+  <macro id="630" versions="5.360" description="Call Macro 30" />
+  <macro id="631" versions="5.360" description="Call Macro 31" />
+  <macro id="632" versions="5.360" description="Call Macro 32" />
+  <macro id="633" versions="5.360" description="Call Macro 33" />
+  <macro id="634" versions="5.360" description="Call Macro 34" />
+  <macro id="635" versions="5.360" description="Call Macro 35" />
+  <macro id="636" versions="5.360" description="Call Macro 36" />
+  <macro id="637" versions="5.360" description="Call Macro 37" />
+  <macro id="638" versions="5.360" description="Call Macro 38" />
+  <macro id="639" versions="5.360" description="Call Macro 39" />
+  <macro id="640" versions="5.360" description="Call Macro 40" />
+  <macro id="641" versions="5.360" description="Call Macro 41" />
+  <macro id="642" versions="5.360" description="Call Macro 42" />
+  <macro id="643" versions="5.360" description="Call Macro 43" />
+  <macro id="644" versions="5.360" description="Call Macro 44" />
+  <macro id="645" versions="5.360" description="Call Macro 45" />
+  <macro id="646" versions="5.360" description="Call Macro 46" />
+  <macro id="647" versions="5.360" description="Call Macro 47" />
+  <macro id="648" versions="5.360" description="Call Macro 48" />
+  <macro id="649" versions="5.360" description="Call Macro 49" />
+  <macro id="650" versions="5.360" description="Call Macro 50" />
+  <macro id="651" versions="5.360" description="Call Macro 51" />
+  <macro id="652" versions="5.360" description="Call Macro 52" />
+  <macro id="653" versions="5.360" description="Call Macro 53" />
+  <macro id="654" versions="5.360" description="Call Macro 54" />
+  <macro id="655" versions="5.360" description="Call Macro 55" />
+  <macro id="656" versions="5.360" description="Call Macro 56" />
+  <macro id="657" versions="5.360" description="Call Macro 57" />
+  <macro id="658" versions="5.360" description="Call Macro 58" />
+  <macro id="659" versions="5.360" description="Call Macro 59" />
+  <macro id="660" versions="5.360" description="Call Macro 60" />
+  <macro id="660" versions="6.000 6.040" description="Suspend Scheduler Setpoint 1" />
+  <macro id="661" versions="5.360" description="Call Macro 61" />
+  <macro id="661" versions="6.000 6.040" description="Suspend Scheduler Setpoint 2" />
+  <macro id="662" versions="5.360" description="Call Macro 62" />
+  <macro id="662" versions="6.000 6.040" description="Suspend Scheduler Setpoint 3" />
+  <macro id="663" versions="5.360" description="Call Macro 63" />
+  <macro id="663" versions="6.000 6.040" description="Suspend Scheduler Setpoint 4" />
+  <macro id="664" versions="5.360" description="Call Macro 64" />
+  <macro id="664" versions="6.000 6.040" description="Suspend Scheduler Setpoint 5" />
+  <macro id="665" versions="5.360" description="Call Macro 65" />
+  <macro id="665" versions="6.000 6.040" description="Suspend Scheduler Setpoint 6" />
+  <macro id="666" versions="5.360" description="Call Macro 66" />
+  <macro id="666" versions="6.000 6.040" description="Suspend Scheduler Setpoint 7" />
+  <macro id="667" versions="5.360" description="Call Macro 67" />
+  <macro id="667" versions="6.000 6.040" description="Suspend Scheduler Setpoint 8" />
+  <macro id="668" versions="5.360" description="Call Macro 68" />
+  <macro id="668" versions="6.000 6.040" description="Suspend Scheduler Setpoint 9" />
+  <macro id="669" versions="5.360" description="Call Macro 69" />
+  <macro id="669" versions="6.000 6.040" description="Suspend Scheduler Setpoint 10" />
+  <macro id="670" versions="5.360" description="Call Macro 70" />
+  <macro id="670" versions="6.000 6.040" description="Suspend Scheduler Setpoint 11" />
+  <macro id="671" versions="5.360" description="Call Macro 71" />
+  <macro id="671" versions="6.000 6.040" description="Suspend Scheduler Setpoint 12" />
+  <macro id="672" versions="5.360" description="Call Macro 72" />
+  <macro id="672" versions="6.000 6.040" description="Suspend Scheduler Setpoint 13" />
+  <macro id="673" versions="5.360" description="Call Macro 73" />
+  <macro id="673" versions="6.000 6.040" description="Suspend Scheduler Setpoint 14" />
+  <macro id="674" versions="5.360" description="Call Macro 74" />
+  <macro id="674" versions="6.000 6.040" description="Suspend Scheduler Setpoint 15" />
+  <macro id="675" versions="5.360" description="Call Macro 75" />
+  <macro id="675" versions="6.000 6.040" description="Suspend Scheduler Setpoint 16" />
+  <macro id="676" versions="5.360" description="Call Macro 76" />
+  <macro id="676" versions="6.000 6.040" description="Suspend Scheduler Setpoint 17" />
+  <macro id="677" versions="5.360" description="Call Macro 77" />
+  <macro id="677" versions="6.000 6.040" description="Suspend Scheduler Setpoint 18" />
+  <macro id="678" versions="5.360" description="Call Macro 78" />
+  <macro id="678" versions="6.000 6.040" description="Suspend Scheduler Setpoint 19" />
+  <macro id="679" versions="5.360" description="Call Macro 79" />
+  <macro id="679" versions="6.000 6.040" description="Suspend Scheduler Setpoint 20" />
+  <macro id="680" versions="5.360" description="Call Macro 80" />
+  <macro id="680" versions="6.000 6.040" description="Resume Scheduler Setpoint 1" />
+  <macro id="681" versions="5.360" description="Call Macro 81" />
+  <macro id="681" versions="6.000 6.040" description="Resume Scheduler Setpoint 2" />
+  <macro id="682" versions="5.360" description="Call Macro 82" />
+  <macro id="682" versions="6.000 6.040" description="Resume Scheduler Setpoint 3" />
+  <macro id="683" versions="5.360" description="Call Macro 83" />
+  <macro id="683" versions="6.000 6.040" description="Resume Scheduler Setpoint 4" />
+  <macro id="684" versions="5.360" description="Call Macro 84" />
+  <macro id="684" versions="6.000 6.040" description="Resume Scheduler Setpoint 5" />
+  <macro id="685" versions="5.360" description="Call Macro 85" />
+  <macro id="685" versions="6.000 6.040" description="Resume Scheduler Setpoint 6" />
+  <macro id="686" versions="5.360" description="Call Macro 86" />
+  <macro id="686" versions="6.000 6.040" description="Resume Scheduler Setpoint 7" />
+  <macro id="687" versions="5.360" description="Call Macro 87" />
+  <macro id="687" versions="6.000 6.040" description="Resume Scheduler Setpoint 8" />
+  <macro id="688" versions="5.360" description="Call Macro 88" />
+  <macro id="688" versions="6.000 6.040" description="Resume Scheduler Setpoint 9" />
+  <macro id="689" versions="5.360" description="Call Macro 89" />
+  <macro id="689" versions="6.000 6.040" description="Resume Scheduler Setpoint 10" />
+  <macro id="690" versions="5.360" description="Call Macro 90" />
+  <macro id="690" versions="6.000 6.040" description="Resume Scheduler Setpoint 11" />
+  <macro id="691" versions="6.000 6.040" description="Resume Scheduler Setpoint 12" />
+  <macro id="692" versions="6.000 6.040" description="Resume Scheduler Setpoint 13" />
+  <macro id="693" versions="6.000 6.040" description="Resume Scheduler Setpoint 14" />
+  <macro id="694" versions="6.000 6.040" description="Resume Scheduler Setpoint 15" />
+  <macro id="695" versions="6.000 6.040" description="Resume Scheduler Setpoint 16" />
+  <macro id="696" versions="6.000 6.040" description="Resume Scheduler Setpoint 17" />
+  <macro id="697" versions="6.000 6.040" description="Resume Scheduler Setpoint 18" />
+  <macro id="698" versions="6.000 6.040" description="Resume Scheduler Setpoint 19" />
+  <macro id="699" versions="6.000 6.040" description="Resume Scheduler Setpoint 20" />
+  <macro id="701" versions="6.000 6.040" description="Call Macro 1" />
+  <macro id="702" versions="6.000 6.040" description="Call Macro 2" />
+  <macro id="703" versions="6.000 6.040" description="Call Macro 3" />
+  <macro id="704" versions="6.000 6.040" description="Call Macro 4" />
+  <macro id="705" versions="6.000 6.040" description="Call Macro 5" />
+  <macro id="706" versions="6.000 6.040" description="Call Macro 6" />
+  <macro id="707" versions="6.000 6.040" description="Call Macro 7" />
+  <macro id="708" versions="6.000 6.040" description="Call Macro 8" />
+  <macro id="709" versions="6.000 6.040" description="Call Macro 9" />
+  <macro id="710" versions="6.000 6.040" description="Call Macro 10" />
+  <macro id="711" versions="6.000 6.040" description="Call Macro 11" />
+  <macro id="712" versions="6.000 6.040" description="Call Macro 12" />
+  <macro id="713" versions="6.000 6.040" description="Call Macro 13" />
+  <macro id="714" versions="6.000 6.040" description="Call Macro 14" />
+  <macro id="715" versions="6.000 6.040" description="Call Macro 15" />
+  <macro id="716" versions="6.000 6.040" description="Call Macro 16" />
+  <macro id="717" versions="6.000 6.040" description="Call Macro 17" />
+  <macro id="718" versions="6.000 6.040" description="Call Macro 18" />
+  <macro id="719" versions="6.000 6.040" description="Call Macro 19" />
+  <macro id="720" versions="6.000 6.040" description="Call Macro 20" />
+  <macro id="721" versions="6.000 6.040" description="Call Macro 21" />
+  <macro id="722" versions="6.000 6.040" description="Call Macro 22" />
+  <macro id="723" versions="6.000 6.040" description="Call Macro 23" />
+  <macro id="724" versions="6.000 6.040" description="Call Macro 24" />
+  <macro id="725" versions="6.000 6.040" description="Call Macro 25" />
+  <macro id="726" versions="6.000 6.040" description="Call Macro 26" />
+  <macro id="727" versions="6.000 6.040" description="Call Macro 27" />
+  <macro id="728" versions="6.000 6.040" description="Call Macro 28" />
+  <macro id="729" versions="6.000 6.040" description="Call Macro 29" />
+  <macro id="730" versions="6.000 6.040" description="Call Macro 30" />
+  <macro id="731" versions="6.000 6.040" description="Call Macro 31" />
+  <macro id="732" versions="6.000 6.040" description="Call Macro 32" />
+  <macro id="733" versions="6.000 6.040" description="Call Macro 33" />
+  <macro id="734" versions="6.000 6.040" description="Call Macro 34" />
+  <macro id="735" versions="6.000 6.040" description="Call Macro 35" />
+  <macro id="736" versions="6.000 6.040" description="Call Macro 36" />
+  <macro id="737" versions="6.000 6.040" description="Call Macro 37" />
+  <macro id="738" versions="6.000 6.040" description="Call Macro 38" />
+  <macro id="739" versions="6.000 6.040" description="Call Macro 39" />
+  <macro id="740" versions="6.000 6.040" description="Call Macro 40" />
+  <macro id="741" versions="6.000 6.040" description="Call Macro 41" />
+  <macro id="742" versions="6.000 6.040" description="Call Macro 42" />
+  <macro id="743" versions="6.000 6.040" description="Call Macro 43" />
+  <macro id="744" versions="6.000 6.040" description="Call Macro 44" />
+  <macro id="745" versions="6.000 6.040" description="Call Macro 45" />
+  <macro id="746" versions="6.000 6.040" description="Call Macro 46" />
+  <macro id="747" versions="6.000 6.040" description="Call Macro 47" />
+  <macro id="748" versions="6.000 6.040" description="Call Macro 48" />
+  <macro id="749" versions="6.000 6.040" description="Call Macro 49" />
+  <macro id="750" versions="6.000 6.040" description="Call Macro 50" />
+  <macro id="751" versions="6.000 6.040" description="Call Macro 51" />
+  <macro id="752" versions="6.000 6.040" description="Call Macro 52" />
+  <macro id="753" versions="6.000 6.040" description="Call Macro 53" />
+  <macro id="754" versions="6.000 6.040" description="Call Macro 54" />
+  <macro id="755" versions="6.000 6.040" description="Call Macro 55" />
+  <macro id="756" versions="6.000 6.040" description="Call Macro 56" />
+  <macro id="757" versions="6.000 6.040" description="Call Macro 57" />
+  <macro id="758" versions="6.000 6.040" description="Call Macro 58" />
+  <macro id="759" versions="6.000 6.040" description="Call Macro 59" />
+  <macro id="760" versions="6.000 6.040" description="Call Macro 60" />
+  <macro id="761" versions="6.000 6.040" description="Call Macro 61" />
+  <macro id="762" versions="6.000 6.040" description="Call Macro 62" />
+  <macro id="763" versions="6.000 6.040" description="Call Macro 63" />
+  <macro id="764" versions="6.000 6.040" description="Call Macro 64" />
+  <macro id="766" versions="6.000 6.040" description="Call Macro 65" />
+  <macro id="767" versions="6.000 6.040" description="Call Macro 66" />
+  <macro id="768" versions="6.000 6.040" description="Call Macro 67" />
+  <macro id="769" versions="6.000 6.040" description="Call Macro 68" />
+  <macro id="770" versions="6.000 6.040" description="Call Macro 69" />
+  <macro id="771" versions="6.000 6.040" description="Call Macro 70" />
+  <macro id="772" versions="6.000 6.040" description="Call Macro 71" />
+  <macro id="773" versions="6.000 6.040" description="Call Macro 72" />
+  <macro id="774" versions="6.000 6.040" description="Call Macro 73" />
+  <macro id="775" versions="6.000 6.040" description="Call Macro 74" />
+  <macro id="776" versions="6.000 6.040" description="Call Macro 75" />
+  <macro id="777" versions="6.000 6.040" description="Call Macro 76" />
+  <macro id="778" versions="6.000 6.040" description="Call Macro 77" />
+  <macro id="779" versions="6.000 6.040" description="Call Macro 78" />
+  <macro id="780" versions="6.000 6.040" description="Call Macro 79" />
+  <macro id="781" versions="6.000 6.040" description="Call Macro 80" />
+  <macro id="782" versions="6.000 6.040" description="Call Macro 81" />
+  <macro id="783" versions="6.000 6.040" description="Call Macro 82" />
+  <macro id="784" versions="6.000 6.040" description="Call Macro 83" />
+  <macro id="785" versions="6.000 6.040" description="Call Macro 84" />
+  <macro id="786" versions="6.000 6.040" description="Call Macro 85" />
+  <macro id="787" versions="6.000 6.040" description="Call Macro 86" />
+  <macro id="788" versions="6.000 6.040" description="Call Macro 87" />
+  <macro id="789" versions="6.000 6.040" description="Call Macro 88" />
+  <macro id="790" versions="6.000 6.040" description="Call Macro 89" />
+  <macro id="791" versions="6.000 6.040" description="Call Macro 90" />
+</macros>

--- a/XML/Ver5_6_macro_def.xml
+++ b/XML/Ver5_6_macro_def.xml
@@ -1,880 +1,880 @@
 <macros version="1.003">
-  <macro id="001" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 CTCSS Access" />
-  <macro id="002" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 CTCSS Access" />
-  <macro id="003" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 CTCSS Access" />
-  <macro id="004" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Carrier Access" />
-  <macro id="005" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Carrier Access" />
-  <macro id="006" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Carrier Access" />
-  <macro id="007" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Covertone ON" />
-  <macro id="008" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Covertone ON" />
-  <macro id="009" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Covertone ON" />
-  <macro id="010" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Covertone OFF" />
-  <macro id="011" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Covertone OFF" />
-  <macro id="012" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Covertone OFF" />
-  <macro id="013" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Enable" />
-  <macro id="014" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Enable" />
-  <macro id="015" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Enable" />
-  <macro id="016" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Disable" />
-  <macro id="017" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Disable" />
-  <macro id="018" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Disable" />
-  <macro id="019" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 1 from Port 2" />
-  <macro id="020" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 1 from Port 3" />
-  <macro id="021" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 1 from Port 2" />
-  <macro id="022" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 1 from Port 3" />
-  <macro id="023" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 2 from Port 1" />
-  <macro id="024" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 2 from Port 3" />
-  <macro id="025" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 2 from Port 1" />
-  <macro id="026" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 2 from Port 3" />
-  <macro id="027" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 3 from Port 1" />
-  <macro id="028" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 3 from Port 2" />
-  <macro id="029" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 3 from Port 1" />
-  <macro id="030" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 3 from Port 2" />
-  <macro id="031" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Monitor Mute" />
-  <macro id="032" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Monitor Mute" />
-  <macro id="033" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Monitor Mute" />
-  <macro id="034" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Monitor Mix" />
-  <macro id="035" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Monitor Mix" />
-  <macro id="036" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Monitor Mix" />
-  <macro id="037" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Repeat ON" />
-  <macro id="038" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Repeat ON" />
-  <macro id="039" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Repeat ON" />
-  <macro id="040" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Repeat OFF" />
-  <macro id="041" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Repeat OFF" />
-  <macro id="042" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Repeat OFF" />
-  <macro id="043" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech OverrideON" />
-  <macro id="044" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech OverrideON" />
-  <macro id="045" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech OverrideON" />
-  <macro id="046" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech Override OFF" />
-  <macro id="047" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech Override OFF" />
-  <macro id="048" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech Override OFF" />
-  <macro id="049" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 1" />
-  <macro id="050" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 2" />
-  <macro id="051" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 3" />
-  <macro id="052" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 4" />
-  <macro id="053" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 5" />
-  <macro id="054" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 6" />
-  <macro id="055" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 7" />
-  <macro id="056" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 8" />
-  <macro id="057" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 9" />
-  <macro id="058" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 10" />
-  <macro id="059" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 1" />
-  <macro id="060" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 2" />
-  <macro id="061" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 3" />
-  <macro id="062" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 4" />
-  <macro id="063" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 5" />
-  <macro id="064" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 6" />
-  <macro id="065" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 7" />
-  <macro id="066" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 8" />
-  <macro id="067" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 9" />
-  <macro id="068" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 10" />
-  <macro id="069" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 1" />
-  <macro id="070" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 2" />
-  <macro id="071" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 3" />
-  <macro id="072" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 4" />
-  <macro id="073" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 5" />
-  <macro id="074" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 6" />
-  <macro id="075" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 7" />
-  <macro id="076" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 8" />
-  <macro id="077" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 9" />
-  <macro id="078" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 10" />
-  <macro id="079" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Muting ON" />
-  <macro id="080" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Muting ON" />
-  <macro id="081" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Muting ON" />
-  <macro id="082" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Muting OFF" />
-  <macro id="083" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Muting OFF" />
-  <macro id="084" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Muting OFF" />
-  <macro id="085" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode ON (for the duration of this Macro)" />
-  <macro id="086" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode OFF (for the duration of this Macro)" />
-  <macro id="087" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 1" />
-  <macro id="088" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 2" />
-  <macro id="089" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 3" />
-  <macro id="090" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 4" />
-  <macro id="091" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 5" />
-  <macro id="092" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 6" />
-  <macro id="093" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 7" />
-  <macro id="094" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 8" />
-  <macro id="095" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 ON" />
-  <macro id="096" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 ON" />
-  <macro id="097" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 ON" />
-  <macro id="098" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 ON" />
-  <macro id="099" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 ON" />
-  <macro id="100" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 ON" />
-  <macro id="101" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 ON" />
-  <macro id="102" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 OFF" />
-  <macro id="103" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 OFF" />
-  <macro id="104" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 OFF" />
-  <macro id="105" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 OFF" />
-  <macro id="106" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 OFF" />
-  <macro id="107" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 OFF" />
-  <macro id="108" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 OFF" />
-  <macro id="109" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 Pulse" />
-  <macro id="110" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 Pulse" />
-  <macro id="111" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 Pulse" />
-  <macro id="112" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 Pulse" />
-  <macro id="113" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 Pulse" />
-  <macro id="114" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 Pulse" />
-  <macro id="115" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 Pulse" />
-  <macro id="116" versions="5.281 5.285 5.360 6.000 6.040" description="Say Time" />
-  <macro id="117" versions="5.281 5.285 5.360 6.000 6.040" description="Say Date" />
-  <macro id="118" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 1 to Port 2" />
-  <macro id="119" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 1 to Port 3" />
-  <macro id="120" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 2 to Port 3" />
-  <macro id="121" versions="5.281 5.285 5.360 6.000 6.040" description="Link All Ports" />
-  <macro id="122" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 1 from Port 2" />
-  <macro id="123" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 1 from Port 3" />
-  <macro id="124" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 2 from Port 3" />
-  <macro id="125" versions="5.281 5.285 5.360 6.000 6.040" description="UnLink All Ports" />
-  <macro id="126" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 1" />
-  <macro id="127" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 2" />
-  <macro id="128" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 3" />
-  <macro id="129" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 4" />
-  <macro id="130" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 5" />
-  <macro id="131" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 6" />
-  <macro id="132" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 7" />
-  <macro id="133" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 8" />
-  <macro id="134" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 9" />
-  <macro id="135" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 10" />
-  <macro id="136" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 11" />
-  <macro id="137" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 12" />
-  <macro id="138" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 13" />
-  <macro id="139" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 14" />
-  <macro id="140" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 15" />
-  <macro id="141" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 16" />
-  <macro id="142" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 17" />
-  <macro id="143" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 18" />
-  <macro id="144" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 19" />
-  <macro id="145" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 20" />
-  <macro id="146" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 1 ON" />
-  <macro id="147" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 2 ON" />
-  <macro id="148" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 3 ON" />
-  <macro id="149" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 1 OFF" />
-  <macro id="150" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 2 OFF" />
-  <macro id="151" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 3 OFF" />
-  <macro id="152" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 1 ON" />
-  <macro id="153" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 2 ON" />
-  <macro id="154" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 3 ON" />
-  <macro id="155" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 4 ON" />
-  <macro id="156" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 5 ON" />
-  <macro id="157" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 1 OFF" />
-  <macro id="158" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 2 OFF" />
-  <macro id="159" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 3 OFF" />
-  <macro id="160" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 4 OFF" />
-  <macro id="161" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 5 OFF" />
-  <macro id="162" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 1" />
-  <macro id="163" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 2" />
-  <macro id="164" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 3" />
-  <macro id="165" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 1 and 2" />
-  <macro id="166" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 1 and 3" />
-  <macro id="167" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 2 and 3" />
-  <macro id="168" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out All Ports" />
-  <macro id="169" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 1" />
-  <macro id="170" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 2" />
-  <macro id="171" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 3" />
-  <macro id="172" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 1" />
-  <macro id="173" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 2" />
-  <macro id="174" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 3" />
-  <macro id="175" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 1" />
-  <macro id="176" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 2" />
-  <macro id="177" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 3" />
-  <macro id="178" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 1" />
-  <macro id="179" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 2" />
-  <macro id="180" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 3" />
-  <macro id="181" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 1" />
-  <macro id="182" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 2" />
-  <macro id="183" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 3" />
-  <macro id="184" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 1" />
-  <macro id="185" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 2" />
-  <macro id="186" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 3" />
-  <macro id="187" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 1" />
-  <macro id="188" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 2" />
-  <macro id="189" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 3" />
-  <macro id="190" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 4" />
-  <macro id="191" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 5" />
-  <macro id="192" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 6" />
-  <macro id="193" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 7" />
-  <macro id="194" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 8" />
-  <macro id="195" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 9" />
-  <macro id="196" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 10" />
-  <macro id="197" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 11" />
-  <macro id="198" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 12" />
-  <macro id="199" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 13" />
-  <macro id="200" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 14" />
-  <macro id="201" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 15" />
-  <macro id="202" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 16" />
-  <macro id="203" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 17" />
-  <macro id="204" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 18" />
-  <macro id="205" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 19" />
-  <macro id="206" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 20" />
-  <macro id="207" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 21" />
-  <macro id="208" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 22" />
-  <macro id="209" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 23" />
-  <macro id="210" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 24" />
-  <macro id="211" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 25" />
-  <macro id="212" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 26" />
-  <macro id="213" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 27" />
-  <macro id="214" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 28" />
-  <macro id="215" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 29" />
-  <macro id="216" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 30" />
-  <macro id="217" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 31" />
-  <macro id="218" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 32" />
-  <macro id="219" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 33" />
-  <macro id="220" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 34" />
-  <macro id="221" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 35" />
-  <macro id="222" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 36" />
-  <macro id="223" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 37" />
-  <macro id="224" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 38" />
-  <macro id="225" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 39" />
-  <macro id="226" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 40" />
-  <macro id="227" versions="5.281 5.285 5.360 6.000 6.040" description="Good Morning/Afternoon/Evening Runtime Variable" />
-  <macro id="228" versions="5.281 5.285 5.360 6.000 6.040" description="Macro Priority High" />
-  <macro id="229" versions="5.281 5.285 5.360 6.000 6.040" description="Macro Priority Low" />
-  <macro id="230" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 1" />
-  <macro id="231" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 2" />
-  <macro id="232" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 3" />
-  <macro id="233" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 1" />
-  <macro id="234" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 2" />
-  <macro id="235" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 3" />
-  <macro id="236" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 1" />
-  <macro id="237" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 2" />
-  <macro id="238" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 3" />
-  <macro id="239" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 1" />
-  <macro id="240" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 2" />
-  <macro id="241" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 3" />
-  <macro id="242" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech ID Override ON" />
-  <macro id="243" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech ID Override ON" />
-  <macro id="244" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech ID Override ON" />
-  <macro id="245" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech ID Override OFF" />
-  <macro id="246" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech ID Override OFF" />
-  <macro id="247" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech ID Override OFF" />
-  <macro id="248" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 1" />
-  <macro id="249" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 2" />
-  <macro id="250" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 3" />
-  <macro id="251" versions="5.281 5.285 5.360 6.000 6.040" description="Force Audio To Entered Port" />
-  <macro id="252" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 1" />
-  <macro id="253" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 2" />
-  <macro id="254" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 3" />
-  <macro id="256" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 1" />
-  <macro id="257" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 2" />
-  <macro id="258" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 3" />
-  <macro id="259" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 1" />
-  <macro id="260" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 2" />
-  <macro id="261" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 3" />
-  <macro id="262" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 4" />
-  <macro id="263" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 5" />
-  <macro id="264" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 6" />
-  <macro id="265" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 7" />
-  <macro id="266" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 8" />
-  <macro id="267" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 9" />
-  <macro id="268" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 10" />
-  <macro id="269" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 11" />
-  <macro id="270" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 12" />
-  <macro id="271" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 13" />
-  <macro id="272" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 14" />
-  <macro id="273" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 15" />
-  <macro id="274" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 16" />
-  <macro id="275" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 17" />
-  <macro id="276" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 18" />
-  <macro id="277" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 19" />
-  <macro id="278" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 20" />
-  <macro id="279" versions="5.281 5.285 5.360 6.000 6.040" description="Clear All Meter Hi/Low Trippoints" />
-  <macro id="280" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 1 Hi/Low Trippoint" />
-  <macro id="281" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 2 Hi/Low Trippoint" />
-  <macro id="282" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 3 Hi/Low Trippoint" />
-  <macro id="283" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 4 Hi/Low Trippoint" />
-  <macro id="284" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 5 Hi/Low Trippoint" />
-  <macro id="285" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 6 Hi/Low Trippoint" />
-  <macro id="286" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 7 Hi/Low Trippoint" />
-  <macro id="287" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 8 Hi/Low Trippoint" />
-  <macro id="288" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 1 Alarm" />
-  <macro id="289" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 2 Alarm" />
-  <macro id="290" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 3 Alarm" />
-  <macro id="291" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 4 Alarm" />
-  <macro id="292" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 5 Alarm" />
-  <macro id="293" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 6 Alarm" />
-  <macro id="294" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 7 Alarm" />
-  <macro id="295" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 8 Alarm" />
-  <macro id="296" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 1 Alarm" />
-  <macro id="297" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 2 Alarm" />
-  <macro id="298" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 3 Alarm" />
-  <macro id="299" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 4 Alarm" />
-  <macro id="300" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 5 Alarm" />
-  <macro id="301" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 6 Alarm" />
-  <macro id="302" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 7 Alarm" />
-  <macro id="303" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 8 Alarm" />
-  <macro id="304" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode Force OFF" />
-  <macro id="305" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode to Programmed Value" />
-  <macro id="306" versions="5.281 5.285 5.360 6.000 6.040" description="Bump Clock By Correction Factor" />
-  <macro id="307" versions="5.281 5.285 5.360 6.000 6.040" description="Say year as part of date" />
-  <macro id="308" versions="5.281 5.285 5.360 6.000 6.040" description="Don't say year as part of date" />
-  <macro id="309" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message OFF" />
-  <macro id="310" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message OFF" />
-  <macro id="311" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message OFF" />
-  <macro id="312" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 1" />
-  <macro id="313" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 1" />
-  <macro id="314" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 1" />
-  <macro id="315" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 2" />
-  <macro id="316" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 2" />
-  <macro id="317" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 2" />
-  <macro id="318" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 3" />
-  <macro id="319" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 3" />
-  <macro id="320" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 3" />
-  <macro id="321" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 1" />
-  <macro id="322" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 2" />
-  <macro id="323" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 3" />
-  <macro id="324" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 4" />
-  <macro id="325" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 5" />
-  <macro id="326" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 6" />
-  <macro id="327" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 7" />
-  <macro id="328" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 8" />
-  <macro id="329" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 9" />
-  <macro id="330" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 10" />
-  <macro id="331" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Zero Hang Time Select" />
-  <macro id="332" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Zero Hang Time Select" />
-  <macro id="333" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Zero Hang Time Select" />
-  <macro id="334" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Hang Time Revert to Programmed Value" />
-  <macro id="335" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Hang Time Revert to Programmed Value" />
-  <macro id="336" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Hang Time Revert to Programmed Value" />
-  <macro id="337" versions="5.281 5.285 5.360 6.000 6.040" description="Allow Autopatch from programmed Ports" />
-  <macro id="338" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Autopatch" />
-  <macro id="339" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 1" />
-  <macro id="340" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 2" />
-  <macro id="341" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 3" />
-  <macro id="342" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 1" />
-  <macro id="343" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 2" />
-  <macro id="344" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 3" />
-  <macro id="345" versions="5.281 5.285 5.360 6.000 6.040" description="User DVR Record test, erase after auto playback" />
-  <macro id="346" versions="5.281 5.285 5.360 6.000 6.040" description="User DVR Record test, don't erase after auto playback" />
-  <macro id="347" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 1" />
-  <macro id="348" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 2" />
-  <macro id="349" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 3" />
-  <macro id="350" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 1" />
+  <macro id="001" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 CTCSS Access" />
+  <macro id="002" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 CTCSS Access" />
+  <macro id="003" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 CTCSS Access" />
+  <macro id="004" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Carrier Access" />
+  <macro id="005" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Carrier Access" />
+  <macro id="006" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Carrier Access" />
+  <macro id="007" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 DTMF Covertone ON" />
+  <macro id="008" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 DTMF Covertone ON" />
+  <macro id="009" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 DTMF Covertone ON" />
+  <macro id="010" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 DTMF Covertone OFF" />
+  <macro id="011" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 DTMF Covertone OFF" />
+  <macro id="012" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 DTMF Covertone OFF" />
+  <macro id="013" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Enable" />
+  <macro id="014" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Enable" />
+  <macro id="015" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Enable" />
+  <macro id="016" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Disable" />
+  <macro id="017" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Disable" />
+  <macro id="018" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Disable" />
+  <macro id="019" versions="5.281 5.285 5.360 6.000 6.045" description="Monitor Port 1 from Port 2" />
+  <macro id="020" versions="5.281 5.285 5.360 6.000 6.045" description="Monitor Port 1 from Port 3" />
+  <macro id="021" versions="5.281 5.285 5.360 6.000 6.045" description="Disconnect Port 1 from Port 2" />
+  <macro id="022" versions="5.281 5.285 5.360 6.000 6.045" description="Disconnect Port 1 from Port 3" />
+  <macro id="023" versions="5.281 5.285 5.360 6.000 6.045" description="Monitor Port 2 from Port 1" />
+  <macro id="024" versions="5.281 5.285 5.360 6.000 6.045" description="Monitor Port 2 from Port 3" />
+  <macro id="025" versions="5.281 5.285 5.360 6.000 6.045" description="Disconnect Port 2 from Port 1" />
+  <macro id="026" versions="5.281 5.285 5.360 6.000 6.045" description="Disconnect Port 2 from Port 3" />
+  <macro id="027" versions="5.281 5.285 5.360 6.000 6.045" description="Monitor Port 3 from Port 1" />
+  <macro id="028" versions="5.281 5.285 5.360 6.000 6.045" description="Monitor Port 3 from Port 2" />
+  <macro id="029" versions="5.281 5.285 5.360 6.000 6.045" description="Disconnect Port 3 from Port 1" />
+  <macro id="030" versions="5.281 5.285 5.360 6.000 6.045" description="Disconnect Port 3 from Port 2" />
+  <macro id="031" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Monitor Mute" />
+  <macro id="032" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Monitor Mute" />
+  <macro id="033" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Monitor Mute" />
+  <macro id="034" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Monitor Mix" />
+  <macro id="035" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Monitor Mix" />
+  <macro id="036" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Monitor Mix" />
+  <macro id="037" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Repeat ON" />
+  <macro id="038" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Repeat ON" />
+  <macro id="039" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Repeat ON" />
+  <macro id="040" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Repeat OFF" />
+  <macro id="041" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Repeat OFF" />
+  <macro id="042" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Repeat OFF" />
+  <macro id="043" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Speech OverrideON" />
+  <macro id="044" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Speech OverrideON" />
+  <macro id="045" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Speech OverrideON" />
+  <macro id="046" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Speech Override OFF" />
+  <macro id="047" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Speech Override OFF" />
+  <macro id="048" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Speech Override OFF" />
+  <macro id="049" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 1" />
+  <macro id="050" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 2" />
+  <macro id="051" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 3" />
+  <macro id="052" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 4" />
+  <macro id="053" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 5" />
+  <macro id="054" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 6" />
+  <macro id="055" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 7" />
+  <macro id="056" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 8" />
+  <macro id="057" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 9" />
+  <macro id="058" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Courtesy Tone 10" />
+  <macro id="059" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 1" />
+  <macro id="060" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 2" />
+  <macro id="061" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 3" />
+  <macro id="062" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 4" />
+  <macro id="063" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 5" />
+  <macro id="064" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 6" />
+  <macro id="065" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 7" />
+  <macro id="066" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 8" />
+  <macro id="067" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 9" />
+  <macro id="068" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Courtesy Tone 10" />
+  <macro id="069" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 1" />
+  <macro id="070" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 2" />
+  <macro id="071" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 3" />
+  <macro id="072" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 4" />
+  <macro id="073" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 5" />
+  <macro id="074" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 6" />
+  <macro id="075" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 7" />
+  <macro id="076" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 8" />
+  <macro id="077" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 9" />
+  <macro id="078" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Courtesy Tone 10" />
+  <macro id="079" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 DTMF Muting ON" />
+  <macro id="080" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 DTMF Muting ON" />
+  <macro id="081" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 DTMF Muting ON" />
+  <macro id="082" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 DTMF Muting OFF" />
+  <macro id="083" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 DTMF Muting OFF" />
+  <macro id="084" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 DTMF Muting OFF" />
+  <macro id="085" versions="5.281 5.285 5.360 6.000 6.045" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="086" versions="5.281 5.285 5.360 6.000 6.045" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="087" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 1" />
+  <macro id="088" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 2" />
+  <macro id="089" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 3" />
+  <macro id="090" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 4" />
+  <macro id="091" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 5" />
+  <macro id="092" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 6" />
+  <macro id="093" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 7" />
+  <macro id="094" versions="5.281 5.285 5.360 6.000 6.045" description="Read ADC Channel 8" />
+  <macro id="095" versions="5.281 5.285 5.360 6.000 6.045" description="UF1 ON" />
+  <macro id="096" versions="5.281 5.285 5.360 6.000 6.045" description="UF2 ON" />
+  <macro id="097" versions="5.281 5.285 5.360 6.000 6.045" description="UF3 ON" />
+  <macro id="098" versions="5.281 5.285 5.360 6.000 6.045" description="UF4 ON" />
+  <macro id="099" versions="5.281 5.285 5.360 6.000 6.045" description="UF5 ON" />
+  <macro id="100" versions="5.281 5.285 5.360 6.000 6.045" description="UF6 ON" />
+  <macro id="101" versions="5.281 5.285 5.360 6.000 6.045" description="UF7 ON" />
+  <macro id="102" versions="5.281 5.285 5.360 6.000 6.045" description="UF1 OFF" />
+  <macro id="103" versions="5.281 5.285 5.360 6.000 6.045" description="UF2 OFF" />
+  <macro id="104" versions="5.281 5.285 5.360 6.000 6.045" description="UF3 OFF" />
+  <macro id="105" versions="5.281 5.285 5.360 6.000 6.045" description="UF4 OFF" />
+  <macro id="106" versions="5.281 5.285 5.360 6.000 6.045" description="UF5 OFF" />
+  <macro id="107" versions="5.281 5.285 5.360 6.000 6.045" description="UF6 OFF" />
+  <macro id="108" versions="5.281 5.285 5.360 6.000 6.045" description="UF7 OFF" />
+  <macro id="109" versions="5.281 5.285 5.360 6.000 6.045" description="UF1 Pulse" />
+  <macro id="110" versions="5.281 5.285 5.360 6.000 6.045" description="UF2 Pulse" />
+  <macro id="111" versions="5.281 5.285 5.360 6.000 6.045" description="UF3 Pulse" />
+  <macro id="112" versions="5.281 5.285 5.360 6.000 6.045" description="UF4 Pulse" />
+  <macro id="113" versions="5.281 5.285 5.360 6.000 6.045" description="UF5 Pulse" />
+  <macro id="114" versions="5.281 5.285 5.360 6.000 6.045" description="UF6 Pulse" />
+  <macro id="115" versions="5.281 5.285 5.360 6.000 6.045" description="UF7 Pulse" />
+  <macro id="116" versions="5.281 5.285 5.360 6.000 6.045" description="Say Time" />
+  <macro id="117" versions="5.281 5.285 5.360 6.000 6.045" description="Say Date" />
+  <macro id="118" versions="5.281 5.285 5.360 6.000 6.045" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="5.281 5.285 5.360 6.000 6.045" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="5.281 5.285 5.360 6.000 6.045" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="5.281 5.285 5.360 6.000 6.045" description="Link All Ports" />
+  <macro id="122" versions="5.281 5.285 5.360 6.000 6.045" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="5.281 5.285 5.360 6.000 6.045" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="5.281 5.285 5.360 6.000 6.045" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="5.281 5.285 5.360 6.000 6.045" description="UnLink All Ports" />
+  <macro id="126" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 1" />
+  <macro id="127" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 2" />
+  <macro id="128" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 3" />
+  <macro id="129" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 4" />
+  <macro id="130" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 5" />
+  <macro id="131" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 6" />
+  <macro id="132" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 7" />
+  <macro id="133" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 8" />
+  <macro id="134" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 9" />
+  <macro id="135" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 10" />
+  <macro id="136" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 11" />
+  <macro id="137" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 12" />
+  <macro id="138" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 13" />
+  <macro id="139" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 14" />
+  <macro id="140" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 15" />
+  <macro id="141" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 16" />
+  <macro id="142" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 17" />
+  <macro id="143" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 18" />
+  <macro id="144" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 19" />
+  <macro id="145" versions="5.281 5.285 5.360 6.000 6.045" description="Play DVR Track 20" />
+  <macro id="146" versions="5.281 5.285 5.360 6.000 6.045" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="5.281 5.285 5.360 6.000 6.045" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="5.281 5.285 5.360 6.000 6.045" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="5.281 5.285 5.360 6.000 6.045" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="5.281 5.285 5.360 6.000 6.045" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="5.281 5.285 5.360 6.000 6.045" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 1 ON" />
+  <macro id="153" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 2 ON" />
+  <macro id="154" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 3 ON" />
+  <macro id="155" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 4 ON" />
+  <macro id="156" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 5 ON" />
+  <macro id="157" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 1 OFF" />
+  <macro id="158" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 2 OFF" />
+  <macro id="159" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 3 OFF" />
+  <macro id="160" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 4 OFF" />
+  <macro id="161" versions="5.281 5.285 5.360 6.000 6.045" description="Alarm 5 OFF" />
+  <macro id="162" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out Port 1" />
+  <macro id="163" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out Port 2" />
+  <macro id="164" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out Port 3" />
+  <macro id="165" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="5.281 5.285 5.360 6.000 6.045" description="Speech Out All Ports" />
+  <macro id="169" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Enable Port 1" />
+  <macro id="170" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Enable Port 2" />
+  <macro id="171" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Enable Port 3" />
+  <macro id="172" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Disable Port 1" />
+  <macro id="173" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Disable Port 2" />
+  <macro id="174" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Disable Port 3" />
+  <macro id="175" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="5.281 5.285 5.360 6.000 6.045" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="5.281 5.285 5.360 6.000 6.045" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="5.281 5.285 5.360 6.000 6.045" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="5.281 5.285 5.360 6.000 6.045" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="5.281 5.285 5.360 6.000 6.045" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="5.281 5.285 5.360 6.000 6.045" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="5.281 5.285 5.360 6.000 6.045" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 1" />
+  <macro id="188" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 2" />
+  <macro id="189" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 3" />
+  <macro id="190" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 4" />
+  <macro id="191" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 5" />
+  <macro id="192" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 6" />
+  <macro id="193" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 7" />
+  <macro id="194" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 8" />
+  <macro id="195" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 9" />
+  <macro id="196" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 10" />
+  <macro id="197" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 11" />
+  <macro id="198" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 12" />
+  <macro id="199" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 13" />
+  <macro id="200" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 14" />
+  <macro id="201" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 15" />
+  <macro id="202" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 16" />
+  <macro id="203" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 17" />
+  <macro id="204" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 18" />
+  <macro id="205" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 19" />
+  <macro id="206" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 20" />
+  <macro id="207" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 21" />
+  <macro id="208" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 22" />
+  <macro id="209" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 23" />
+  <macro id="210" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 24" />
+  <macro id="211" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 25" />
+  <macro id="212" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 26" />
+  <macro id="213" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 27" />
+  <macro id="214" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 28" />
+  <macro id="215" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 29" />
+  <macro id="216" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 30" />
+  <macro id="217" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 31" />
+  <macro id="218" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 32" />
+  <macro id="219" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 33" />
+  <macro id="220" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 34" />
+  <macro id="221" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 35" />
+  <macro id="222" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 36" />
+  <macro id="223" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 37" />
+  <macro id="224" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 38" />
+  <macro id="225" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 39" />
+  <macro id="226" versions="5.281 5.285 5.360 6.000 6.045" description="Play Message Macro 40" />
+  <macro id="227" versions="5.281 5.285 5.360 6.000 6.045" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="5.281 5.285 5.360 6.000 6.045" description="Macro Priority High" />
+  <macro id="229" versions="5.281 5.285 5.360 6.000 6.045" description="Macro Priority Low" />
+  <macro id="230" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Receiver Port 1" />
+  <macro id="237" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Receiver Port 2" />
+  <macro id="238" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Receiver Port 3" />
+  <macro id="239" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Receiver Port 1" />
+  <macro id="240" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Receiver Port 2" />
+  <macro id="241" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Receiver Port 3" />
+  <macro id="242" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="5.281 5.285 5.360 6.000 6.045" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="5.281 5.285 5.360 6.000 6.045" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="5.281 5.285 5.360 6.000 6.045" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="5.281 5.285 5.360 6.000 6.045" description="Force Audio To Entered Port" />
+  <macro id="252" versions="5.281 5.285 5.360 6.000 6.045" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="5.281 5.285 5.360 6.000 6.045" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="5.281 5.285 5.360 6.000 6.045" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="5.281 5.285 5.360 6.000 6.045" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="5.281 5.285 5.360 6.000 6.045" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="5.281 5.285 5.360 6.000 6.045" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 1" />
+  <macro id="260" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 2" />
+  <macro id="261" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 3" />
+  <macro id="262" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 4" />
+  <macro id="263" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 5" />
+  <macro id="264" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 6" />
+  <macro id="265" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 7" />
+  <macro id="266" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 8" />
+  <macro id="267" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 9" />
+  <macro id="268" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 10" />
+  <macro id="269" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 11" />
+  <macro id="270" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 12" />
+  <macro id="271" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 13" />
+  <macro id="272" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 14" />
+  <macro id="273" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 15" />
+  <macro id="274" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 16" />
+  <macro id="275" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 17" />
+  <macro id="276" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 18" />
+  <macro id="277" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 19" />
+  <macro id="278" versions="5.281 5.285 5.360 6.000 6.045" description="Send DTMF Memory 20" />
+  <macro id="279" versions="5.281 5.285 5.360 6.000 6.045" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="5.281 5.285 5.360 6.000 6.045" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="5.281 5.285 5.360 6.000 6.045" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="5.281 5.285 5.360 6.000 6.045" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="5.281 5.285 5.360 6.000 6.045" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="5.281 5.285 5.360 6.000 6.045" description="Say year as part of date" />
+  <macro id="308" versions="5.281 5.285 5.360 6.000 6.045" description="Don't say year as part of date" />
+  <macro id="309" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 1" />
+  <macro id="322" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 2" />
+  <macro id="323" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 3" />
+  <macro id="324" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 4" />
+  <macro id="325" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 5" />
+  <macro id="326" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 6" />
+  <macro id="327" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 7" />
+  <macro id="328" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 8" />
+  <macro id="329" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 9" />
+  <macro id="330" versions="5.281 5.285 5.360 6.000 6.045" description="Remote Base Memory 10" />
+  <macro id="331" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Zero Hang Time Select" />
+  <macro id="334" versions="5.281 5.285 5.360 6.000 6.045" description="Port 1 Hang Time Revert to Programmed Value" />
+  <macro id="335" versions="5.281 5.285 5.360 6.000 6.045" description="Port 2 Hang Time Revert to Programmed Value" />
+  <macro id="336" versions="5.281 5.285 5.360 6.000 6.045" description="Port 3 Hang Time Revert to Programmed Value" />
+  <macro id="337" versions="5.281 5.285 5.360 6.000 6.045" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Autopatch" />
+  <macro id="339" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="5.281 5.285 5.360 6.000 6.045" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="5.281 5.285 5.360 6.000 6.045" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="5.281 5.285 5.360 6.000 6.045" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="5.281 5.285 5.360 6.000 6.045" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="5.281 5.285 5.360 6.000 6.045" description="Start General Timer 1" />
+  <macro id="348" versions="5.281 5.285 5.360 6.000 6.045" description="Start General Timer 2" />
+  <macro id="349" versions="5.281 5.285 5.360 6.000 6.045" description="Start General Timer 3" />
+  <macro id="350" versions="5.285 5.360 6.000 6.045" description="Stop General Timer 1" />
   <macro id="351" versions="5.281" description="Suspend Scheduler Setpoint 1" />
-  <macro id="351" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 2" />
+  <macro id="351" versions="5.285 5.360 6.000 6.045" description="Stop General Timer 2" />
   <macro id="352" versions="5.281" description="Suspend Scheduler Setpoint 2" />
-  <macro id="352" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 3" />
+  <macro id="352" versions="5.285 5.360 6.000 6.045" description="Stop General Timer 3" />
   <macro id="353" versions="5.281" description="Suspend Scheduler Setpoint 3" />
-  <macro id="353" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 1" />
+  <macro id="353" versions="5.285 5.360 6.000 6.045" description="Remote Base Power Select 1" />
   <macro id="354" versions="5.281" description="Suspend Scheduler Setpoint 4" />
-  <macro id="354" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 2" />
+  <macro id="354" versions="5.285 5.360 6.000 6.045" description="Remote Base Power Select 2" />
   <macro id="355" versions="5.281" description="Suspend Scheduler Setpoint 5" />
-  <macro id="355" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 3" />
+  <macro id="355" versions="5.285 5.360 6.000 6.045" description="Remote Base Power Select 3" />
   <macro id="356" versions="5.281" description="Suspend Scheduler Setpoint 6" />
-  <macro id="356" versions="5.285 5.360 6.000 6.040" description="Guest Macros Enabled" />
+  <macro id="356" versions="5.285 5.360 6.000 6.045" description="Guest Macros Enabled" />
   <macro id="357" versions="5.281" description="Suspend Scheduler Setpoint 7" />
-  <macro id="357" versions="5.285 5.360 6.000 6.040" description="Guest Macros Disabled" />
+  <macro id="357" versions="5.285 5.360 6.000 6.045" description="Guest Macros Disabled" />
   <macro id="358" versions="5.281" description="Suspend Scheduler Setpoint 8" />
   <macro id="358" versions="5.285" description="Receiver Is Active Port 1" />
-  <macro id="358" versions="5.360 6.000 6.040" description="Receiver 1 Macros On" />
+  <macro id="358" versions="5.360 6.000 6.045" description="Receiver 1 Macros On" />
   <macro id="359" versions="5.281" description="Suspend Scheduler Setpoint 9" />
   <macro id="359" versions="5.285" description="Receiver Is Active Port 2" />
-  <macro id="359" versions="5.360 6.000 6.040" description="Receiver 2 Macros On" />
+  <macro id="359" versions="5.360 6.000 6.045" description="Receiver 2 Macros On" />
   <macro id="360" versions="5.281" description="Suspend Scheduler Setpoint 10" />
   <macro id="360" versions="5.285" description="Receiver Is Active Port 3" />
-  <macro id="360" versions="5.360 6.000 6.040" description="Receiver 3 Macros On" />
+  <macro id="360" versions="5.360 6.000 6.045" description="Receiver 3 Macros On" />
   <macro id="361" versions="5.281" description="Suspend Scheduler Setpoint 11" />
   <macro id="361" versions="5.285" description="Receiver Is Inactive Port 1" />
-  <macro id="361" versions="5.360 6.000 6.040" description="Receiver 3 Macros Off" />
+  <macro id="361" versions="5.360 6.000 6.045" description="Receiver 3 Macros Off" />
   <macro id="362" versions="5.281" description="Suspend Scheduler Setpoint 12" />
   <macro id="362" versions="5.285" description="Receiver Is Inactive Port 2" />
-  <macro id="362" versions="5.360 6.000 6.040" description="Receiver 3 Macros Off" />
+  <macro id="362" versions="5.360 6.000 6.045" description="Receiver 3 Macros Off" />
   <macro id="363" versions="5.281" description="Suspend Scheduler Setpoint 13" />
   <macro id="363" versions="5.285" description="Receiver Is Inactive Port 3" />
-  <macro id="363" versions="5.360 6.000 6.040" description="Receiver 3 Macros Off" />
+  <macro id="363" versions="5.360 6.000 6.045" description="Receiver 3 Macros Off" />
   <macro id="364" versions="5.281" description="Suspend Scheduler Setpoint 14" />
   <macro id="364" versions="5.285" description="Play Message Macro 41" />
-  <macro id="364" versions="5.360 6.000 6.040" description="Extended Logic 1 Output ON" />
+  <macro id="364" versions="5.360 6.000 6.045" description="Extended Logic 1 Output ON" />
   <macro id="365" versions="5.281" description="Suspend Scheduler Setpoint 15" />
   <macro id="365" versions="5.285" description="Play Message Macro 42" />
-  <macro id="365" versions="5.360 6.000 6.040" description="Extended Logic 2 Output ON" />
+  <macro id="365" versions="5.360 6.000 6.045" description="Extended Logic 2 Output ON" />
   <macro id="366" versions="5.281" description="Suspend Scheduler Setpoint 16" />
   <macro id="366" versions="5.285" description="Play Message Macro 43" />
-  <macro id="366" versions="5.360 6.000 6.040" description="Extended Logic 3 Output ON" />
+  <macro id="366" versions="5.360 6.000 6.045" description="Extended Logic 3 Output ON" />
   <macro id="367" versions="5.281" description="Suspend Scheduler Setpoint 17" />
   <macro id="367" versions="5.285" description="Play Message Macro 44" />
-  <macro id="367" versions="5.360 6.000 6.040" description="Extended Logic 4 Output ON" />
+  <macro id="367" versions="5.360 6.000 6.045" description="Extended Logic 4 Output ON" />
   <macro id="368" versions="5.281" description="Suspend Scheduler Setpoint 18" />
   <macro id="368" versions="5.285" description="Play Message Macro 45" />
-  <macro id="368" versions="5.360 6.000 6.040" description="Extended Logic 5 Output ON" />
+  <macro id="368" versions="5.360 6.000 6.045" description="Extended Logic 5 Output ON" />
   <macro id="369" versions="5.281" description="Suspend Scheduler Setpoint 19" />
   <macro id="369" versions="5.285" description="Play Message Macro 46" />
-  <macro id="369" versions="5.360 6.000 6.040" description="Extended Logic 6 Output ON" />
+  <macro id="369" versions="5.360 6.000 6.045" description="Extended Logic 6 Output ON" />
   <macro id="370" versions="5.281" description="Suspend Scheduler Setpoint 20" />
   <macro id="370" versions="5.285" description="Play Message Macro 47" />
-  <macro id="370" versions="5.360 6.000 6.040" description="Extended Logic 7 Output ON" />
+  <macro id="370" versions="5.360 6.000 6.045" description="Extended Logic 7 Output ON" />
   <macro id="371" versions="5.281" description="Resume Scheduler Setpoint 1" />
   <macro id="371" versions="5.285" description="Play Message Macro 48" />
-  <macro id="371" versions="5.360 6.000 6.040" description="Extended Logic 8 Output ON" />
+  <macro id="371" versions="5.360 6.000 6.045" description="Extended Logic 8 Output ON" />
   <macro id="372" versions="5.281" description="Resume Scheduler Setpoint 2" />
   <macro id="372" versions="5.285" description="Play Message Macro 49" />
-  <macro id="372" versions="5.360 6.000 6.040" description="Extended Logic 9 Output ON" />
+  <macro id="372" versions="5.360 6.000 6.045" description="Extended Logic 9 Output ON" />
   <macro id="373" versions="5.281" description="Resume Scheduler Setpoint 3" />
   <macro id="373" versions="5.285" description="Play Message Macro 50" />
-  <macro id="373" versions="5.360 6.000 6.040" description="Extended Logic 10 Output ON" />
+  <macro id="373" versions="5.360 6.000 6.045" description="Extended Logic 10 Output ON" />
   <macro id="374" versions="5.281" description="Resume Scheduler Setpoint 4" />
   <macro id="374" versions="5.285" description="Play Message Macro 51" />
-  <macro id="374" versions="5.360 6.000 6.040" description="Extended Logic 11 Output ON" />
+  <macro id="374" versions="5.360 6.000 6.045" description="Extended Logic 11 Output ON" />
   <macro id="375" versions="5.281" description="Resume Scheduler Setpoint 5" />
   <macro id="375" versions="5.285" description="Play Message Macro 52" />
-  <macro id="375" versions="5.360 6.000 6.040" description="Extended Logic 12 Output ON" />
+  <macro id="375" versions="5.360 6.000 6.045" description="Extended Logic 12 Output ON" />
   <macro id="376" versions="5.281" description="Resume Scheduler Setpoint 6" />
   <macro id="376" versions="5.285" description="Play Message Macro 53" />
-  <macro id="376" versions="5.360 6.000 6.040" description="Extended Logic 13 Output ON" />
+  <macro id="376" versions="5.360 6.000 6.045" description="Extended Logic 13 Output ON" />
   <macro id="377" versions="5.281" description="Resume Scheduler Setpoint 7" />
   <macro id="377" versions="5.285" description="Play Message Macro 54" />
-  <macro id="377" versions="5.360 6.000 6.040" description="Extended Logic 14 Output ON" />
+  <macro id="377" versions="5.360 6.000 6.045" description="Extended Logic 14 Output ON" />
   <macro id="378" versions="5.281" description="Resume Scheduler Setpoint 8" />
   <macro id="378" versions="5.285" description="Play Message Macro 55" />
-  <macro id="378" versions="5.360 6.000 6.040" description="Extended Logic 15 Output ON" />
+  <macro id="378" versions="5.360 6.000 6.045" description="Extended Logic 15 Output ON" />
   <macro id="379" versions="5.281" description="Resume Scheduler Setpoint 9" />
   <macro id="379" versions="5.285" description="Play Message Macro 56" />
-  <macro id="379" versions="5.360 6.000 6.040" description="Extended Logic 16 Output ON" />
+  <macro id="379" versions="5.360 6.000 6.045" description="Extended Logic 16 Output ON" />
   <macro id="380" versions="5.281" description="Resume Scheduler Setpoint 10" />
   <macro id="380" versions="5.285" description="Play Message Macro 57" />
-  <macro id="380" versions="5.360 6.000 6.040" description="Extended Logic 17 Output ON" />
+  <macro id="380" versions="5.360 6.000 6.045" description="Extended Logic 17 Output ON" />
   <macro id="381" versions="5.281" description="Resume Scheduler Setpoint 11" />
   <macro id="381" versions="5.285" description="Play Message Macro 58" />
-  <macro id="381" versions="5.360 6.000 6.040" description="Extended Logic 18 Output ON" />
+  <macro id="381" versions="5.360 6.000 6.045" description="Extended Logic 18 Output ON" />
   <macro id="382" versions="5.281" description="Resume Scheduler Setpoint 12" />
   <macro id="382" versions="5.285" description="Play Message Macro 59" />
-  <macro id="382" versions="5.360 6.000 6.040" description="Extended Logic 19 Output ON" />
+  <macro id="382" versions="5.360 6.000 6.045" description="Extended Logic 19 Output ON" />
   <macro id="383" versions="5.281" description="Resume Scheduler Setpoint 13" />
   <macro id="383" versions="5.285" description="Play Message Macro 60" />
-  <macro id="383" versions="5.360 6.000 6.040" description="Extended Logic 20 Output ON" />
+  <macro id="383" versions="5.360 6.000 6.045" description="Extended Logic 20 Output ON" />
   <macro id="384" versions="5.281" description="Resume Scheduler Setpoint 14" />
   <macro id="384" versions="5.285" description="Play Message Macro 61" />
-  <macro id="384" versions="5.360 6.000 6.040" description="Extended Logic 21 Output ON" />
+  <macro id="384" versions="5.360 6.000 6.045" description="Extended Logic 21 Output ON" />
   <macro id="385" versions="5.281" description="Resume Scheduler Setpoint 15" />
   <macro id="385" versions="5.285" description="Play Message Macro 62" />
-  <macro id="385" versions="5.360 6.000 6.040" description="Extended Logic 22 Output ON" />
+  <macro id="385" versions="5.360 6.000 6.045" description="Extended Logic 22 Output ON" />
   <macro id="386" versions="5.281" description="Resume Scheduler Setpoint 16" />
   <macro id="386" versions="5.285" description="Play Message Macro 63" />
-  <macro id="386" versions="5.360 6.000 6.040" description="Extended Logic 23 Output ON" />
+  <macro id="386" versions="5.360 6.000 6.045" description="Extended Logic 23 Output ON" />
   <macro id="387" versions="5.281" description="Resume Scheduler Setpoint 17" />
   <macro id="387" versions="5.285" description="Play Message Macro 64" />
-  <macro id="387" versions="5.360 6.000 6.040" description="Extended Logic 24 Output ON" />
+  <macro id="387" versions="5.360 6.000 6.045" description="Extended Logic 24 Output ON" />
   <macro id="388" versions="5.281" description="Resume Scheduler Setpoint 18" />
   <macro id="388" versions="5.285" description="Play Message Macro 65" />
-  <macro id="388" versions="5.360 6.000 6.040" description="Extended Logic 25 Output ON" />
+  <macro id="388" versions="5.360 6.000 6.045" description="Extended Logic 25 Output ON" />
   <macro id="389" versions="5.281" description="Resume Scheduler Setpoint 19" />
   <macro id="389" versions="5.285" description="Play Message Macro 66" />
-  <macro id="389" versions="5.360 6.000 6.040" description="Extended Logic 26 Output ON" />
+  <macro id="389" versions="5.360 6.000 6.045" description="Extended Logic 26 Output ON" />
   <macro id="390" versions="5.281" description="Resume Scheduler Setpoint 20" />
   <macro id="390" versions="5.285" description="Play Message Macro 67" />
-  <macro id="390" versions="5.360 6.000 6.040" description="Extended Logic 27 Output ON" />
+  <macro id="390" versions="5.360 6.000 6.045" description="Extended Logic 27 Output ON" />
   <macro id="391" versions="5.281" description="Stop General Timer 1" />
   <macro id="391" versions="5.285" description="Play Message Macro 68" />
-  <macro id="391" versions="5.360 6.000 6.040" description="Extended Logic 28 Output ON" />
+  <macro id="391" versions="5.360 6.000 6.045" description="Extended Logic 28 Output ON" />
   <macro id="392" versions="5.281" description="Stop General Timer 2" />
   <macro id="392" versions="5.285" description="Play Message Macro 69" />
-  <macro id="392" versions="5.360 6.000 6.040" description="Extended Logic 29 Output ON" />
+  <macro id="392" versions="5.360 6.000 6.045" description="Extended Logic 29 Output ON" />
   <macro id="393" versions="5.281" description="Stop General Timer 3" />
   <macro id="393" versions="5.285" description="Play Message Macro 70" />
-  <macro id="393" versions="5.360 6.000 6.040" description="Extended Logic 30 Output ON" />
+  <macro id="393" versions="5.360 6.000 6.045" description="Extended Logic 30 Output ON" />
   <macro id="394" versions="5.285" description="Remote Base Memory 11" />
-  <macro id="394" versions="5.360 6.000 6.040" description="Extended Logic 31 Output ON" />
+  <macro id="394" versions="5.360 6.000 6.045" description="Extended Logic 31 Output ON" />
   <macro id="395" versions="5.285" description="Remote Base Memory 12" />
-  <macro id="395" versions="5.360 6.000 6.040" description="Extended Logic 32 Output ON" />
+  <macro id="395" versions="5.360 6.000 6.045" description="Extended Logic 32 Output ON" />
   <macro id="396" versions="5.285" description="Remote Base Memory 13" />
-  <macro id="396" versions="5.360 6.000 6.040" description="Extended Logic 1 Output Pulse" />
+  <macro id="396" versions="5.360 6.000 6.045" description="Extended Logic 1 Output Pulse" />
   <macro id="397" versions="5.281" description="Macro Subset Disable" />
   <macro id="397" versions="5.285" description="Remote Base Memory 14" />
-  <macro id="397" versions="5.360 6.000 6.040" description="Extended Logic 2 Output Pulse" />
+  <macro id="397" versions="5.360 6.000 6.045" description="Extended Logic 2 Output Pulse" />
   <macro id="398" versions="5.281" description="Macro Subset Enable" />
   <macro id="398" versions="5.285" description="Remote Base Memory 15" />
-  <macro id="398" versions="5.360 6.000 6.040" description="Extended Logic 3 Output Pulse" />
+  <macro id="398" versions="5.360 6.000 6.045" description="Extended Logic 3 Output Pulse" />
   <macro id="399" versions="5.285" description="Remote Base Memory 16" />
-  <macro id="399" versions="5.360 6.000 6.040" description="Extended Logic 4 Output Pulse" />
+  <macro id="399" versions="5.360 6.000 6.045" description="Extended Logic 4 Output Pulse" />
   <macro id="400" versions="5.285" description="Remote Base Memory 17" />
-  <macro id="400" versions="5.360 6.000 6.040" description="Extended Logic 5 Output Pulse" />
+  <macro id="400" versions="5.360 6.000 6.045" description="Extended Logic 5 Output Pulse" />
   <macro id="401" versions="5.281" description="Macro 1" />
   <macro id="401" versions="5.285" description="Remote Base Memory 18" />
-  <macro id="401" versions="5.360 6.000 6.040" description="Extended Logic 6 Output Pulse" />
+  <macro id="401" versions="5.360 6.000 6.045" description="Extended Logic 6 Output Pulse" />
   <macro id="402" versions="5.281" description="Macro 2" />
   <macro id="402" versions="5.285" description="Remote Base Memory 19" />
-  <macro id="402" versions="5.360 6.000 6.040" description="Extended Logic 7 Output Pulse" />
+  <macro id="402" versions="5.360 6.000 6.045" description="Extended Logic 7 Output Pulse" />
   <macro id="403" versions="5.281" description="Macro 3" />
   <macro id="403" versions="5.285" description="Remote Base Memory 20" />
-  <macro id="403" versions="5.360 6.000 6.040" description="Extended Logic 8 Output Pulse" />
+  <macro id="403" versions="5.360 6.000 6.045" description="Extended Logic 8 Output Pulse" />
   <macro id="404" versions="5.281" description="Macro 4" />
   <macro id="404" versions="5.285" description="Remote Base Memory 21" />
-  <macro id="404" versions="5.360 6.000 6.040" description="Extended Logic 9 Output Pulse" />
+  <macro id="404" versions="5.360 6.000 6.045" description="Extended Logic 9 Output Pulse" />
   <macro id="405" versions="5.281" description="Macro 5" />
   <macro id="405" versions="5.285" description="Remote Base Memory 22" />
-  <macro id="405" versions="5.360 6.000 6.040" description="Extended Logic 10 Output Pulse" />
+  <macro id="405" versions="5.360 6.000 6.045" description="Extended Logic 10 Output Pulse" />
   <macro id="406" versions="5.281" description="Macro 6" />
   <macro id="406" versions="5.285" description="Remote Base Memory 23" />
-  <macro id="406" versions="5.360 6.000 6.040" description="Extended Logic 11 Output Pulse" />
+  <macro id="406" versions="5.360 6.000 6.045" description="Extended Logic 11 Output Pulse" />
   <macro id="407" versions="5.281" description="Macro 7" />
   <macro id="407" versions="5.285" description="Remote Base Memory 24" />
-  <macro id="407" versions="5.360 6.000 6.040" description="Extended Logic 12 Output Pulse" />
+  <macro id="407" versions="5.360 6.000 6.045" description="Extended Logic 12 Output Pulse" />
   <macro id="408" versions="5.281" description="Macro 8" />
   <macro id="408" versions="5.285" description="Remote Base Memory 25" />
-  <macro id="408" versions="5.360 6.000 6.040" description="Extended Logic 13 Output Pulse" />
+  <macro id="408" versions="5.360 6.000 6.045" description="Extended Logic 13 Output Pulse" />
   <macro id="409" versions="5.281" description="Macro 9" />
   <macro id="409" versions="5.285" description="Remote Base Memory 26" />
-  <macro id="409" versions="5.360 6.000 6.040" description="Extended Logic 14 Output Pulse" />
+  <macro id="409" versions="5.360 6.000 6.045" description="Extended Logic 14 Output Pulse" />
   <macro id="410" versions="5.281" description="Macro 10" />
   <macro id="410" versions="5.285" description="Remote Base Memory 27" />
-  <macro id="410" versions="5.360 6.000 6.040" description="Extended Logic 15 Output Pulse" />
+  <macro id="410" versions="5.360 6.000 6.045" description="Extended Logic 15 Output Pulse" />
   <macro id="411" versions="5.281" description="Macro 11" />
   <macro id="411" versions="5.285" description="Remote Base Memory 28" />
-  <macro id="411" versions="5.360 6.000 6.040" description="Extended Logic 16 Output Pulse" />
+  <macro id="411" versions="5.360 6.000 6.045" description="Extended Logic 16 Output Pulse" />
   <macro id="412" versions="5.281" description="Macro 12" />
   <macro id="412" versions="5.285" description="Remote Base Memory 29" />
-  <macro id="412" versions="5.360 6.000 6.040" description="Extended Logic 17 Output Pulse" />
+  <macro id="412" versions="5.360 6.000 6.045" description="Extended Logic 17 Output Pulse" />
   <macro id="413" versions="5.281" description="Macro 13" />
   <macro id="413" versions="5.285" description="Remote Base Memory 30" />
-  <macro id="413" versions="5.360 6.000 6.040" description="Extended Logic 18 Output Pulse" />
+  <macro id="413" versions="5.360 6.000 6.045" description="Extended Logic 18 Output Pulse" />
   <macro id="414" versions="5.281" description="Macro 14" />
   <macro id="414" versions="5.285" description="Remote Base Memory 31" />
-  <macro id="414" versions="5.360 6.000 6.040" description="Extended Logic 19 Output Pulse" />
+  <macro id="414" versions="5.360 6.000 6.045" description="Extended Logic 19 Output Pulse" />
   <macro id="415" versions="5.281" description="Macro 15" />
   <macro id="415" versions="5.285" description="Remote Base Memory 32" />
-  <macro id="415" versions="5.360 6.000 6.040" description="Extended Logic 20 Output Pulse" />
+  <macro id="415" versions="5.360 6.000 6.045" description="Extended Logic 20 Output Pulse" />
   <macro id="416" versions="5.281" description="Macro 16" />
   <macro id="416" versions="5.285" description="Remote Base Memory 33" />
-  <macro id="416" versions="5.360 6.000 6.040" description="Extended Logic 21 Output Pulse" />
+  <macro id="416" versions="5.360 6.000 6.045" description="Extended Logic 21 Output Pulse" />
   <macro id="417" versions="5.281" description="Macro 17" />
   <macro id="417" versions="5.285" description="Remote Base Memory 34" />
-  <macro id="417" versions="5.360 6.000 6.040" description="Extended Logic 22 Output Pulse" />
+  <macro id="417" versions="5.360 6.000 6.045" description="Extended Logic 22 Output Pulse" />
   <macro id="418" versions="5.281" description="Macro 18" />
   <macro id="418" versions="5.285" description="Remote Base Memory 35" />
-  <macro id="418" versions="5.360 6.000 6.040" description="Extended Logic 23 Output Pulse" />
+  <macro id="418" versions="5.360 6.000 6.045" description="Extended Logic 23 Output Pulse" />
   <macro id="419" versions="5.281" description="Macro 19" />
   <macro id="419" versions="5.285" description="Remote Base Memory 36" />
-  <macro id="419" versions="5.360 6.000 6.040" description="Extended Logic 24 Output Pulse" />
+  <macro id="419" versions="5.360 6.000 6.045" description="Extended Logic 24 Output Pulse" />
   <macro id="420" versions="5.281" description="Macro 20" />
   <macro id="420" versions="5.285" description="Remote Base Memory 37" />
-  <macro id="420" versions="5.360 6.000 6.040" description="Extended Logic 25 Output Pulse" />
+  <macro id="420" versions="5.360 6.000 6.045" description="Extended Logic 25 Output Pulse" />
   <macro id="421" versions="5.281" description="Macro 21" />
   <macro id="421" versions="5.285" description="Remote Base Memory 38" />
-  <macro id="421" versions="5.360 6.000 6.040" description="Extended Logic 26 Output Pulse" />
+  <macro id="421" versions="5.360 6.000 6.045" description="Extended Logic 26 Output Pulse" />
   <macro id="422" versions="5.281" description="Macro 22" />
   <macro id="422" versions="5.285" description="Remote Base Memory 39" />
-  <macro id="422" versions="5.360 6.000 6.040" description="Extended Logic 27 Output Pulse" />
+  <macro id="422" versions="5.360 6.000 6.045" description="Extended Logic 27 Output Pulse" />
   <macro id="423" versions="5.281" description="Macro 23" />
   <macro id="423" versions="5.285" description="Remote Base Memory 40" />
-  <macro id="423" versions="5.360 6.000 6.040" description="Extended Logic 28 Output Pulse" />
+  <macro id="423" versions="5.360 6.000 6.045" description="Extended Logic 28 Output Pulse" />
   <macro id="424" versions="5.281" description="Macro 24" />
   <macro id="424" versions="5.285" description="Send DTMF Memory 21" />
-  <macro id="424" versions="5.360 6.000 6.040" description="Extended Logic 29 Output Pulse" />
+  <macro id="424" versions="5.360 6.000 6.045" description="Extended Logic 29 Output Pulse" />
   <macro id="425" versions="5.281" description="Macro 25" />
   <macro id="425" versions="5.285" description="Send DTMF Memory 22" />
-  <macro id="425" versions="5.360 6.000 6.040" description="Extended Logic 30 Output Pulse" />
+  <macro id="425" versions="5.360 6.000 6.045" description="Extended Logic 30 Output Pulse" />
   <macro id="426" versions="5.281" description="Macro 26" />
   <macro id="426" versions="5.285" description="Send DTMF Memory 23" />
-  <macro id="426" versions="5.360 6.000 6.040" description="Extended Logic 31 Output Pulse" />
+  <macro id="426" versions="5.360 6.000 6.045" description="Extended Logic 31 Output Pulse" />
   <macro id="427" versions="5.281" description="Macro 27" />
   <macro id="427" versions="5.285" description="Send DTMF Memory 24" />
-  <macro id="427" versions="5.360 6.000 6.040" description="Extended Logic 32 Output Pulse" />
+  <macro id="427" versions="5.360 6.000 6.045" description="Extended Logic 32 Output Pulse" />
   <macro id="428" versions="5.281" description="Macro 28" />
   <macro id="428" versions="5.285" description="Send DTMF Memory 25" />
-  <macro id="428" versions="5.360 6.000 6.040" description="Extended Logic 1 Output OFF" />
+  <macro id="428" versions="5.360 6.000 6.045" description="Extended Logic 1 Output OFF" />
   <macro id="429" versions="5.281" description="Macro 29" />
   <macro id="429" versions="5.285" description="Send DTMF Memory 26" />
-  <macro id="429" versions="5.360 6.000 6.040" description="Extended Logic 2 Output OFF" />
+  <macro id="429" versions="5.360 6.000 6.045" description="Extended Logic 2 Output OFF" />
   <macro id="430" versions="5.281" description="Macro 30" />
   <macro id="430" versions="5.285" description="Send DTMF Memory 27" />
-  <macro id="430" versions="5.360 6.000 6.040" description="Extended Logic 3 Output OFF" />
+  <macro id="430" versions="5.360 6.000 6.045" description="Extended Logic 3 Output OFF" />
   <macro id="431" versions="5.281" description="Macro 31" />
   <macro id="431" versions="5.285" description="Send DTMF Memory 28" />
-  <macro id="431" versions="5.360 6.000 6.040" description="Extended Logic 4 Output OFF" />
+  <macro id="431" versions="5.360 6.000 6.045" description="Extended Logic 4 Output OFF" />
   <macro id="432" versions="5.281" description="Macro 32" />
   <macro id="432" versions="5.285" description="Send DTMF Memory 29" />
-  <macro id="432" versions="5.360 6.000 6.040" description="Extended Logic 5 Output OFF" />
+  <macro id="432" versions="5.360 6.000 6.045" description="Extended Logic 5 Output OFF" />
   <macro id="433" versions="5.281" description="Macro 33" />
   <macro id="433" versions="5.285" description="Send DTMF Memory 30" />
-  <macro id="433" versions="5.360 6.000 6.040" description="Extended Logic 6 Output OFF" />
+  <macro id="433" versions="5.360 6.000 6.045" description="Extended Logic 6 Output OFF" />
   <macro id="434" versions="5.281" description="Macro 34" />
   <macro id="434" versions="5.285" description="Send DTMF Memory 31" />
-  <macro id="434" versions="5.360 6.000 6.040" description="Extended Logic 7 Output OFF" />
+  <macro id="434" versions="5.360 6.000 6.045" description="Extended Logic 7 Output OFF" />
   <macro id="435" versions="5.281" description="Macro 35" />
   <macro id="435" versions="5.285" description="Send DTMF Memory 32" />
-  <macro id="435" versions="5.360 6.000 6.040" description="Extended Logic 8 Output OFF" />
+  <macro id="435" versions="5.360 6.000 6.045" description="Extended Logic 8 Output OFF" />
   <macro id="436" versions="5.281" description="Macro 36" />
   <macro id="436" versions="5.285" description="Send DTMF Memory 33" />
-  <macro id="436" versions="5.360 6.000 6.040" description="Extended Logic 9 Output OFF" />
+  <macro id="436" versions="5.360 6.000 6.045" description="Extended Logic 9 Output OFF" />
   <macro id="437" versions="5.281" description="Macro 37" />
   <macro id="437" versions="5.285" description="Send DTMF Memory 34" />
-  <macro id="437" versions="5.360 6.000 6.040" description="Extended Logic 10 Output OFF" />
+  <macro id="437" versions="5.360 6.000 6.045" description="Extended Logic 10 Output OFF" />
   <macro id="438" versions="5.281" description="Macro 38" />
   <macro id="438" versions="5.285" description="Send DTMF Memory 35" />
-  <macro id="438" versions="5.360 6.000 6.040" description="Extended Logic 11 Output OFF" />
+  <macro id="438" versions="5.360 6.000 6.045" description="Extended Logic 11 Output OFF" />
   <macro id="439" versions="5.281" description="Macro 39" />
   <macro id="439" versions="5.285" description="Send DTMF Memory 36" />
-  <macro id="439" versions="5.360 6.000 6.040" description="Extended Logic 12 Output OFF" />
+  <macro id="439" versions="5.360 6.000 6.045" description="Extended Logic 12 Output OFF" />
   <macro id="440" versions="5.281" description="Macro 40" />
   <macro id="440" versions="5.285" description="Send DTMF Memory 37" />
-  <macro id="440" versions="5.360 6.000 6.040" description="Extended Logic 13 Output OFF" />
+  <macro id="440" versions="5.360 6.000 6.045" description="Extended Logic 13 Output OFF" />
   <macro id="441" versions="5.281" description="Macro 41" />
   <macro id="441" versions="5.285" description="Send DTMF Memory 38" />
-  <macro id="441" versions="5.360 6.000 6.040" description="Extended Logic 14 Output OFF" />
+  <macro id="441" versions="5.360 6.000 6.045" description="Extended Logic 14 Output OFF" />
   <macro id="442" versions="5.281" description="Macro 42" />
   <macro id="442" versions="5.285" description="Send DTMF Memory 39" />
-  <macro id="442" versions="5.360 6.000 6.040" description="Extended Logic 15 Output OFF" />
+  <macro id="442" versions="5.360 6.000 6.045" description="Extended Logic 15 Output OFF" />
   <macro id="443" versions="5.281" description="Macro 43" />
   <macro id="443" versions="5.285" description="Send DTMF Memory 40" />
-  <macro id="443" versions="5.360 6.000 6.040" description="Extended Logic 16 Output OFF" />
+  <macro id="443" versions="5.360 6.000 6.045" description="Extended Logic 16 Output OFF" />
   <macro id="444" versions="5.281" description="Macro 44" />
   <macro id="444" versions="5.285" description="Send DTMF Memory 41" />
-  <macro id="444" versions="5.360 6.000 6.040" description="Extended Logic 17 Output OFF" />
+  <macro id="444" versions="5.360 6.000 6.045" description="Extended Logic 17 Output OFF" />
   <macro id="445" versions="5.281" description="Macro 45" />
   <macro id="445" versions="5.285" description="Send DTMF Memory 42" />
-  <macro id="445" versions="5.360 6.000 6.040" description="Extended Logic 18 Output OFF" />
+  <macro id="445" versions="5.360 6.000 6.045" description="Extended Logic 18 Output OFF" />
   <macro id="446" versions="5.281" description="Macro 46" />
   <macro id="446" versions="5.285" description="Send DTMF Memory 43" />
-  <macro id="446" versions="5.360 6.000 6.040" description="Extended Logic 19 Output OFF" />
+  <macro id="446" versions="5.360 6.000 6.045" description="Extended Logic 19 Output OFF" />
   <macro id="447" versions="5.281" description="Macro 47" />
   <macro id="447" versions="5.285" description="Send DTMF Memory 44" />
-  <macro id="447" versions="5.360 6.000 6.040" description="Extended Logic 20 Output OFF" />
+  <macro id="447" versions="5.360 6.000 6.045" description="Extended Logic 20 Output OFF" />
   <macro id="448" versions="5.281" description="Macro 48" />
   <macro id="448" versions="5.285" description="Send DTMF Memory 45" />
-  <macro id="448" versions="5.360 6.000 6.040" description="Extended Logic 21 Output OFF" />
+  <macro id="448" versions="5.360 6.000 6.045" description="Extended Logic 21 Output OFF" />
   <macro id="449" versions="5.281" description="Macro 49" />
   <macro id="449" versions="5.285" description="Send DTMF Memory 46" />
-  <macro id="449" versions="5.360 6.000 6.040" description="Extended Logic 22 Output OFF" />
+  <macro id="449" versions="5.360 6.000 6.045" description="Extended Logic 22 Output OFF" />
   <macro id="450" versions="5.281" description="Macro 50" />
   <macro id="450" versions="5.285" description="Send DTMF Memory 47" />
-  <macro id="450" versions="5.360 6.000 6.040" description="Extended Logic 23 Output OFF" />
+  <macro id="450" versions="5.360 6.000 6.045" description="Extended Logic 23 Output OFF" />
   <macro id="451" versions="5.281" description="Macro 51" />
   <macro id="451" versions="5.285" description="Send DTMF Memory 48" />
-  <macro id="451" versions="5.360 6.000 6.040" description="Extended Logic 24 Output OFF" />
+  <macro id="451" versions="5.360 6.000 6.045" description="Extended Logic 24 Output OFF" />
   <macro id="452" versions="5.281" description="Macro 52" />
   <macro id="452" versions="5.285" description="Send DTMF Memory 49" />
-  <macro id="452" versions="5.360 6.000 6.040" description="Extended Logic 25 Output OFF" />
+  <macro id="452" versions="5.360 6.000 6.045" description="Extended Logic 25 Output OFF" />
   <macro id="453" versions="5.281" description="Macro 53" />
   <macro id="453" versions="5.285" description="Send DTMF Memory 50" />
-  <macro id="453" versions="5.360 6.000 6.040" description="Extended Logic 26 Output OFF" />
+  <macro id="453" versions="5.360 6.000 6.045" description="Extended Logic 26 Output OFF" />
   <macro id="454" versions="5.281" description="Macro 54" />
   <macro id="454" versions="5.285" description="Load RTC Time/Date" />
-  <macro id="454" versions="5.360 6.000 6.040" description="Extended Logic 27 Output OFF" />
+  <macro id="454" versions="5.360 6.000 6.045" description="Extended Logic 27 Output OFF" />
   <macro id="455" versions="5.281" description="Macro 55" />
-  <macro id="455" versions="5.360 6.000 6.040" description="Extended Logic 28 Output OFF" />
+  <macro id="455" versions="5.360 6.000 6.045" description="Extended Logic 28 Output OFF" />
   <macro id="456" versions="5.281" description="Macro 56" />
-  <macro id="456" versions="5.360 6.000 6.040" description="Extended Logic 29 Output OFF" />
+  <macro id="456" versions="5.360 6.000 6.045" description="Extended Logic 29 Output OFF" />
   <macro id="457" versions="5.281" description="Macro 57" />
-  <macro id="457" versions="5.360 6.000 6.040" description="Extended Logic 30 Output OFF" />
+  <macro id="457" versions="5.360 6.000 6.045" description="Extended Logic 30 Output OFF" />
   <macro id="458" versions="5.281" description="Macro 58" />
-  <macro id="458" versions="5.360 6.000 6.040" description="Extended Logic 31 Output OFF" />
+  <macro id="458" versions="5.360 6.000 6.045" description="Extended Logic 31 Output OFF" />
   <macro id="459" versions="5.281" description="Macro 59" />
-  <macro id="459" versions="5.360 6.000 6.040" description="Extended Logic 32 Output OFF" />
+  <macro id="459" versions="5.360 6.000 6.045" description="Extended Logic 32 Output OFF" />
   <macro id="460" versions="5.281" description="Macro 60" />
   <macro id="460" versions="5.285" description="Suspend Scheduler Setpoint 1" />
-  <macro id="460" versions="5.360 6.000 6.040" description="Play Message Macro 41" />
+  <macro id="460" versions="5.360 6.000 6.045" description="Play Message Macro 41" />
   <macro id="461" versions="5.281" description="Macro 61" />
   <macro id="461" versions="5.285" description="Suspend Scheduler Setpoint 2" />
-  <macro id="461" versions="5.360 6.000 6.040" description="Play Message Macro 42" />
+  <macro id="461" versions="5.360 6.000 6.045" description="Play Message Macro 42" />
   <macro id="462" versions="5.281" description="Macro 62" />
   <macro id="462" versions="5.285" description="Suspend Scheduler Setpoint 3" />
-  <macro id="462" versions="5.360 6.000 6.040" description="Play Message Macro 43" />
+  <macro id="462" versions="5.360 6.000 6.045" description="Play Message Macro 43" />
   <macro id="463" versions="5.281" description="Macro 63" />
   <macro id="463" versions="5.285" description="Suspend Scheduler Setpoint 4" />
-  <macro id="463" versions="5.360 6.000 6.040" description="Play Message Macro 44" />
+  <macro id="463" versions="5.360 6.000 6.045" description="Play Message Macro 44" />
   <macro id="464" versions="5.281" description="Macro 64" />
   <macro id="464" versions="5.285" description="Suspend Scheduler Setpoint 5" />
-  <macro id="464" versions="5.360 6.000 6.040" description="Play Message Macro 45" />
+  <macro id="464" versions="5.360 6.000 6.045" description="Play Message Macro 45" />
   <macro id="465" versions="5.281" description="Macro 65" />
   <macro id="465" versions="5.285" description="Suspend Scheduler Setpoint 6" />
-  <macro id="465" versions="5.360 6.000 6.040" description="Play Message Macro 46" />
+  <macro id="465" versions="5.360 6.000 6.045" description="Play Message Macro 46" />
   <macro id="466" versions="5.281" description="Macro 66" />
   <macro id="466" versions="5.285" description="Suspend Scheduler Setpoint 7" />
-  <macro id="466" versions="5.360 6.000 6.040" description="Play Message Macro 47" />
+  <macro id="466" versions="5.360 6.000 6.045" description="Play Message Macro 47" />
   <macro id="467" versions="5.281" description="Macro 67" />
   <macro id="467" versions="5.285" description="Suspend Scheduler Setpoint 8" />
-  <macro id="467" versions="5.360 6.000 6.040" description="Play Message Macro 48" />
+  <macro id="467" versions="5.360 6.000 6.045" description="Play Message Macro 48" />
   <macro id="468" versions="5.281" description="Macro 68" />
   <macro id="468" versions="5.285" description="Suspend Scheduler Setpoint 9" />
-  <macro id="468" versions="5.360 6.000 6.040" description="Play Message Macro 49" />
+  <macro id="468" versions="5.360 6.000 6.045" description="Play Message Macro 49" />
   <macro id="469" versions="5.281" description="Macro 69" />
   <macro id="469" versions="5.285" description="Suspend Scheduler Setpoint 10" />
-  <macro id="469" versions="5.360 6.000 6.040" description="Play Message Macro 50" />
+  <macro id="469" versions="5.360 6.000 6.045" description="Play Message Macro 50" />
   <macro id="470" versions="5.281" description="Macro 70" />
   <macro id="470" versions="5.285" description="Suspend Scheduler Setpoint 11" />
-  <macro id="470" versions="5.360 6.000 6.040" description="Play Message Macro 51" />
+  <macro id="470" versions="5.360 6.000 6.045" description="Play Message Macro 51" />
   <macro id="471" versions="5.281" description="Macro 71" />
   <macro id="471" versions="5.285" description="Suspend Scheduler Setpoint 12" />
-  <macro id="471" versions="5.360 6.000 6.040" description="Play Message Macro 52" />
+  <macro id="471" versions="5.360 6.000 6.045" description="Play Message Macro 52" />
   <macro id="472" versions="5.281" description="Macro 72" />
   <macro id="472" versions="5.285" description="Suspend Scheduler Setpoint 13" />
-  <macro id="472" versions="5.360 6.000 6.040" description="Play Message Macro 53" />
+  <macro id="472" versions="5.360 6.000 6.045" description="Play Message Macro 53" />
   <macro id="473" versions="5.281" description="Macro 73" />
   <macro id="473" versions="5.285" description="Suspend Scheduler Setpoint 14" />
-  <macro id="473" versions="5.360 6.000 6.040" description="Play Message Macro 54" />
+  <macro id="473" versions="5.360 6.000 6.045" description="Play Message Macro 54" />
   <macro id="474" versions="5.281" description="Macro 74" />
   <macro id="474" versions="5.285" description="Suspend Scheduler Setpoint 15" />
-  <macro id="474" versions="5.360 6.000 6.040" description="Play Message Macro 55" />
+  <macro id="474" versions="5.360 6.000 6.045" description="Play Message Macro 55" />
   <macro id="475" versions="5.281" description="Macro 75" />
   <macro id="475" versions="5.285" description="Suspend Scheduler Setpoint 16" />
-  <macro id="475" versions="5.360 6.000 6.040" description="Play Message Macro 56" />
+  <macro id="475" versions="5.360 6.000 6.045" description="Play Message Macro 56" />
   <macro id="476" versions="5.281" description="Macro 76" />
   <macro id="476" versions="5.285" description="Suspend Scheduler Setpoint 17" />
-  <macro id="476" versions="5.360 6.000 6.040" description="Play Message Macro 57" />
+  <macro id="476" versions="5.360 6.000 6.045" description="Play Message Macro 57" />
   <macro id="477" versions="5.281" description="Macro 77" />
   <macro id="477" versions="5.285" description="Suspend Scheduler Setpoint 18" />
-  <macro id="477" versions="5.360 6.000 6.040" description="Play Message Macro 58" />
+  <macro id="477" versions="5.360 6.000 6.045" description="Play Message Macro 58" />
   <macro id="478" versions="5.281" description="Macro 78" />
   <macro id="478" versions="5.285" description="Suspend Scheduler Setpoint 19" />
-  <macro id="478" versions="5.360 6.000 6.040" description="Play Message Macro 59" />
+  <macro id="478" versions="5.360 6.000 6.045" description="Play Message Macro 59" />
   <macro id="479" versions="5.281" description="Macro 79" />
   <macro id="479" versions="5.285" description="Suspend Scheduler Setpoint 20" />
-  <macro id="479" versions="5.360 6.000 6.040" description="Play Message Macro 60" />
+  <macro id="479" versions="5.360 6.000 6.045" description="Play Message Macro 60" />
   <macro id="480" versions="5.281" description="Macro 80" />
   <macro id="480" versions="5.285" description="Resume Scheduler Setpoint 1" />
-  <macro id="480" versions="5.360 6.000 6.040" description="Play Message Macro 61" />
+  <macro id="480" versions="5.360 6.000 6.045" description="Play Message Macro 61" />
   <macro id="481" versions="5.281" description="Macro 81" />
   <macro id="481" versions="5.285" description="Resume Scheduler Setpoint 2" />
-  <macro id="481" versions="5.360 6.000 6.040" description="Play Message Macro 62" />
+  <macro id="481" versions="5.360 6.000 6.045" description="Play Message Macro 62" />
   <macro id="482" versions="5.281" description="Macro 82" />
   <macro id="482" versions="5.285" description="Resume Scheduler Setpoint 3" />
-  <macro id="482" versions="5.360 6.000 6.040" description="Play Message Macro 63" />
+  <macro id="482" versions="5.360 6.000 6.045" description="Play Message Macro 63" />
   <macro id="483" versions="5.281" description="Macro 83" />
   <macro id="483" versions="5.285" description="Resume Scheduler Setpoint 4" />
-  <macro id="483" versions="5.360 6.000 6.040" description="Play Message Macro 64" />
+  <macro id="483" versions="5.360 6.000 6.045" description="Play Message Macro 64" />
   <macro id="484" versions="5.281" description="Macro 84" />
   <macro id="484" versions="5.285" description="Resume Scheduler Setpoint 5" />
-  <macro id="484" versions="5.360 6.000 6.040" description="Play Message Macro 65" />
+  <macro id="484" versions="5.360 6.000 6.045" description="Play Message Macro 65" />
   <macro id="485" versions="5.281" description="Macro 85" />
   <macro id="485" versions="5.285" description="Resume Scheduler Setpoint 6" />
-  <macro id="485" versions="5.360 6.000 6.040" description="Play Message Macro 66" />
+  <macro id="485" versions="5.360 6.000 6.045" description="Play Message Macro 66" />
   <macro id="486" versions="5.281" description="Macro 86" />
   <macro id="486" versions="5.285" description="Resume Scheduler Setpoint 7" />
-  <macro id="486" versions="5.360 6.000 6.040" description="Play Message Macro 67" />
+  <macro id="486" versions="5.360 6.000 6.045" description="Play Message Macro 67" />
   <macro id="487" versions="5.281" description="Macro 87" />
   <macro id="487" versions="5.285" description="Resume Scheduler Setpoint 8" />
-  <macro id="487" versions="5.360 6.000 6.040" description="Play Message Macro 68" />
+  <macro id="487" versions="5.360 6.000 6.045" description="Play Message Macro 68" />
   <macro id="488" versions="5.281" description="Macro 88" />
   <macro id="488" versions="5.285" description="Resume Scheduler Setpoint 9" />
-  <macro id="488" versions="5.360 6.000 6.040" description="Play Message Macro 69" />
+  <macro id="488" versions="5.360 6.000 6.045" description="Play Message Macro 69" />
   <macro id="489" versions="5.281" description="Macro 89" />
   <macro id="489" versions="5.285" description="Resume Scheduler Setpoint 10" />
-  <macro id="489" versions="5.360 6.000 6.040" description="Play Message Macro 70" />
+  <macro id="489" versions="5.360 6.000 6.045" description="Play Message Macro 70" />
   <macro id="490" versions="5.281" description="Macro 90" />
   <macro id="490" versions="5.285" description="Resume Scheduler Setpoint 11" />
-  <macro id="490" versions="5.360 6.000 6.040" description="Remote Base Memory 11" />
+  <macro id="490" versions="5.360 6.000 6.045" description="Remote Base Memory 11" />
   <macro id="491" versions="5.285" description="Resume Scheduler Setpoint 12" />
-  <macro id="491" versions="5.360 6.000 6.040" description="Remote Base Memory 12" />
+  <macro id="491" versions="5.360 6.000 6.045" description="Remote Base Memory 12" />
   <macro id="492" versions="5.285" description="Resume Scheduler Setpoint 13" />
-  <macro id="492" versions="5.360 6.000 6.040" description="Remote Base Memory 13" />
+  <macro id="492" versions="5.360 6.000 6.045" description="Remote Base Memory 13" />
   <macro id="493" versions="5.285" description="Resume Scheduler Setpoint 14" />
-  <macro id="493" versions="5.360 6.000 6.040" description="Remote Base Memory 14" />
+  <macro id="493" versions="5.360 6.000 6.045" description="Remote Base Memory 14" />
   <macro id="494" versions="5.285" description="Resume Scheduler Setpoint 15" />
-  <macro id="494" versions="5.360 6.000 6.040" description="Remote Base Memory 15" />
+  <macro id="494" versions="5.360 6.000 6.045" description="Remote Base Memory 15" />
   <macro id="495" versions="5.285" description="Resume Scheduler Setpoint 16" />
-  <macro id="495" versions="5.360 6.000 6.040" description="Remote Base Memory 16" />
+  <macro id="495" versions="5.360 6.000 6.045" description="Remote Base Memory 16" />
   <macro id="496" versions="5.285" description="Resume Scheduler Setpoint 17" />
-  <macro id="496" versions="5.360 6.000 6.040" description="Remote Base Memory 17" />
+  <macro id="496" versions="5.360 6.000 6.045" description="Remote Base Memory 17" />
   <macro id="497" versions="5.285" description="Resume Scheduler Setpoint 18" />
-  <macro id="497" versions="5.360 6.000 6.040" description="Remote Base Memory 18" />
+  <macro id="497" versions="5.360 6.000 6.045" description="Remote Base Memory 18" />
   <macro id="498" versions="5.285" description="Resume Scheduler Setpoint 19" />
-  <macro id="498" versions="5.360 6.000 6.040" description="Remote Base Memory 19" />
+  <macro id="498" versions="5.360 6.000 6.045" description="Remote Base Memory 19" />
   <macro id="499" versions="5.285" description="Resume Scheduler Setpoint 20" />
-  <macro id="499" versions="5.360 6.000 6.040" description="Remote Base Memory 20" />
-  <macro id="500" versions="5.360 6.000 6.040" description="Remote Base Memory 21" />
+  <macro id="499" versions="5.360 6.000 6.045" description="Remote Base Memory 20" />
+  <macro id="500" versions="5.360 6.000 6.045" description="Remote Base Memory 21" />
   <macro id="501" versions="5.285" description="Call Macro 1" />
-  <macro id="501" versions="5.360 6.000 6.040" description="Remote Base Memory 22" />
+  <macro id="501" versions="5.360 6.000 6.045" description="Remote Base Memory 22" />
   <macro id="502" versions="5.285" description="Call Macro 2" />
-  <macro id="502" versions="5.360 6.000 6.040" description="Remote Base Memory 23" />
+  <macro id="502" versions="5.360 6.000 6.045" description="Remote Base Memory 23" />
   <macro id="503" versions="5.285" description="Call Macro 3" />
-  <macro id="503" versions="5.360 6.000 6.040" description="Remote Base Memory 24" />
+  <macro id="503" versions="5.360 6.000 6.045" description="Remote Base Memory 24" />
   <macro id="504" versions="5.285" description="Call Macro 4" />
-  <macro id="504" versions="5.360 6.000 6.040" description="Remote Base Memory 25" />
+  <macro id="504" versions="5.360 6.000 6.045" description="Remote Base Memory 25" />
   <macro id="505" versions="5.285" description="Call Macro 5" />
-  <macro id="505" versions="5.360 6.000 6.040" description="Remote Base Memory 26" />
+  <macro id="505" versions="5.360 6.000 6.045" description="Remote Base Memory 26" />
   <macro id="506" versions="5.285" description="Call Macro 6" />
-  <macro id="506" versions="5.360 6.000 6.040" description="Remote Base Memory 27" />
+  <macro id="506" versions="5.360 6.000 6.045" description="Remote Base Memory 27" />
   <macro id="507" versions="5.285" description="Call Macro 7" />
-  <macro id="507" versions="5.360 6.000 6.040" description="Remote Base Memory 28" />
+  <macro id="507" versions="5.360 6.000 6.045" description="Remote Base Memory 28" />
   <macro id="508" versions="5.285" description="Call Macro 8" />
-  <macro id="508" versions="5.360 6.000 6.040" description="Remote Base Memory 29" />
+  <macro id="508" versions="5.360 6.000 6.045" description="Remote Base Memory 29" />
   <macro id="509" versions="5.285" description="Call Macro 9" />
-  <macro id="509" versions="5.360 6.000 6.040" description="Remote Base Memory 30" />
+  <macro id="509" versions="5.360 6.000 6.045" description="Remote Base Memory 30" />
   <macro id="510" versions="5.285" description="Call Macro 10" />
   <macro id="511" versions="5.285" description="Call Macro 11" />
-  <macro id="511" versions="5.360 6.000 6.040" description="Remote Base Memory 31" />
+  <macro id="511" versions="5.360 6.000 6.045" description="Remote Base Memory 31" />
   <macro id="512" versions="5.285" description="Call Macro 12" />
-  <macro id="512" versions="5.360 6.000 6.040" description="Remote Base Memory 32" />
+  <macro id="512" versions="5.360 6.000 6.045" description="Remote Base Memory 32" />
   <macro id="513" versions="5.285" description="Call Macro 13" />
-  <macro id="513" versions="5.360 6.000 6.040" description="Remote Base Memory 33" />
+  <macro id="513" versions="5.360 6.000 6.045" description="Remote Base Memory 33" />
   <macro id="514" versions="5.285" description="Call Macro 14" />
-  <macro id="514" versions="5.360 6.000 6.040" description="Remote Base Memory 34" />
+  <macro id="514" versions="5.360 6.000 6.045" description="Remote Base Memory 34" />
   <macro id="515" versions="5.285" description="Call Macro 15" />
-  <macro id="515" versions="5.360 6.000 6.040" description="Remote Base Memory 35" />
+  <macro id="515" versions="5.360 6.000 6.045" description="Remote Base Memory 35" />
   <macro id="516" versions="5.285" description="Call Macro 16" />
-  <macro id="516" versions="5.360 6.000 6.040" description="Remote Base Memory 36" />
+  <macro id="516" versions="5.360 6.000 6.045" description="Remote Base Memory 36" />
   <macro id="517" versions="5.285" description="Call Macro 17" />
-  <macro id="517" versions="5.360 6.000 6.040" description="Remote Base Memory 37" />
+  <macro id="517" versions="5.360 6.000 6.045" description="Remote Base Memory 37" />
   <macro id="518" versions="5.285" description="Call Macro 18" />
-  <macro id="518" versions="5.360 6.000 6.040" description="Remote Base Memory 38" />
+  <macro id="518" versions="5.360 6.000 6.045" description="Remote Base Memory 38" />
   <macro id="519" versions="5.285" description="Call Macro 19" />
-  <macro id="519" versions="5.360 6.000 6.040" description="Remote Base Memory 39" />
+  <macro id="519" versions="5.360 6.000 6.045" description="Remote Base Memory 39" />
   <macro id="520" versions="5.285" description="Call Macro 20" />
-  <macro id="520" versions="5.360 6.000 6.040" description="Remote Base Memory 40" />
+  <macro id="520" versions="5.360 6.000 6.045" description="Remote Base Memory 40" />
   <macro id="521" versions="5.285" description="Call Macro 21" />
-  <macro id="521" versions="5.360 6.000 6.040" description="Send DTMF Memory 21" />
+  <macro id="521" versions="5.360 6.000 6.045" description="Send DTMF Memory 21" />
   <macro id="522" versions="5.285" description="Call Macro 22" />
-  <macro id="522" versions="5.360 6.000 6.040" description="Send DTMF Memory 22" />
+  <macro id="522" versions="5.360 6.000 6.045" description="Send DTMF Memory 22" />
   <macro id="523" versions="5.285" description="Call Macro 23" />
-  <macro id="523" versions="5.360 6.000 6.040" description="Send DTMF Memory 23" />
+  <macro id="523" versions="5.360 6.000 6.045" description="Send DTMF Memory 23" />
   <macro id="524" versions="5.285" description="Call Macro 24" />
-  <macro id="524" versions="5.360 6.000 6.040" description="Send DTMF Memory 24" />
+  <macro id="524" versions="5.360 6.000 6.045" description="Send DTMF Memory 24" />
   <macro id="525" versions="5.285" description="Call Macro 25" />
-  <macro id="525" versions="5.360 6.000 6.040" description="Send DTMF Memory 25" />
+  <macro id="525" versions="5.360 6.000 6.045" description="Send DTMF Memory 25" />
   <macro id="526" versions="5.285" description="Call Macro 26" />
-  <macro id="526" versions="5.360 6.000 6.040" description="Send DTMF Memory 26" />
+  <macro id="526" versions="5.360 6.000 6.045" description="Send DTMF Memory 26" />
   <macro id="527" versions="5.285" description="Call Macro 27" />
-  <macro id="527" versions="5.360 6.000 6.040" description="Send DTMF Memory 27" />
+  <macro id="527" versions="5.360 6.000 6.045" description="Send DTMF Memory 27" />
   <macro id="528" versions="5.285" description="Call Macro 28" />
-  <macro id="528" versions="5.360 6.000 6.040" description="Send DTMF Memory 28" />
+  <macro id="528" versions="5.360 6.000 6.045" description="Send DTMF Memory 28" />
   <macro id="529" versions="5.285" description="Call Macro 29" />
-  <macro id="529" versions="5.360 6.000 6.040" description="Send DTMF Memory 29" />
+  <macro id="529" versions="5.360 6.000 6.045" description="Send DTMF Memory 29" />
   <macro id="530" versions="5.285" description="Call Macro 30" />
-  <macro id="530" versions="5.360 6.000 6.040" description="Send DTMF Memory 30" />
+  <macro id="530" versions="5.360 6.000 6.045" description="Send DTMF Memory 30" />
   <macro id="531" versions="5.285" description="Call Macro 31" />
-  <macro id="531" versions="5.360 6.000 6.040" description="Send DTMF Memory 31" />
+  <macro id="531" versions="5.360 6.000 6.045" description="Send DTMF Memory 31" />
   <macro id="532" versions="5.285" description="Call Macro 32" />
-  <macro id="532" versions="5.360 6.000 6.040" description="Send DTMF Memory 32" />
+  <macro id="532" versions="5.360 6.000 6.045" description="Send DTMF Memory 32" />
   <macro id="533" versions="5.285" description="Call Macro 33" />
-  <macro id="533" versions="5.360 6.000 6.040" description="Send DTMF Memory 33" />
+  <macro id="533" versions="5.360 6.000 6.045" description="Send DTMF Memory 33" />
   <macro id="534" versions="5.285" description="Call Macro 34" />
-  <macro id="534" versions="5.360 6.000 6.040" description="Send DTMF Memory 34" />
+  <macro id="534" versions="5.360 6.000 6.045" description="Send DTMF Memory 34" />
   <macro id="535" versions="5.285" description="Call Macro 35" />
-  <macro id="535" versions="5.360 6.000 6.040" description="Send DTMF Memory 35" />
+  <macro id="535" versions="5.360 6.000 6.045" description="Send DTMF Memory 35" />
   <macro id="536" versions="5.285" description="Call Macro 36" />
-  <macro id="536" versions="5.360 6.000 6.040" description="Send DTMF Memory 36" />
+  <macro id="536" versions="5.360 6.000 6.045" description="Send DTMF Memory 36" />
   <macro id="537" versions="5.285" description="Call Macro 37" />
-  <macro id="537" versions="5.360 6.000 6.040" description="Send DTMF Memory 37" />
+  <macro id="537" versions="5.360 6.000 6.045" description="Send DTMF Memory 37" />
   <macro id="538" versions="5.285" description="Call Macro 38" />
-  <macro id="538" versions="5.360 6.000 6.040" description="Send DTMF Memory 38" />
+  <macro id="538" versions="5.360 6.000 6.045" description="Send DTMF Memory 38" />
   <macro id="539" versions="5.285" description="Call Macro 39" />
-  <macro id="539" versions="5.360 6.000 6.040" description="Send DTMF Memory 39" />
+  <macro id="539" versions="5.360 6.000 6.045" description="Send DTMF Memory 39" />
   <macro id="540" versions="5.285" description="Call Macro 40" />
-  <macro id="540" versions="5.360 6.000 6.040" description="Send DTMF Memory 40" />
+  <macro id="540" versions="5.360 6.000 6.045" description="Send DTMF Memory 40" />
   <macro id="541" versions="5.285" description="Call Macro 41" />
-  <macro id="541" versions="5.360 6.000 6.040" description="Send DTMF Memory 41" />
+  <macro id="541" versions="5.360 6.000 6.045" description="Send DTMF Memory 41" />
   <macro id="542" versions="5.285" description="Call Macro 42" />
-  <macro id="542" versions="5.360 6.000 6.040" description="Send DTMF Memory 42" />
+  <macro id="542" versions="5.360 6.000 6.045" description="Send DTMF Memory 42" />
   <macro id="543" versions="5.285" description="Call Macro 43" />
-  <macro id="543" versions="5.360 6.000 6.040" description="Send DTMF Memory 43" />
+  <macro id="543" versions="5.360 6.000 6.045" description="Send DTMF Memory 43" />
   <macro id="544" versions="5.285" description="Call Macro 44" />
-  <macro id="544" versions="5.360 6.000 6.040" description="Send DTMF Memory 44" />
+  <macro id="544" versions="5.360 6.000 6.045" description="Send DTMF Memory 44" />
   <macro id="545" versions="5.285" description="Call Macro 45" />
-  <macro id="545" versions="5.360 6.000 6.040" description="Send DTMF Memory 45" />
+  <macro id="545" versions="5.360 6.000 6.045" description="Send DTMF Memory 45" />
   <macro id="546" versions="5.285" description="Call Macro 46" />
-  <macro id="546" versions="5.360 6.000 6.040" description="Send DTMF Memory 46" />
+  <macro id="546" versions="5.360 6.000 6.045" description="Send DTMF Memory 46" />
   <macro id="547" versions="5.285" description="Call Macro 47" />
-  <macro id="547" versions="5.360 6.000 6.040" description="Send DTMF Memory 47" />
+  <macro id="547" versions="5.360 6.000 6.045" description="Send DTMF Memory 47" />
   <macro id="548" versions="5.285" description="Call Macro 48" />
-  <macro id="548" versions="5.360 6.000 6.040" description="Send DTMF Memory 48" />
+  <macro id="548" versions="5.360 6.000 6.045" description="Send DTMF Memory 48" />
   <macro id="549" versions="5.285" description="Call Macro 49" />
-  <macro id="549" versions="5.360 6.000 6.040" description="Send DTMF Memory 49" />
+  <macro id="549" versions="5.360 6.000 6.045" description="Send DTMF Memory 49" />
   <macro id="550" versions="5.285" description="Call Macro 50" />
-  <macro id="550" versions="5.360 6.000 6.040" description="Send DTMF Memory 50" />
+  <macro id="550" versions="5.360 6.000 6.045" description="Send DTMF Memory 50" />
   <macro id="551" versions="5.285" description="Call Macro 51" />
-  <macro id="551" versions="5.360 6.000 6.040" description="Get RTC Time and Date" />
+  <macro id="551" versions="5.360 6.000 6.045" description="Get RTC Time and Date" />
   <macro id="552" versions="5.285" description="Call Macro 52" />
-  <macro id="552" versions="6.000 6.040" description="CTCSS During ID ON" />
+  <macro id="552" versions="6.000 6.045" description="CTCSS During ID ON" />
   <macro id="553" versions="5.285" description="Call Macro 53" />
-  <macro id="553" versions="6.000 6.040" description="CTCSS During ID OFF" />
+  <macro id="553" versions="6.000 6.045" description="CTCSS During ID OFF" />
   <macro id="554" versions="5.285" description="Call Macro 54" />
   <macro id="555" versions="5.285" description="Call Macro 55" />
   <macro id="556" versions="5.285" description="Call Macro 56" />
@@ -885,7 +885,7 @@
   <macro id="560" versions="5.360" description="Suspend Scheduler Setpoint 1" />
   <macro id="561" versions="5.285" description="Call Macro 61" />
   <macro id="561" versions="5.360" description="Suspend Scheduler Setpoint 2" />
-  <macro id="561" versions="6.000 6.040" description="Restart Controller" />
+  <macro id="561" versions="6.000 6.045" description="Restart Controller" />
   <macro id="562" versions="5.285" description="Call Macro 62" />
   <macro id="562" versions="5.360" description="Suspend Scheduler Setpoint 3" />
   <macro id="563" versions="5.285" description="Call Macro 63" />
@@ -904,102 +904,102 @@
   <macro id="569" versions="5.360" description="Suspend Scheduler Setpoint 10" />
   <macro id="570" versions="5.285" description="Call Macro 70" />
   <macro id="570" versions="5.360" description="Suspend Scheduler Setpoint 11" />
-  <macro id="570" versions="6.000 6.040" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="570" versions="6.000 6.045" description="Readback A/D Channel 1 Stored Low" />
   <macro id="571" versions="5.285" description="Call Macro 71" />
   <macro id="571" versions="5.360" description="Suspend Scheduler Setpoint 12" />
-  <macro id="571" versions="6.000 6.040" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="571" versions="6.000 6.045" description="Readback A/D Channel 2 Stored Low" />
   <macro id="572" versions="5.285" description="Call Macro 72" />
   <macro id="572" versions="5.360" description="Suspend Scheduler Setpoint 13" />
-  <macro id="572" versions="6.000 6.040" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="572" versions="6.000 6.045" description="Readback A/D Channel 3 Stored Low" />
   <macro id="573" versions="5.285" description="Call Macro 73" />
   <macro id="573" versions="5.360" description="Suspend Scheduler Setpoint 14" />
-  <macro id="573" versions="6.000 6.040" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="573" versions="6.000 6.045" description="Readback A/D Channel 4 Stored Low" />
   <macro id="574" versions="5.285" description="Call Macro 74" />
   <macro id="574" versions="5.360" description="Suspend Scheduler Setpoint 15" />
-  <macro id="574" versions="6.000 6.040" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="574" versions="6.000 6.045" description="Readback A/D Channel 5 Stored Low" />
   <macro id="575" versions="5.285" description="Call Macro 75" />
   <macro id="575" versions="5.360" description="Suspend Scheduler Setpoint 16" />
-  <macro id="575" versions="6.000 6.040" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="575" versions="6.000 6.045" description="Readback A/D Channel 6 Stored Low" />
   <macro id="576" versions="5.285" description="Call Macro 76" />
   <macro id="576" versions="5.360" description="Suspend Scheduler Setpoint 17" />
-  <macro id="576" versions="6.000 6.040" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="576" versions="6.000 6.045" description="Readback A/D Channel 7 Stored Low" />
   <macro id="577" versions="5.285" description="Call Macro 77" />
   <macro id="577" versions="5.360" description="Suspend Scheduler Setpoint 18" />
-  <macro id="577" versions="6.000 6.040" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="577" versions="6.000 6.045" description="Readback A/D Channel 8 Stored Low" />
   <macro id="578" versions="5.285" description="Call Macro 78" />
   <macro id="578" versions="5.360" description="Suspend Scheduler Setpoint 19" />
-  <macro id="578" versions="6.000 6.040" description="Readback A/D Channel 1 Stored High" />
+  <macro id="578" versions="6.000 6.045" description="Readback A/D Channel 1 Stored High" />
   <macro id="579" versions="5.285" description="Call Macro 79" />
   <macro id="579" versions="5.360" description="Suspend Scheduler Setpoint 20" />
-  <macro id="579" versions="6.000 6.040" description="Readback A/D Channel 2 Stored High" />
+  <macro id="579" versions="6.000 6.045" description="Readback A/D Channel 2 Stored High" />
   <macro id="580" versions="5.285" description="Call Macro 80" />
   <macro id="580" versions="5.360" description="Resume Scheduler Setpoint 1" />
-  <macro id="580" versions="6.000 6.040" description="Readback A/D Channel 3 Stored High" />
+  <macro id="580" versions="6.000 6.045" description="Readback A/D Channel 3 Stored High" />
   <macro id="581" versions="5.285" description="Call Macro 81" />
   <macro id="581" versions="5.360" description="Resume Scheduler Setpoint 2" />
-  <macro id="581" versions="6.000 6.040" description="Readback A/D Channel 4 Stored High" />
+  <macro id="581" versions="6.000 6.045" description="Readback A/D Channel 4 Stored High" />
   <macro id="582" versions="5.285" description="Call Macro 82" />
   <macro id="582" versions="5.360" description="Resume Scheduler Setpoint 3" />
-  <macro id="582" versions="6.000 6.040" description="Readback A/D Channel 5 Stored High" />
+  <macro id="582" versions="6.000 6.045" description="Readback A/D Channel 5 Stored High" />
   <macro id="583" versions="5.285" description="Call Macro 83" />
   <macro id="583" versions="5.360" description="Resume Scheduler Setpoint 4" />
-  <macro id="583" versions="6.000 6.040" description="Readback A/D Channel 6 Stored High" />
+  <macro id="583" versions="6.000 6.045" description="Readback A/D Channel 6 Stored High" />
   <macro id="584" versions="5.285" description="Call Macro 84" />
   <macro id="584" versions="5.360" description="Resume Scheduler Setpoint 5" />
-  <macro id="584" versions="6.000 6.040" description="Readback A/D Channel 7 Stored High" />
+  <macro id="584" versions="6.000 6.045" description="Readback A/D Channel 7 Stored High" />
   <macro id="585" versions="5.285" description="Call Macro 85" />
   <macro id="585" versions="5.360" description="Resume Scheduler Setpoint 6" />
-  <macro id="585" versions="6.000 6.040" description="Readback A/D Channel 8 Stored High" />
+  <macro id="585" versions="6.000 6.045" description="Readback A/D Channel 8 Stored High" />
   <macro id="586" versions="5.285" description="Call Macro 86" />
   <macro id="586" versions="5.360" description="Resume Scheduler Setpoint 7" />
-  <macro id="586" versions="6.000 6.040" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="586" versions="6.000 6.045" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
   <macro id="587" versions="5.285" description="Call Macro 87" />
   <macro id="587" versions="5.360" description="Resume Scheduler Setpoint 8" />
-  <macro id="587" versions="6.000 6.040" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="6.000 6.045" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
   <macro id="588" versions="5.285" description="Call Macro 88" />
   <macro id="588" versions="5.360" description="Resume Scheduler Setpoint 9" />
-  <macro id="588" versions="6.000 6.040" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="6.000 6.045" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
   <macro id="589" versions="5.285" description="Call Macro 89" />
   <macro id="589" versions="5.360" description="Resume Scheduler Setpoint 10" />
-  <macro id="589" versions="6.000 6.040" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="6.000 6.045" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
   <macro id="590" versions="5.285" description="Call Macro 90" />
   <macro id="590" versions="5.360" description="Resume Scheduler Setpoint 11" />
-  <macro id="590" versions="6.000 6.040" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="6.000 6.045" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
   <macro id="591" versions="5.360" description="Resume Scheduler Setpoint 12" />
-  <macro id="591" versions="6.000 6.040" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="6.000 6.045" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
   <macro id="592" versions="5.360" description="Resume Scheduler Setpoint 13" />
-  <macro id="592" versions="6.000 6.040" description="Current wind speed and direction" />
+  <macro id="592" versions="6.000 6.045" description="Current wind speed and direction" />
   <macro id="593" versions="5.360" description="Resume Scheduler Setpoint 14" />
-  <macro id="593" versions="6.000 6.040" description="Current Outdoor temperature" />
+  <macro id="593" versions="6.000 6.045" description="Current Outdoor temperature" />
   <macro id="594" versions="5.360" description="Resume Scheduler Setpoint 15" />
-  <macro id="594" versions="6.000 6.040" description="Indoor humidity" />
+  <macro id="594" versions="6.000 6.045" description="Indoor humidity" />
   <macro id="595" versions="5.360" description="Resume Scheduler Setpoint 16" />
-  <macro id="595" versions="6.000 6.040" description="Outdoor humidity" />
+  <macro id="595" versions="6.000 6.045" description="Outdoor humidity" />
   <macro id="596" versions="5.360" description="Resume Scheduler Setpoint 17" />
-  <macro id="596" versions="6.000 6.040" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="596" versions="6.000 6.045" description="Wind Speed high and direction (since Midnight)" />
   <macro id="597" versions="5.360" description="Resume Scheduler Setpoint 18" />
-  <macro id="597" versions="6.000 6.040" description="Outdoor Temp High (since Midnight)" />
+  <macro id="597" versions="6.000 6.045" description="Outdoor Temp High (since Midnight)" />
   <macro id="598" versions="5.360" description="Resume Scheduler Setpoint 19" />
-  <macro id="598" versions="6.000 6.040" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="598" versions="6.000 6.045" description="Outdoor Temp Low (since Midnight)" />
   <macro id="599" versions="5.360" description="Resume Scheduler Setpoint 20" />
   <macro id="601" versions="5.360" description="Call Macro 1" />
   <macro id="602" versions="5.360" description="Call Macro 2" />
   <macro id="603" versions="5.360" description="Call Macro 3" />
   <macro id="604" versions="5.360" description="Call Macro 4" />
   <macro id="605" versions="5.360" description="Call Macro 5" />
-  <macro id="605" versions="6.000 6.040" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="605" versions="6.000 6.045" description="Speak Current Remote Base Freq and Offset" />
   <macro id="606" versions="5.360" description="Call Macro 6" />
-  <macro id="606" versions="6.044" description="Start General Timer 4" />
+  <macro id="606" versions="6.045" description="Start General Timer 4" />
   <macro id="607" versions="5.360" description="Call Macro 7" />
-  <macro id="607" versions="6.044" description="Start General Timer 5" />
+  <macro id="607" versions="6.045" description="Start General Timer 5" />
   <macro id="608" versions="5.360" description="Call Macro 8" />
-  <macro id="608" versions="6.044" description="Start General Timer 6" />
+  <macro id="608" versions="6.045" description="Start General Timer 6" />
   <macro id="609" versions="5.360" description="Call Macro 9" />
-  <macro id="609" versions="6.044" description="Stop General Timer 4" />
+  <macro id="609" versions="6.045" description="Stop General Timer 4" />
   <macro id="610" versions="5.360" description="Call Macro 10" />
-  <macro id="610" versions="6.044" description="Stop General Timer 5" />
+  <macro id="610" versions="6.045" description="Stop General Timer 5" />
   <macro id="611" versions="5.360" description="Call Macro 11" />
-  <macro id="611" versions="6.044" description="Stop General Timer 6" />
+  <macro id="611" versions="6.045" description="Stop General Timer 6" />
   <macro id="612" versions="5.360" description="Call Macro 12" />
   <macro id="612" versions="6.045" description="Disable Port 1 Inactivity Timer" />
   <macro id="613" versions="5.360" description="Call Macro 13" />
@@ -1058,164 +1058,164 @@
   <macro id="658" versions="5.360" description="Call Macro 58" />
   <macro id="659" versions="5.360" description="Call Macro 59" />
   <macro id="660" versions="5.360" description="Call Macro 60" />
-  <macro id="660" versions="6.000 6.040" description="Suspend Scheduler Setpoint 1" />
+  <macro id="660" versions="6.000 6.045" description="Suspend Scheduler Setpoint 1" />
   <macro id="661" versions="5.360" description="Call Macro 61" />
-  <macro id="661" versions="6.000 6.040" description="Suspend Scheduler Setpoint 2" />
+  <macro id="661" versions="6.000 6.045" description="Suspend Scheduler Setpoint 2" />
   <macro id="662" versions="5.360" description="Call Macro 62" />
-  <macro id="662" versions="6.000 6.040" description="Suspend Scheduler Setpoint 3" />
+  <macro id="662" versions="6.000 6.045" description="Suspend Scheduler Setpoint 3" />
   <macro id="663" versions="5.360" description="Call Macro 63" />
-  <macro id="663" versions="6.000 6.040" description="Suspend Scheduler Setpoint 4" />
+  <macro id="663" versions="6.000 6.045" description="Suspend Scheduler Setpoint 4" />
   <macro id="664" versions="5.360" description="Call Macro 64" />
-  <macro id="664" versions="6.000 6.040" description="Suspend Scheduler Setpoint 5" />
+  <macro id="664" versions="6.000 6.045" description="Suspend Scheduler Setpoint 5" />
   <macro id="665" versions="5.360" description="Call Macro 65" />
-  <macro id="665" versions="6.000 6.040" description="Suspend Scheduler Setpoint 6" />
+  <macro id="665" versions="6.000 6.045" description="Suspend Scheduler Setpoint 6" />
   <macro id="666" versions="5.360" description="Call Macro 66" />
-  <macro id="666" versions="6.000 6.040" description="Suspend Scheduler Setpoint 7" />
+  <macro id="666" versions="6.000 6.045" description="Suspend Scheduler Setpoint 7" />
   <macro id="667" versions="5.360" description="Call Macro 67" />
-  <macro id="667" versions="6.000 6.040" description="Suspend Scheduler Setpoint 8" />
+  <macro id="667" versions="6.000 6.045" description="Suspend Scheduler Setpoint 8" />
   <macro id="668" versions="5.360" description="Call Macro 68" />
-  <macro id="668" versions="6.000 6.040" description="Suspend Scheduler Setpoint 9" />
+  <macro id="668" versions="6.000 6.045" description="Suspend Scheduler Setpoint 9" />
   <macro id="669" versions="5.360" description="Call Macro 69" />
-  <macro id="669" versions="6.000 6.040" description="Suspend Scheduler Setpoint 10" />
+  <macro id="669" versions="6.000 6.045" description="Suspend Scheduler Setpoint 10" />
   <macro id="670" versions="5.360" description="Call Macro 70" />
-  <macro id="670" versions="6.000 6.040" description="Suspend Scheduler Setpoint 11" />
+  <macro id="670" versions="6.000 6.045" description="Suspend Scheduler Setpoint 11" />
   <macro id="671" versions="5.360" description="Call Macro 71" />
-  <macro id="671" versions="6.000 6.040" description="Suspend Scheduler Setpoint 12" />
+  <macro id="671" versions="6.000 6.045" description="Suspend Scheduler Setpoint 12" />
   <macro id="672" versions="5.360" description="Call Macro 72" />
-  <macro id="672" versions="6.000 6.040" description="Suspend Scheduler Setpoint 13" />
+  <macro id="672" versions="6.000 6.045" description="Suspend Scheduler Setpoint 13" />
   <macro id="673" versions="5.360" description="Call Macro 73" />
-  <macro id="673" versions="6.000 6.040" description="Suspend Scheduler Setpoint 14" />
+  <macro id="673" versions="6.000 6.045" description="Suspend Scheduler Setpoint 14" />
   <macro id="674" versions="5.360" description="Call Macro 74" />
-  <macro id="674" versions="6.000 6.040" description="Suspend Scheduler Setpoint 15" />
+  <macro id="674" versions="6.000 6.045" description="Suspend Scheduler Setpoint 15" />
   <macro id="675" versions="5.360" description="Call Macro 75" />
-  <macro id="675" versions="6.000 6.040" description="Suspend Scheduler Setpoint 16" />
+  <macro id="675" versions="6.000 6.045" description="Suspend Scheduler Setpoint 16" />
   <macro id="676" versions="5.360" description="Call Macro 76" />
-  <macro id="676" versions="6.000 6.040" description="Suspend Scheduler Setpoint 17" />
+  <macro id="676" versions="6.000 6.045" description="Suspend Scheduler Setpoint 17" />
   <macro id="677" versions="5.360" description="Call Macro 77" />
-  <macro id="677" versions="6.000 6.040" description="Suspend Scheduler Setpoint 18" />
+  <macro id="677" versions="6.000 6.045" description="Suspend Scheduler Setpoint 18" />
   <macro id="678" versions="5.360" description="Call Macro 78" />
-  <macro id="678" versions="6.000 6.040" description="Suspend Scheduler Setpoint 19" />
+  <macro id="678" versions="6.000 6.045" description="Suspend Scheduler Setpoint 19" />
   <macro id="679" versions="5.360" description="Call Macro 79" />
-  <macro id="679" versions="6.000 6.040" description="Suspend Scheduler Setpoint 20" />
+  <macro id="679" versions="6.000 6.045" description="Suspend Scheduler Setpoint 20" />
   <macro id="680" versions="5.360" description="Call Macro 80" />
-  <macro id="680" versions="6.000 6.040" description="Resume Scheduler Setpoint 1" />
+  <macro id="680" versions="6.000 6.045" description="Resume Scheduler Setpoint 1" />
   <macro id="681" versions="5.360" description="Call Macro 81" />
-  <macro id="681" versions="6.000 6.040" description="Resume Scheduler Setpoint 2" />
+  <macro id="681" versions="6.000 6.045" description="Resume Scheduler Setpoint 2" />
   <macro id="682" versions="5.360" description="Call Macro 82" />
-  <macro id="682" versions="6.000 6.040" description="Resume Scheduler Setpoint 3" />
+  <macro id="682" versions="6.000 6.045" description="Resume Scheduler Setpoint 3" />
   <macro id="683" versions="5.360" description="Call Macro 83" />
-  <macro id="683" versions="6.000 6.040" description="Resume Scheduler Setpoint 4" />
+  <macro id="683" versions="6.000 6.045" description="Resume Scheduler Setpoint 4" />
   <macro id="684" versions="5.360" description="Call Macro 84" />
-  <macro id="684" versions="6.000 6.040" description="Resume Scheduler Setpoint 5" />
+  <macro id="684" versions="6.000 6.045" description="Resume Scheduler Setpoint 5" />
   <macro id="685" versions="5.360" description="Call Macro 85" />
-  <macro id="685" versions="6.000 6.040" description="Resume Scheduler Setpoint 6" />
+  <macro id="685" versions="6.000 6.045" description="Resume Scheduler Setpoint 6" />
   <macro id="686" versions="5.360" description="Call Macro 86" />
-  <macro id="686" versions="6.000 6.040" description="Resume Scheduler Setpoint 7" />
+  <macro id="686" versions="6.000 6.045" description="Resume Scheduler Setpoint 7" />
   <macro id="687" versions="5.360" description="Call Macro 87" />
-  <macro id="687" versions="6.000 6.040" description="Resume Scheduler Setpoint 8" />
+  <macro id="687" versions="6.000 6.045" description="Resume Scheduler Setpoint 8" />
   <macro id="688" versions="5.360" description="Call Macro 88" />
-  <macro id="688" versions="6.000 6.040" description="Resume Scheduler Setpoint 9" />
+  <macro id="688" versions="6.000 6.045" description="Resume Scheduler Setpoint 9" />
   <macro id="689" versions="5.360" description="Call Macro 89" />
-  <macro id="689" versions="6.000 6.040" description="Resume Scheduler Setpoint 10" />
+  <macro id="689" versions="6.000 6.045" description="Resume Scheduler Setpoint 10" />
   <macro id="690" versions="5.360" description="Call Macro 90" />
-  <macro id="690" versions="6.000 6.040" description="Resume Scheduler Setpoint 11" />
-  <macro id="691" versions="6.000 6.040" description="Resume Scheduler Setpoint 12" />
-  <macro id="692" versions="6.000 6.040" description="Resume Scheduler Setpoint 13" />
-  <macro id="693" versions="6.000 6.040" description="Resume Scheduler Setpoint 14" />
-  <macro id="694" versions="6.000 6.040" description="Resume Scheduler Setpoint 15" />
-  <macro id="695" versions="6.000 6.040" description="Resume Scheduler Setpoint 16" />
-  <macro id="696" versions="6.000 6.040" description="Resume Scheduler Setpoint 17" />
-  <macro id="697" versions="6.000 6.040" description="Resume Scheduler Setpoint 18" />
-  <macro id="698" versions="6.000 6.040" description="Resume Scheduler Setpoint 19" />
-  <macro id="699" versions="6.000 6.040" description="Resume Scheduler Setpoint 20" />
-  <macro id="701" versions="6.000 6.040" description="Call Macro 1" />
-  <macro id="702" versions="6.000 6.040" description="Call Macro 2" />
-  <macro id="703" versions="6.000 6.040" description="Call Macro 3" />
-  <macro id="704" versions="6.000 6.040" description="Call Macro 4" />
-  <macro id="705" versions="6.000 6.040" description="Call Macro 5" />
-  <macro id="706" versions="6.000 6.040" description="Call Macro 6" />
-  <macro id="707" versions="6.000 6.040" description="Call Macro 7" />
-  <macro id="708" versions="6.000 6.040" description="Call Macro 8" />
-  <macro id="709" versions="6.000 6.040" description="Call Macro 9" />
-  <macro id="710" versions="6.000 6.040" description="Call Macro 10" />
-  <macro id="711" versions="6.000 6.040" description="Call Macro 11" />
-  <macro id="712" versions="6.000 6.040" description="Call Macro 12" />
-  <macro id="713" versions="6.000 6.040" description="Call Macro 13" />
-  <macro id="714" versions="6.000 6.040" description="Call Macro 14" />
-  <macro id="715" versions="6.000 6.040" description="Call Macro 15" />
-  <macro id="716" versions="6.000 6.040" description="Call Macro 16" />
-  <macro id="717" versions="6.000 6.040" description="Call Macro 17" />
-  <macro id="718" versions="6.000 6.040" description="Call Macro 18" />
-  <macro id="719" versions="6.000 6.040" description="Call Macro 19" />
-  <macro id="720" versions="6.000 6.040" description="Call Macro 20" />
-  <macro id="721" versions="6.000 6.040" description="Call Macro 21" />
-  <macro id="722" versions="6.000 6.040" description="Call Macro 22" />
-  <macro id="723" versions="6.000 6.040" description="Call Macro 23" />
-  <macro id="724" versions="6.000 6.040" description="Call Macro 24" />
-  <macro id="725" versions="6.000 6.040" description="Call Macro 25" />
-  <macro id="726" versions="6.000 6.040" description="Call Macro 26" />
-  <macro id="727" versions="6.000 6.040" description="Call Macro 27" />
-  <macro id="728" versions="6.000 6.040" description="Call Macro 28" />
-  <macro id="729" versions="6.000 6.040" description="Call Macro 29" />
-  <macro id="730" versions="6.000 6.040" description="Call Macro 30" />
-  <macro id="731" versions="6.000 6.040" description="Call Macro 31" />
-  <macro id="732" versions="6.000 6.040" description="Call Macro 32" />
-  <macro id="733" versions="6.000 6.040" description="Call Macro 33" />
-  <macro id="734" versions="6.000 6.040" description="Call Macro 34" />
-  <macro id="735" versions="6.000 6.040" description="Call Macro 35" />
-  <macro id="736" versions="6.000 6.040" description="Call Macro 36" />
-  <macro id="737" versions="6.000 6.040" description="Call Macro 37" />
-  <macro id="738" versions="6.000 6.040" description="Call Macro 38" />
-  <macro id="739" versions="6.000 6.040" description="Call Macro 39" />
-  <macro id="740" versions="6.000 6.040" description="Call Macro 40" />
-  <macro id="741" versions="6.000 6.040" description="Call Macro 41" />
-  <macro id="742" versions="6.000 6.040" description="Call Macro 42" />
-  <macro id="743" versions="6.000 6.040" description="Call Macro 43" />
-  <macro id="744" versions="6.000 6.040" description="Call Macro 44" />
-  <macro id="745" versions="6.000 6.040" description="Call Macro 45" />
-  <macro id="746" versions="6.000 6.040" description="Call Macro 46" />
-  <macro id="747" versions="6.000 6.040" description="Call Macro 47" />
-  <macro id="748" versions="6.000 6.040" description="Call Macro 48" />
-  <macro id="749" versions="6.000 6.040" description="Call Macro 49" />
-  <macro id="750" versions="6.000 6.040" description="Call Macro 50" />
-  <macro id="751" versions="6.000 6.040" description="Call Macro 51" />
-  <macro id="752" versions="6.000 6.040" description="Call Macro 52" />
-  <macro id="753" versions="6.000 6.040" description="Call Macro 53" />
-  <macro id="754" versions="6.000 6.040" description="Call Macro 54" />
-  <macro id="755" versions="6.000 6.040" description="Call Macro 55" />
-  <macro id="756" versions="6.000 6.040" description="Call Macro 56" />
-  <macro id="757" versions="6.000 6.040" description="Call Macro 57" />
-  <macro id="758" versions="6.000 6.040" description="Call Macro 58" />
-  <macro id="759" versions="6.000 6.040" description="Call Macro 59" />
-  <macro id="760" versions="6.000 6.040" description="Call Macro 60" />
-  <macro id="761" versions="6.000 6.040" description="Call Macro 61" />
-  <macro id="762" versions="6.000 6.040" description="Call Macro 62" />
-  <macro id="763" versions="6.000 6.040" description="Call Macro 63" />
-  <macro id="764" versions="6.000 6.040" description="Call Macro 64" />
-  <macro id="766" versions="6.000 6.040" description="Call Macro 65" />
-  <macro id="767" versions="6.000 6.040" description="Call Macro 66" />
-  <macro id="768" versions="6.000 6.040" description="Call Macro 67" />
-  <macro id="769" versions="6.000 6.040" description="Call Macro 68" />
-  <macro id="770" versions="6.000 6.040" description="Call Macro 69" />
-  <macro id="771" versions="6.000 6.040" description="Call Macro 70" />
-  <macro id="772" versions="6.000 6.040" description="Call Macro 71" />
-  <macro id="773" versions="6.000 6.040" description="Call Macro 72" />
-  <macro id="774" versions="6.000 6.040" description="Call Macro 73" />
-  <macro id="775" versions="6.000 6.040" description="Call Macro 74" />
-  <macro id="776" versions="6.000 6.040" description="Call Macro 75" />
-  <macro id="777" versions="6.000 6.040" description="Call Macro 76" />
-  <macro id="778" versions="6.000 6.040" description="Call Macro 77" />
-  <macro id="779" versions="6.000 6.040" description="Call Macro 78" />
-  <macro id="780" versions="6.000 6.040" description="Call Macro 79" />
-  <macro id="781" versions="6.000 6.040" description="Call Macro 80" />
-  <macro id="782" versions="6.000 6.040" description="Call Macro 81" />
-  <macro id="783" versions="6.000 6.040" description="Call Macro 82" />
-  <macro id="784" versions="6.000 6.040" description="Call Macro 83" />
-  <macro id="785" versions="6.000 6.040" description="Call Macro 84" />
-  <macro id="786" versions="6.000 6.040" description="Call Macro 85" />
-  <macro id="787" versions="6.000 6.040" description="Call Macro 86" />
-  <macro id="788" versions="6.000 6.040" description="Call Macro 87" />
-  <macro id="789" versions="6.000 6.040" description="Call Macro 88" />
-  <macro id="790" versions="6.000 6.040" description="Call Macro 89" />
-  <macro id="791" versions="6.000 6.040" description="Call Macro 90" />
+  <macro id="690" versions="6.000 6.045" description="Resume Scheduler Setpoint 11" />
+  <macro id="691" versions="6.000 6.045" description="Resume Scheduler Setpoint 12" />
+  <macro id="692" versions="6.000 6.045" description="Resume Scheduler Setpoint 13" />
+  <macro id="693" versions="6.000 6.045" description="Resume Scheduler Setpoint 14" />
+  <macro id="694" versions="6.000 6.045" description="Resume Scheduler Setpoint 15" />
+  <macro id="695" versions="6.000 6.045" description="Resume Scheduler Setpoint 16" />
+  <macro id="696" versions="6.000 6.045" description="Resume Scheduler Setpoint 17" />
+  <macro id="697" versions="6.000 6.045" description="Resume Scheduler Setpoint 18" />
+  <macro id="698" versions="6.000 6.045" description="Resume Scheduler Setpoint 19" />
+  <macro id="699" versions="6.000 6.045" description="Resume Scheduler Setpoint 20" />
+  <macro id="701" versions="6.000 6.045" description="Call Macro 1" />
+  <macro id="702" versions="6.000 6.045" description="Call Macro 2" />
+  <macro id="703" versions="6.000 6.045" description="Call Macro 3" />
+  <macro id="704" versions="6.000 6.045" description="Call Macro 4" />
+  <macro id="705" versions="6.000 6.045" description="Call Macro 5" />
+  <macro id="706" versions="6.000 6.045" description="Call Macro 6" />
+  <macro id="707" versions="6.000 6.045" description="Call Macro 7" />
+  <macro id="708" versions="6.000 6.045" description="Call Macro 8" />
+  <macro id="709" versions="6.000 6.045" description="Call Macro 9" />
+  <macro id="710" versions="6.000 6.045" description="Call Macro 10" />
+  <macro id="711" versions="6.000 6.045" description="Call Macro 11" />
+  <macro id="712" versions="6.000 6.045" description="Call Macro 12" />
+  <macro id="713" versions="6.000 6.045" description="Call Macro 13" />
+  <macro id="714" versions="6.000 6.045" description="Call Macro 14" />
+  <macro id="715" versions="6.000 6.045" description="Call Macro 15" />
+  <macro id="716" versions="6.000 6.045" description="Call Macro 16" />
+  <macro id="717" versions="6.000 6.045" description="Call Macro 17" />
+  <macro id="718" versions="6.000 6.045" description="Call Macro 18" />
+  <macro id="719" versions="6.000 6.045" description="Call Macro 19" />
+  <macro id="720" versions="6.000 6.045" description="Call Macro 20" />
+  <macro id="721" versions="6.000 6.045" description="Call Macro 21" />
+  <macro id="722" versions="6.000 6.045" description="Call Macro 22" />
+  <macro id="723" versions="6.000 6.045" description="Call Macro 23" />
+  <macro id="724" versions="6.000 6.045" description="Call Macro 24" />
+  <macro id="725" versions="6.000 6.045" description="Call Macro 25" />
+  <macro id="726" versions="6.000 6.045" description="Call Macro 26" />
+  <macro id="727" versions="6.000 6.045" description="Call Macro 27" />
+  <macro id="728" versions="6.000 6.045" description="Call Macro 28" />
+  <macro id="729" versions="6.000 6.045" description="Call Macro 29" />
+  <macro id="730" versions="6.000 6.045" description="Call Macro 30" />
+  <macro id="731" versions="6.000 6.045" description="Call Macro 31" />
+  <macro id="732" versions="6.000 6.045" description="Call Macro 32" />
+  <macro id="733" versions="6.000 6.045" description="Call Macro 33" />
+  <macro id="734" versions="6.000 6.045" description="Call Macro 34" />
+  <macro id="735" versions="6.000 6.045" description="Call Macro 35" />
+  <macro id="736" versions="6.000 6.045" description="Call Macro 36" />
+  <macro id="737" versions="6.000 6.045" description="Call Macro 37" />
+  <macro id="738" versions="6.000 6.045" description="Call Macro 38" />
+  <macro id="739" versions="6.000 6.045" description="Call Macro 39" />
+  <macro id="740" versions="6.000 6.045" description="Call Macro 40" />
+  <macro id="741" versions="6.000 6.045" description="Call Macro 41" />
+  <macro id="742" versions="6.000 6.045" description="Call Macro 42" />
+  <macro id="743" versions="6.000 6.045" description="Call Macro 43" />
+  <macro id="744" versions="6.000 6.045" description="Call Macro 44" />
+  <macro id="745" versions="6.000 6.045" description="Call Macro 45" />
+  <macro id="746" versions="6.000 6.045" description="Call Macro 46" />
+  <macro id="747" versions="6.000 6.045" description="Call Macro 47" />
+  <macro id="748" versions="6.000 6.045" description="Call Macro 48" />
+  <macro id="749" versions="6.000 6.045" description="Call Macro 49" />
+  <macro id="750" versions="6.000 6.045" description="Call Macro 50" />
+  <macro id="751" versions="6.000 6.045" description="Call Macro 51" />
+  <macro id="752" versions="6.000 6.045" description="Call Macro 52" />
+  <macro id="753" versions="6.000 6.045" description="Call Macro 53" />
+  <macro id="754" versions="6.000 6.045" description="Call Macro 54" />
+  <macro id="755" versions="6.000 6.045" description="Call Macro 55" />
+  <macro id="756" versions="6.000 6.045" description="Call Macro 56" />
+  <macro id="757" versions="6.000 6.045" description="Call Macro 57" />
+  <macro id="758" versions="6.000 6.045" description="Call Macro 58" />
+  <macro id="759" versions="6.000 6.045" description="Call Macro 59" />
+  <macro id="760" versions="6.000 6.045" description="Call Macro 60" />
+  <macro id="761" versions="6.000 6.045" description="Call Macro 61" />
+  <macro id="762" versions="6.000 6.045" description="Call Macro 62" />
+  <macro id="763" versions="6.000 6.045" description="Call Macro 63" />
+  <macro id="764" versions="6.000 6.045" description="Call Macro 64" />
+  <macro id="766" versions="6.000 6.045" description="Call Macro 65" />
+  <macro id="767" versions="6.000 6.045" description="Call Macro 66" />
+  <macro id="768" versions="6.000 6.045" description="Call Macro 67" />
+  <macro id="769" versions="6.000 6.045" description="Call Macro 68" />
+  <macro id="770" versions="6.000 6.045" description="Call Macro 69" />
+  <macro id="771" versions="6.000 6.045" description="Call Macro 70" />
+  <macro id="772" versions="6.000 6.045" description="Call Macro 71" />
+  <macro id="773" versions="6.000 6.045" description="Call Macro 72" />
+  <macro id="774" versions="6.000 6.045" description="Call Macro 73" />
+  <macro id="775" versions="6.000 6.045" description="Call Macro 74" />
+  <macro id="776" versions="6.000 6.045" description="Call Macro 75" />
+  <macro id="777" versions="6.000 6.045" description="Call Macro 76" />
+  <macro id="778" versions="6.000 6.045" description="Call Macro 77" />
+  <macro id="779" versions="6.000 6.045" description="Call Macro 78" />
+  <macro id="780" versions="6.000 6.045" description="Call Macro 79" />
+  <macro id="781" versions="6.000 6.045" description="Call Macro 80" />
+  <macro id="782" versions="6.000 6.045" description="Call Macro 81" />
+  <macro id="783" versions="6.000 6.045" description="Call Macro 82" />
+  <macro id="784" versions="6.000 6.045" description="Call Macro 83" />
+  <macro id="785" versions="6.000 6.045" description="Call Macro 84" />
+  <macro id="786" versions="6.000 6.045" description="Call Macro 85" />
+  <macro id="787" versions="6.000 6.045" description="Call Macro 86" />
+  <macro id="788" versions="6.000 6.045" description="Call Macro 87" />
+  <macro id="789" versions="6.000 6.045" description="Call Macro 88" />
+  <macro id="790" versions="6.000 6.045" description="Call Macro 89" />
+  <macro id="791" versions="6.000 6.045" description="Call Macro 90" />
 </macros>

--- a/XML/Ver7_macro_def.xml
+++ b/XML/Ver7_macro_def.xml
@@ -1,0 +1,1009 @@
+<macros version="2.000">
+  <macro id="001" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 CTCSS Access" />
+  <macro id="002" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 CTCSS Access" />
+  <macro id="003" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 CTCSS Access" />
+  <macro id="004" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Carrier Access" />
+  <macro id="005" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Carrier Access" />
+  <macro id="006" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Carrier Access" />
+  <macro id="007" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 DTMF Covertone ON" />
+  <macro id="008" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 DTMF Covertone ON" />
+  <macro id="009" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 DTMF Covertone ON" />
+  <macro id="010" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 DTMF Covertone OFF" />
+  <macro id="011" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 DTMF Covertone OFF" />
+  <macro id="012" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 DTMF Covertone OFF" />
+  <macro id="013" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Enable" />
+  <macro id="014" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Enable" />
+  <macro id="015" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Enable" />
+  <macro id="016" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Disable" />
+  <macro id="017" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Disable" />
+  <macro id="018" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Disable" />
+  <macro id="019" versions="7.00 7.01 7.32 7.36 7.361" description="Monitor Port 1 from Port 2" />
+  <macro id="020" versions="7.00 7.01 7.32 7.36 7.361" description="Monitor Port 1 from Port 3" />
+  <macro id="021" versions="7.00 7.01 7.32 7.36 7.361" description="Disconnect Port 1 from Port 2" />
+  <macro id="022" versions="7.00 7.01 7.32 7.36 7.361" description="Disconnect Port 1 from Port 3" />
+  <macro id="023" versions="7.00 7.01 7.32 7.36 7.361" description="Monitor Port 2 from Port 1" />
+  <macro id="024" versions="7.00 7.01 7.32 7.36 7.361" description="Monitor Port 2 from Port 3" />
+  <macro id="025" versions="7.00 7.01 7.32 7.36 7.361" description="Disconnect Port 2 from Port 1" />
+  <macro id="026" versions="7.00 7.01 7.32 7.36 7.361" description="Disconnect Port 2 from Port 3" />
+  <macro id="027" versions="7.00 7.01 7.32 7.36 7.361" description="Monitor Port 3 from Port 1" />
+  <macro id="028" versions="7.00 7.01 7.32 7.36 7.361" description="Monitor Port 3 from Port 2" />
+  <macro id="029" versions="7.00 7.01 7.32 7.36 7.361" description="Disconnect Port 3 from Port 1" />
+  <macro id="030" versions="7.00 7.01 7.32 7.36 7.361" description="Disconnect Port 3 from Port 2" />
+  <macro id="031" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Monitor Mute" />
+  <macro id="032" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Monitor Mute" />
+  <macro id="033" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Monitor Mute" />
+  <macro id="034" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Monitor Mix" />
+  <macro id="035" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Monitor Mix" />
+  <macro id="036" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Monitor Mix" />
+  <macro id="037" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Repeat ON" />
+  <macro id="038" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Repeat ON" />
+  <macro id="039" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Repeat ON" />
+  <macro id="040" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Repeat OFF" />
+  <macro id="041" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Repeat OFF" />
+  <macro id="042" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Repeat OFF" />
+  <macro id="043" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Speech OverrideON" />
+  <macro id="044" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Speech OverrideON" />
+  <macro id="045" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Speech OverrideON" />
+  <macro id="046" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Speech Override OFF" />
+  <macro id="047" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Speech Override OFF" />
+  <macro id="048" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Speech Override OFF" />
+  <macro id="049" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 1" />
+  <macro id="050" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 2" />
+  <macro id="051" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 3" />
+  <macro id="052" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 4" />
+  <macro id="053" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 5" />
+  <macro id="054" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 6" />
+  <macro id="055" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 7" />
+  <macro id="056" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 8" />
+  <macro id="057" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 9" />
+  <macro id="058" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Courtesy Tone 10" />
+  <macro id="059" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 1" />
+  <macro id="060" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 2" />
+  <macro id="061" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 3" />
+  <macro id="062" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 4" />
+  <macro id="063" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 5" />
+  <macro id="064" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 6" />
+  <macro id="065" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 7" />
+  <macro id="066" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 8" />
+  <macro id="067" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 9" />
+  <macro id="068" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Courtesy Tone 10" />
+  <macro id="069" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 1" />
+  <macro id="070" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 2" />
+  <macro id="071" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 3" />
+  <macro id="072" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 4" />
+  <macro id="073" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 5" />
+  <macro id="074" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 6" />
+  <macro id="075" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 7" />
+  <macro id="076" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 8" />
+  <macro id="077" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 9" />
+  <macro id="078" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Courtesy Tone 10" />
+  <macro id="079" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 DTMF Muting ON" />
+  <macro id="080" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 DTMF Muting ON" />
+  <macro id="081" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 DTMF Muting ON" />
+  <macro id="082" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 DTMF Muting OFF" />
+  <macro id="083" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 DTMF Muting OFF" />
+  <macro id="084" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 DTMF Muting OFF" />
+  <macro id="085" versions="7.00 7.01 7.32 7.36 7.361" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="086" versions="7.00 7.01 7.32 7.36 7.361" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="087" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 1" />
+  <macro id="088" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 2" />
+  <macro id="089" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 3" />
+  <macro id="090" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 4" />
+  <macro id="091" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 5" />
+  <macro id="092" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 6" />
+  <macro id="093" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 7" />
+  <macro id="094" versions="7.00 7.01 7.32 7.36 7.361" description="Read ADC Channel 8" />
+  <macro id="095" versions="7.00 7.01 7.32 7.36 7.361" description="UF1 ON" />
+  <macro id="096" versions="7.00 7.01 7.32 7.36 7.361" description="UF2 ON" />
+  <macro id="097" versions="7.00 7.01 7.32 7.36 7.361" description="UF3 ON" />
+  <macro id="098" versions="7.00 7.01 7.32 7.36 7.361" description="UF4 ON" />
+  <macro id="099" versions="7.00 7.01 7.32 7.36 7.361" description="UF5 ON" />
+  <macro id="100" versions="7.00 7.01 7.32 7.36 7.361" description="UF6 ON" />
+  <macro id="101" versions="7.00 7.01 7.32 7.36 7.361" description="UF7 ON" />
+  <macro id="102" versions="7.00 7.01 7.32 7.36 7.361" description="UF1 OFF" />
+  <macro id="103" versions="7.00 7.01 7.32 7.36 7.361" description="UF2 OFF" />
+  <macro id="104" versions="7.00 7.01 7.32 7.36 7.361" description="UF3 OFF" />
+  <macro id="105" versions="7.00 7.01 7.32 7.36 7.361" description="UF4 OFF" />
+  <macro id="106" versions="7.00 7.01 7.32 7.36 7.361" description="UF5 OFF" />
+  <macro id="107" versions="7.00 7.01 7.32 7.36 7.361" description="UF6 OFF" />
+  <macro id="108" versions="7.00 7.01 7.32 7.36 7.361" description="UF7 OFF" />
+  <macro id="109" versions="7.00 7.01 7.32 7.36 7.361" description="UF1 Pulse" />
+  <macro id="110" versions="7.00 7.01 7.32 7.36 7.361" description="UF2 Pulse" />
+  <macro id="111" versions="7.00 7.01 7.32 7.36 7.361" description="UF3 Pulse" />
+  <macro id="112" versions="7.00 7.01 7.32 7.36 7.361" description="UF4 Pulse" />
+  <macro id="113" versions="7.00 7.01 7.32 7.36 7.361" description="UF5 Pulse" />
+  <macro id="114" versions="7.00 7.01 7.32 7.36 7.361" description="UF6 Pulse" />
+  <macro id="115" versions="7.00 7.01 7.32 7.36 7.361" description="UF7 Pulse" />
+  <macro id="116" versions="7.00 7.01 7.32 7.36 7.361" description="Say Time" />
+  <macro id="117" versions="7.00 7.01 7.32 7.36 7.361" description="Say Date" />
+  <macro id="118" versions="7.00 7.01 7.32 7.36 7.361" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="7.00 7.01 7.32 7.36 7.361" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="7.00 7.01 7.32 7.36 7.361" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="7.00 7.01 7.32 7.36 7.361" description="Link All Ports" />
+  <macro id="122" versions="7.00 7.01 7.32 7.36 7.361" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="7.00 7.01 7.32 7.36 7.361" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="7.00 7.01 7.32 7.36 7.361" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="7.00 7.01 7.32 7.36 7.361" description="UnLink All Ports" />
+  <macro id="126" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 1" />
+  <macro id="127" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 2" />
+  <macro id="128" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 3" />
+  <macro id="129" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 4" />
+  <macro id="130" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 5" />
+  <macro id="131" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 6" />
+  <macro id="132" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 7" />
+  <macro id="133" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 8" />
+  <macro id="134" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 9" />
+  <macro id="135" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 10" />
+  <macro id="136" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 11" />
+  <macro id="137" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 12" />
+  <macro id="138" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 13" />
+  <macro id="139" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 14" />
+  <macro id="140" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 15" />
+  <macro id="141" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 16" />
+  <macro id="142" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 17" />
+  <macro id="143" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 18" />
+  <macro id="144" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 19" />
+  <macro id="145" versions="7.00 7.01 7.32 7.36 7.361" description="Play DVR Track 20" />
+  <macro id="146" versions="7.00 7.01 7.32 7.36 7.361" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="7.00 7.01 7.32 7.36 7.361" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="7.00 7.01 7.32 7.36 7.361" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="7.00 7.01 7.32 7.36 7.361" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="7.00 7.01 7.32 7.36 7.361" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="7.00 7.01 7.32 7.36 7.361" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 1 ON" />
+  <macro id="153" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 2 ON" />
+  <macro id="154" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 3 ON" />
+  <macro id="155" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 4 ON" />
+  <macro id="156" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 5 ON" />
+  <macro id="157" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 1 OFF" />
+  <macro id="158" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 2 OFF" />
+  <macro id="159" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 3 OFF" />
+  <macro id="160" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 4 OFF" />
+  <macro id="161" versions="7.00 7.01 7.32 7.36 7.361" description="Alarm 5 OFF" />
+  <macro id="162" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out Port 1" />
+  <macro id="163" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out Port 2" />
+  <macro id="164" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out Port 3" />
+  <macro id="165" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="7.00 7.01 7.32 7.36 7.361" description="Speech Out All Ports" />
+  <macro id="169" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Enable Port 1" />
+  <macro id="170" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Enable Port 2" />
+  <macro id="171" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Enable Port 3" />
+  <macro id="172" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Disable Port 1" />
+  <macro id="173" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Disable Port 2" />
+  <macro id="174" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Disable Port 3" />
+  <macro id="175" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="7.00 7.01 7.32 7.36 7.361" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="7.00 7.01 7.32 7.36 7.361" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="7.00 7.01 7.32 7.36 7.361" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="7.00 7.01 7.32 7.36 7.361" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="7.00 7.01 7.32 7.36 7.361" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="7.00 7.01 7.32 7.36 7.361" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="7.00 7.01 7.32 7.36 7.361" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 1" />
+  <macro id="188" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 2" />
+  <macro id="189" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 3" />
+  <macro id="190" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 4" />
+  <macro id="191" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 5" />
+  <macro id="192" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 6" />
+  <macro id="193" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 7" />
+  <macro id="194" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 8" />
+  <macro id="195" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 9" />
+  <macro id="196" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 10" />
+  <macro id="197" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 11" />
+  <macro id="198" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 12" />
+  <macro id="199" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 13" />
+  <macro id="200" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 14" />
+  <macro id="201" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 15" />
+  <macro id="202" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 16" />
+  <macro id="203" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 17" />
+  <macro id="204" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 18" />
+  <macro id="205" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 19" />
+  <macro id="206" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 20" />
+  <macro id="207" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 21" />
+  <macro id="208" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 22" />
+  <macro id="209" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 23" />
+  <macro id="210" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 24" />
+  <macro id="211" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 25" />
+  <macro id="212" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 26" />
+  <macro id="213" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 27" />
+  <macro id="214" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 28" />
+  <macro id="215" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 29" />
+  <macro id="216" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 30" />
+  <macro id="217" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 31" />
+  <macro id="218" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 32" />
+  <macro id="219" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 33" />
+  <macro id="220" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 34" />
+  <macro id="221" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 35" />
+  <macro id="222" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 36" />
+  <macro id="223" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 37" />
+  <macro id="224" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 38" />
+  <macro id="225" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 39" />
+  <macro id="226" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 40" />
+  <macro id="227" versions="7.00 7.01 7.32 7.36 7.361" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="7.00 7.01 7.32 7.36 7.361" description="Macro Priority High" />
+  <macro id="229" versions="7.00 7.01 7.32 7.36 7.361" description="Macro Priority Low" />
+  <macro id="230" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Receiver Port 1" />
+  <macro id="237" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Receiver Port 2" />
+  <macro id="238" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Receiver Port 3" />
+  <macro id="239" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Receiver Port 1" />
+  <macro id="240" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Receiver Port 2" />
+  <macro id="241" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Receiver Port 3" />
+  <macro id="242" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="7.00 7.01 7.32 7.36 7.361" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="7.00 7.01 7.32 7.36 7.361" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="7.00 7.01 7.32 7.36 7.361" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="7.00 7.01 7.32 7.36 7.361" description="Force Audio To Entered Port" />
+  <macro id="252" versions="7.00 7.01 7.32 7.36 7.361" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="7.00 7.01 7.32 7.36 7.361" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="7.00 7.01 7.32 7.36 7.361" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="7.00 7.01 7.32 7.36 7.361" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="7.00 7.01 7.32 7.36 7.361" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="7.00 7.01 7.32 7.36 7.361" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 1" />
+  <macro id="260" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 2" />
+  <macro id="261" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 3" />
+  <macro id="262" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 4" />
+  <macro id="263" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 5" />
+  <macro id="264" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 6" />
+  <macro id="265" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 7" />
+  <macro id="266" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 8" />
+  <macro id="267" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 9" />
+  <macro id="268" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 10" />
+  <macro id="269" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 11" />
+  <macro id="270" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 12" />
+  <macro id="271" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 13" />
+  <macro id="272" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 14" />
+  <macro id="273" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 15" />
+  <macro id="274" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 16" />
+  <macro id="275" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 17" />
+  <macro id="276" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 18" />
+  <macro id="277" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 19" />
+  <macro id="278" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 20" />
+  <macro id="279" versions="7.00 7.01 7.32 7.36 7.361" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="7.00 7.01 7.32 7.36 7.361" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="7.00 7.01 7.32 7.36 7.361" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="7.00 7.01 7.32 7.36 7.361" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="7.00 7.01 7.32 7.36 7.361" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="7.00 7.01 7.32 7.36 7.361" description="Say year as part of date" />
+  <macro id="308" versions="7.00 7.01 7.32 7.36 7.361" description="Don't say year as part of date" />
+  <macro id="309" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 1" />
+  <macro id="322" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 2" />
+  <macro id="323" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 3" />
+  <macro id="324" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 4" />
+  <macro id="325" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 5" />
+  <macro id="326" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 6" />
+  <macro id="327" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 7" />
+  <macro id="328" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 8" />
+  <macro id="329" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 9" />
+  <macro id="330" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 10" />
+  <macro id="331" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Zero Hang Time Select" />
+  <macro id="336" versions="7.36 7.361" description="Dial 911" />
+  <macro id="337" versions="7.00 7.01 7.32 7.36 7.361" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Autopatch" />
+  <macro id="339" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="7.00 7.01 7.32 7.36 7.361" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="7.00 7.01 7.32 7.36 7.361" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="7.00 7.01 7.32 7.36 7.361" description="Start General Timer 1" />
+  <macro id="348" versions="7.00 7.01 7.32 7.36 7.361" description="Start General Timer 2" />
+  <macro id="349" versions="7.00 7.01 7.32 7.36 7.361" description="Start General Timer 3" />
+  <macro id="350" versions="7.00 7.01 7.32 7.36 7.361" description="Stop General Timer 1" />
+  <macro id="351" versions="7.00 7.01 7.32 7.36 7.361" description="Stop General Timer 2" />
+  <macro id="352" versions="7.00 7.01 7.32 7.36 7.361" description="Stop General Timer 3" />
+  <macro id="353" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Power Select 1" />
+  <macro id="354" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Power Select 2" />
+  <macro id="355" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Power Select 3" />
+  <macro id="356" versions="7.00 7.01 7.32 7.36 7.361" description="Guest Macros Enabled" />
+  <macro id="357" versions="7.00 7.01 7.32 7.36 7.361" description="Guest Macros Disabled" />
+  <macro id="358" versions="7.00 7.01 7.32 7.36 7.361" description="Receiver 1 Macros On" />
+  <macro id="359" versions="7.00 7.01 7.32 7.36 7.361" description="Receiver 2 Macros On" />
+  <macro id="360" versions="7.00 7.01 7.32 7.36 7.361" description="Receiver 3 Macros On" />
+  <macro id="361" versions="7.00 7.01 7.32 7.36 7.361" description="Receiver 1 Macros Off" />
+  <macro id="362" versions="7.00 7.01 7.32 7.36 7.361" description="Receiver 2 Macros Off" />
+  <macro id="363" versions="7.00 7.01 7.32 7.36 7.361" description="Receiver 3 Macros Off" />
+  <macro id="364" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 1 Output ON" />
+  <macro id="365" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 2 Output ON" />
+  <macro id="366" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 3 Output ON" />
+  <macro id="367" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 4 Output ON" />
+  <macro id="368" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 5 Output ON" />
+  <macro id="369" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 6 Output ON" />
+  <macro id="370" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 7 Output ON" />
+  <macro id="371" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 8 Output ON" />
+  <macro id="372" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 9 Output ON" />
+  <macro id="373" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 10 Output ON" />
+  <macro id="374" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 11 Output ON" />
+  <macro id="375" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 12 Output ON" />
+  <macro id="376" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 13 Output ON" />
+  <macro id="377" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 14 Output ON" />
+  <macro id="378" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 15 Output ON" />
+  <macro id="379" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 16 Output ON" />
+  <macro id="380" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 17 Output ON" />
+  <macro id="381" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 18 Output ON" />
+  <macro id="382" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 19 Output ON" />
+  <macro id="383" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 20 Output ON" />
+  <macro id="384" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 21 Output ON" />
+  <macro id="385" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 22 Output ON" />
+  <macro id="386" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 23 Output ON" />
+  <macro id="387" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 24 Output ON" />
+  <macro id="388" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 25 Output ON" />
+  <macro id="389" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 26 Output ON" />
+  <macro id="390" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 27 Output ON" />
+  <macro id="391" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 28 Output ON" />
+  <macro id="392" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 29 Output ON" />
+  <macro id="393" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 30 Output ON" />
+  <macro id="394" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 31 Output ON" />
+  <macro id="395" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 32 Output ON" />
+  <macro id="396" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 1 Output Pulse" />
+  <macro id="397" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 2 Output Pulse" />
+  <macro id="398" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 3 Output Pulse" />
+  <macro id="399" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 4 Output Pulse" />
+  <macro id="400" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 5 Output Pulse" />
+  <macro id="401" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 6 Output Pulse" />
+  <macro id="402" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 7 Output Pulse" />
+  <macro id="403" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 8 Output Pulse" />
+  <macro id="404" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 9 Output Pulse" />
+  <macro id="405" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 10 Output Pulse" />
+  <macro id="406" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 11 Output Pulse" />
+  <macro id="407" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 12 Output Pulse" />
+  <macro id="408" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 13 Output Pulse" />
+  <macro id="409" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 14 Output Pulse" />
+  <macro id="410" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 15 Output Pulse" />
+  <macro id="411" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 16 Output Pulse" />
+  <macro id="412" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 17 Output Pulse" />
+  <macro id="413" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 18 Output Pulse" />
+  <macro id="414" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 19 Output Pulse" />
+  <macro id="415" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 20 Output Pulse" />
+  <macro id="416" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 21 Output Pulse" />
+  <macro id="417" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 22 Output Pulse" />
+  <macro id="418" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 23 Output Pulse" />
+  <macro id="419" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 24 Output Pulse" />
+  <macro id="420" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 25 Output Pulse" />
+  <macro id="421" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 26 Output Pulse" />
+  <macro id="422" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 27 Output Pulse" />
+  <macro id="423" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 28 Output Pulse" />
+  <macro id="424" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 29 Output Pulse" />
+  <macro id="425" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 30 Output Pulse" />
+  <macro id="426" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 31 Output Pulse" />
+  <macro id="427" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 32 Output Pulse" />
+  <macro id="428" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 1 Output OFF" />
+  <macro id="429" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 2 Output OFF" />
+  <macro id="430" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 3 Output OFF" />
+  <macro id="431" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 4 Output OFF" />
+  <macro id="432" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 5 Output OFF" />
+  <macro id="433" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 6 Output OFF" />
+  <macro id="434" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 7 Output OFF" />
+  <macro id="435" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 8 Output OFF" />
+  <macro id="436" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 9 Output OFF" />
+  <macro id="437" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 10 Output OFF" />
+  <macro id="438" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 11 Output OFF" />
+  <macro id="439" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 12 Output OFF" />
+  <macro id="440" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 13 Output OFF" />
+  <macro id="441" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 14 Output OFF" />
+  <macro id="442" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 15 Output OFF" />
+  <macro id="443" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 16 Output OFF" />
+  <macro id="444" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 17 Output OFF" />
+  <macro id="445" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 18 Output OFF" />
+  <macro id="446" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 19 Output OFF" />
+  <macro id="447" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 20 Output OFF" />
+  <macro id="448" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 21 Output OFF" />
+  <macro id="449" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 22 Output OFF" />
+  <macro id="450" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 23 Output OFF" />
+  <macro id="451" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 24 Output OFF" />
+  <macro id="452" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 25 Output OFF" />
+  <macro id="453" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 26 Output OFF" />
+  <macro id="454" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 27 Output OFF" />
+  <macro id="455" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 28 Output OFF" />
+  <macro id="456" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 29 Output OFF" />
+  <macro id="457" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 30 Output OFF" />
+  <macro id="458" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 31 Output OFF" />
+  <macro id="459" versions="7.00 7.01 7.32 7.36 7.361" description="Extended Logic 32 Output OFF" />
+  <macro id="460" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 41" />
+  <macro id="461" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 42" />
+  <macro id="462" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 43" />
+  <macro id="463" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 44" />
+  <macro id="464" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 45" />
+  <macro id="465" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 46" />
+  <macro id="466" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 47" />
+  <macro id="467" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 48" />
+  <macro id="468" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 49" />
+  <macro id="469" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 50" />
+  <macro id="470" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 51" />
+  <macro id="471" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 52" />
+  <macro id="472" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 53" />
+  <macro id="473" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 54" />
+  <macro id="474" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 55" />
+  <macro id="475" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 56" />
+  <macro id="476" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 57" />
+  <macro id="477" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 58" />
+  <macro id="478" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 59" />
+  <macro id="479" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 60" />
+  <macro id="480" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 61" />
+  <macro id="481" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 62" />
+  <macro id="482" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 63" />
+  <macro id="483" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 64" />
+  <macro id="484" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 65" />
+  <macro id="485" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 66" />
+  <macro id="486" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 67" />
+  <macro id="487" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 68" />
+  <macro id="488" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 69" />
+  <macro id="489" versions="7.00 7.01 7.32 7.36 7.361" description="Play Message Macro 70" />
+  <macro id="490" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 11" />
+  <macro id="491" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 12" />
+  <macro id="492" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 13" />
+  <macro id="493" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 14" />
+  <macro id="494" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 15" />
+  <macro id="495" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 16" />
+  <macro id="496" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 17" />
+  <macro id="497" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 18" />
+  <macro id="498" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 19" />
+  <macro id="499" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 20" />
+  <macro id="500" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 21" />
+  <macro id="501" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 22" />
+  <macro id="502" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 23" />
+  <macro id="503" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 24" />
+  <macro id="504" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 25" />
+  <macro id="505" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 26" />
+  <macro id="506" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 27" />
+  <macro id="507" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 28" />
+  <macro id="508" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 29" />
+  <macro id="509" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 30" />
+  <macro id="511" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 31" />
+  <macro id="512" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 32" />
+  <macro id="513" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 33" />
+  <macro id="514" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 34" />
+  <macro id="515" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 35" />
+  <macro id="516" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 36" />
+  <macro id="517" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 37" />
+  <macro id="518" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 38" />
+  <macro id="519" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 39" />
+  <macro id="520" versions="7.00 7.01 7.32 7.36 7.361" description="Remote Base Memory 40" />
+  <macro id="521" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 21" />
+  <macro id="522" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 22" />
+  <macro id="523" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 23" />
+  <macro id="524" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 24" />
+  <macro id="525" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 25" />
+  <macro id="526" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 26" />
+  <macro id="527" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 27" />
+  <macro id="528" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 28" />
+  <macro id="529" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 29" />
+  <macro id="530" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 30" />
+  <macro id="531" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 31" />
+  <macro id="532" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 32" />
+  <macro id="533" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 33" />
+  <macro id="534" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 34" />
+  <macro id="535" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 35" />
+  <macro id="536" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 36" />
+  <macro id="537" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 37" />
+  <macro id="538" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 38" />
+  <macro id="539" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 39" />
+  <macro id="540" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 40" />
+  <macro id="541" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 41" />
+  <macro id="542" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 42" />
+  <macro id="543" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 43" />
+  <macro id="544" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 44" />
+  <macro id="545" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 45" />
+  <macro id="546" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 46" />
+  <macro id="547" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 47" />
+  <macro id="548" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 48" />
+  <macro id="549" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 49" />
+  <macro id="550" versions="7.00 7.01 7.32 7.36 7.361" description="Send DTMF Memory 50" />
+  <macro id="551" versions="7.00 7.01 7.32 7.36 7.361" description="Get RTC Time and Date" />
+  <macro id="552" versions="7.00 7.01 7.32 7.36 7.361" description="CTCSS During ID ON" />
+  <macro id="553" versions="7.00 7.01 7.32 7.36 7.361" description="CTCSS During ID OFF" />
+  <macro id="561" versions="7.00 7.01 7.32 7.36 7.361" description="Restart Controller" />
+  <macro id="570" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="571" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="572" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="573" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="574" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="575" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="576" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="577" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="578" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 1 Stored High" />
+  <macro id="579" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 2 Stored High" />
+  <macro id="580" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 3 Stored High" />
+  <macro id="581" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 4 Stored High" />
+  <macro id="582" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 5 Stored High" />
+  <macro id="583" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 6 Stored High" />
+  <macro id="584" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 7 Stored High" />
+  <macro id="585" versions="7.00 7.01 7.32 7.36 7.361" description="Readback A/D Channel 8 Stored High" />
+  <macro id="586" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="592" versions="7.00 7.01 7.32 7.36 7.361" description="Current wind speed and direction" />
+  <macro id="593" versions="7.00 7.01 7.32 7.36 7.361" description="Current Outdoor temperature" />
+  <macro id="594" versions="7.00 7.01 7.32 7.36 7.361" description="Indoor humidity" />
+  <macro id="595" versions="7.00 7.01 7.32 7.36 7.361" description="Outdoor humidity" />
+  <macro id="596" versions="7.00 7.01 7.32 7.36 7.361" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="597" versions="7.00 7.01 7.32 7.36 7.361" description="Outdoor Temp High (since Midnight)" />
+  <macro id="598" versions="7.00 7.01 7.32 7.36 7.361" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="605" versions="7.00 7.01 7.32 7.36 7.361" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="606" versions="7.00 7.01 7.32 7.36 7.361" description="Start General Timer 4" />
+  <macro id="607" versions="7.00 7.01 7.32 7.36 7.361" description="Start General Timer 5" />
+  <macro id="608" versions="7.00 7.01 7.32 7.36 7.361" description="Start General Timer 6" />
+  <macro id="609" versions="7.00 7.01 7.32 7.36 7.361" description="Stop General Timer 4" />
+  <macro id="610" versions="7.00 7.01 7.32 7.36 7.361" description="Stop General Timer 5" />
+  <macro id="611" versions="7.00 7.01 7.32 7.36 7.361" description="Stop General Timer 6" />
+  <macro id="612" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Port 1 Inactivity Timer" />
+  <macro id="613" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Port 2 Inactivity Timer" />
+  <macro id="614" versions="7.00 7.01 7.32 7.36 7.361" description="Disable Port 3 Inactivity Timer" />
+  <macro id="615" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="7.00 7.01 7.32 7.36 7.361" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="618" versions="7.00 7.01 7.32 7.36 7.361" description="1 Second Execution Delay" />
+  <macro id="619" versions="7.00 7.01 7.32 7.36 7.361" description="2 Second Execution Delay" />
+  <macro id="620" versions="7.00 7.01 7.32 7.36 7.361" description="4 Second Execution Delay" />
+  <macro id="621" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Hangtimer 1 Select" />
+  <macro id="622" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Hangtimer 2 Select" />
+  <macro id="623" versions="7.00 7.01 7.32 7.36 7.361" description="Port 1 Hangtimer 3 Select" />
+  <macro id="624" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Hangtimer 1 Select" />
+  <macro id="625" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Hangtimer 2 Select" />
+  <macro id="626" versions="7.00 7.01 7.32 7.36 7.361" description="Port 2 Hangtimer 3 Select" />
+  <macro id="627" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Hangtimer 1 Select" />
+  <macro id="628" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Hangtimer 2 Select" />
+  <macro id="629" versions="7.00 7.01 7.32 7.36 7.361" description="Port 3 Hangtimer 3 Select" />
+  <macro id="630" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 1" />
+  <macro id="631" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 2" />
+  <macro id="632" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 3" />
+  <macro id="633" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 4" />
+  <macro id="634" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 5" />
+  <macro id="635" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 6" />
+  <macro id="636" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 7" />
+  <macro id="637" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 8" />
+  <macro id="638" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 9" />
+  <macro id="639" versions="7.32 7.36 7.361" description="Port 1 Next Courtesy Tone 10" />
+  <macro id="640" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 1" />
+  <macro id="641" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 2" />
+  <macro id="642" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 3" />
+  <macro id="643" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 4" />
+  <macro id="644" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 5" />
+  <macro id="645" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 6" />
+  <macro id="646" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 7" />
+  <macro id="647" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 8" />
+  <macro id="648" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 9" />
+  <macro id="649" versions="7.32 7.36 7.361" description="Port 1 Following Courtesy Tone 10" />
+  <macro id="650" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="651" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone1" />
+  <macro id="652" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone2" />
+  <macro id="653" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="654" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="655" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="656" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="657" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="658" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone" />
+  <macro id="659" versions="7.32 7.36 7.361" description="Port 2 Next Courtesy Tone 10" />
+  <macro id="660" versions="7.00 7.01" description="Suspend Scheduler Setpoint 1" />
+  <macro id="660" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 1" />
+  <macro id="661" versions="7.00 7.01" description="Suspend Scheduler Setpoint 2" />
+  <macro id="661" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 2" />
+  <macro id="662" versions="7.00 7.01" description="Suspend Scheduler Setpoint 3" />
+  <macro id="662" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 3" />
+  <macro id="663" versions="7.00 7.01" description="Suspend Scheduler Setpoint 4" />
+  <macro id="663" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 4" />
+  <macro id="664" versions="7.00 7.01" description="Suspend Scheduler Setpoint 5" />
+  <macro id="664" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 5" />
+  <macro id="665" versions="7.00 7.01" description="Suspend Scheduler Setpoint 6" />
+  <macro id="665" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 6" />
+  <macro id="666" versions="7.00 7.01" description="Suspend Scheduler Setpoint 7" />
+  <macro id="666" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 7" />
+  <macro id="667" versions="7.00 7.01" description="Suspend Scheduler Setpoint 8" />
+  <macro id="667" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 8" />
+  <macro id="668" versions="7.00 7.01" description="Suspend Scheduler Setpoint 9" />
+  <macro id="668" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 9" />
+  <macro id="669" versions="7.00 7.01" description="Suspend Scheduler Setpoint 10" />
+  <macro id="669" versions="7.32 7.36 7.361" description="Port 2 Following Courtesy Tone 10" />
+  <macro id="670" versions="7.00 7.01" description="Suspend Scheduler Setpoint 11" />
+  <macro id="670" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 1" />
+  <macro id="671" versions="7.00 7.01" description="Suspend Scheduler Setpoint 12" />
+  <macro id="671" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 2" />
+  <macro id="672" versions="7.00 7.01" description="Suspend Scheduler Setpoint 13" />
+  <macro id="672" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 3" />
+  <macro id="673" versions="7.00 7.01" description="Suspend Scheduler Setpoint 14" />
+  <macro id="673" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 4" />
+  <macro id="674" versions="7.00 7.01" description="Suspend Scheduler Setpoint 15" />
+  <macro id="674" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 5" />
+  <macro id="675" versions="7.00 7.01" description="Suspend Scheduler Setpoint 16" />
+  <macro id="675" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 6" />
+  <macro id="676" versions="7.00 7.01" description="Suspend Scheduler Setpoint 17" />
+  <macro id="676" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 7" />
+  <macro id="677" versions="7.00 7.01" description="Suspend Scheduler Setpoint 18" />
+  <macro id="677" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 8" />
+  <macro id="678" versions="7.00 7.01" description="Suspend Scheduler Setpoint 19" />
+  <macro id="678" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 9" />
+  <macro id="679" versions="7.00 7.01" description="Suspend Scheduler Setpoint 20" />
+  <macro id="679" versions="7.32 7.36 7.361" description="Port 3 Next Courtesy Tone 10" />
+  <macro id="680" versions="7.00 7.01" description="Resume Scheduler Setpoint 1" />
+  <macro id="680" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 1" />
+  <macro id="681" versions="7.00 7.01" description="Resume Scheduler Setpoint 2" />
+  <macro id="681" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="682" versions="7.00 7.01" description="Resume Scheduler Setpoint 3" />
+  <macro id="682" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="683" versions="7.00 7.01" description="Resume Scheduler Setpoint 4" />
+  <macro id="683" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 4" />
+  <macro id="684" versions="7.00 7.01" description="Resume Scheduler Setpoint 5" />
+  <macro id="684" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 5" />
+  <macro id="685" versions="7.00 7.01" description="Resume Scheduler Setpoint 6" />
+  <macro id="685" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 6" />
+  <macro id="686" versions="7.00 7.01" description="Resume Scheduler Setpoint 7" />
+  <macro id="686" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 7" />
+  <macro id="687" versions="7.00 7.01" description="Resume Scheduler Setpoint 8" />
+  <macro id="687" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 8" />
+  <macro id="688" versions="7.00 7.01" description="Resume Scheduler Setpoint 9" />
+  <macro id="688" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 9" />
+  <macro id="689" versions="7.00 7.01" description="Resume Scheduler Setpoint 10" />
+  <macro id="689" versions="7.32 7.36 7.361" description="Port 3 Following Courtesy Tone 10" />
+  <macro id="690" versions="7.00 7.01" description="Resume Scheduler Setpoint 11" />
+  <macro id="691" versions="7.00 7.01" description="Resume Scheduler Setpoint 12" />
+  <macro id="692" versions="7.00 7.01" description="Resume Scheduler Setpoint 13" />
+  <macro id="692" versions="7.36 7.361" description="Play Port 1 Pending ID" />
+  <macro id="693" versions="7.00 7.01" description="Resume Scheduler Setpoint 14" />
+  <macro id="693" versions="7.36 7.361" description="Play Port 2 Pending ID" />
+  <macro id="694" versions="7.00 7.01" description="Resume Scheduler Setpoint 15" />
+  <macro id="694" versions="7.36 7.361" description="Play Port 3 Pending ID" />
+  <macro id="695" versions="7.00 7.01" description="Resume Scheduler Setpoint 16" />
+  <macro id="696" versions="7.00 7.01" description="Resume Scheduler Setpoint 17" />
+  <macro id="697" versions="7.00 7.01" description="Resume Scheduler Setpoint 18" />
+  <macro id="698" versions="7.00 7.01" description="Resume Scheduler Setpoint 19" />
+  <macro id="699" versions="7.00 7.01" description="Resume Scheduler Setpoint 20" />
+  <macro id="701" versions="7.00 7.01" description="Call Macro 1" />
+  <macro id="702" versions="7.00 7.01" description="Call Macro 2" />
+  <macro id="703" versions="7.00 7.01" description="Call Macro 3" />
+  <macro id="704" versions="7.00 7.01" description="Call Macro 4" />
+  <macro id="705" versions="7.00 7.01" description="Call Macro 5" />
+  <macro id="706" versions="7.00 7.01" description="Call Macro 6" />
+  <macro id="707" versions="7.00 7.01" description="Call Macro 7" />
+  <macro id="708" versions="7.00 7.01" description="Call Macro 8" />
+  <macro id="709" versions="7.00 7.01" description="Call Macro 9" />
+  <macro id="710" versions="7.00 7.01" description="Call Macro 10" />
+  <macro id="711" versions="7.00 7.01" description="Call Macro 11" />
+  <macro id="712" versions="7.00 7.01" description="Call Macro 12" />
+  <macro id="713" versions="7.00 7.01" description="Call Macro 13" />
+  <macro id="714" versions="7.00 7.01" description="Call Macro 14" />
+  <macro id="715" versions="7.00 7.01" description="Call Macro 15" />
+  <macro id="716" versions="7.00 7.01" description="Call Macro 16" />
+  <macro id="717" versions="7.00 7.01" description="Call Macro 17" />
+  <macro id="718" versions="7.00 7.01" description="Call Macro 18" />
+  <macro id="719" versions="7.00 7.01" description="Call Macro 19" />
+  <macro id="720" versions="7.00 7.01" description="Call Macro 20" />
+  <macro id="721" versions="7.00 7.01" description="Call Macro 21" />
+  <macro id="722" versions="7.00 7.01" description="Call Macro 22" />
+  <macro id="723" versions="7.00 7.01" description="Call Macro 23" />
+  <macro id="724" versions="7.00 7.01" description="Call Macro 24" />
+  <macro id="725" versions="7.00 7.01" description="Call Macro 25" />
+  <macro id="726" versions="7.00 7.01" description="Call Macro 26" />
+  <macro id="727" versions="7.00 7.01" description="Call Macro 27" />
+  <macro id="728" versions="7.00 7.01" description="Call Macro 28" />
+  <macro id="729" versions="7.00 7.01" description="Call Macro 29" />
+  <macro id="730" versions="7.00 7.01" description="Call Macro 30" />
+  <macro id="731" versions="7.00 7.01" description="Call Macro 31" />
+  <macro id="732" versions="7.00 7.01" description="Call Macro 32" />
+  <macro id="733" versions="7.00 7.01" description="Call Macro 33" />
+  <macro id="734" versions="7.00 7.01" description="Call Macro 34" />
+  <macro id="735" versions="7.00 7.01" description="Call Macro 35" />
+  <macro id="736" versions="7.00 7.01" description="Call Macro 36" />
+  <macro id="737" versions="7.00 7.01" description="Call Macro 37" />
+  <macro id="738" versions="7.00 7.01" description="Call Macro 38" />
+  <macro id="739" versions="7.00 7.01" description="Call Macro 39" />
+  <macro id="740" versions="7.00 7.01" description="Call Macro 40" />
+  <macro id="741" versions="7.00 7.01" description="Call Macro 41" />
+  <macro id="742" versions="7.00 7.01" description="Call Macro 42" />
+  <macro id="743" versions="7.00 7.01" description="Call Macro 43" />
+  <macro id="744" versions="7.00 7.01" description="Call Macro 44" />
+  <macro id="745" versions="7.00 7.01" description="Call Macro 45" />
+  <macro id="746" versions="7.00 7.01" description="Call Macro 46" />
+  <macro id="747" versions="7.00 7.01" description="Call Macro 47" />
+  <macro id="748" versions="7.00 7.01" description="Call Macro 48" />
+  <macro id="749" versions="7.00 7.01" description="Call Macro 49" />
+  <macro id="750" versions="7.00 7.01" description="Call Macro 50" />
+  <macro id="751" versions="7.00 7.01" description="Call Macro 51" />
+  <macro id="752" versions="7.00 7.01" description="Call Macro 52" />
+  <macro id="753" versions="7.00 7.01" description="Call Macro 53" />
+  <macro id="754" versions="7.00 7.01" description="Call Macro 54" />
+  <macro id="755" versions="7.00 7.01" description="Call Macro 55" />
+  <macro id="756" versions="7.00 7.01" description="Call Macro 56" />
+  <macro id="757" versions="7.00 7.01" description="Call Macro 57" />
+  <macro id="758" versions="7.00 7.01" description="Call Macro 58" />
+  <macro id="759" versions="7.00 7.01" description="Call Macro 59" />
+  <macro id="760" versions="7.00 7.01" description="Call Macro 60" />
+  <macro id="761" versions="7.00 7.01" description="Call Macro 61" />
+  <macro id="762" versions="7.00 7.01" description="Call Macro 62" />
+  <macro id="763" versions="7.00 7.01" description="Call Macro 63" />
+  <macro id="764" versions="7.00 7.01" description="Call Macro 64" />
+  <macro id="766" versions="7.00 7.01" description="Call Macro 65" />
+  <macro id="767" versions="7.00 7.01" description="Call Macro 66" />
+  <macro id="768" versions="7.00 7.01" description="Call Macro 67" />
+  <macro id="769" versions="7.00 7.01" description="Call Macro 68" />
+  <macro id="770" versions="7.00 7.01" description="Call Macro 69" />
+  <macro id="771" versions="7.00 7.01" description="Call Macro 70" />
+  <macro id="772" versions="7.00 7.01" description="Call Macro 71" />
+  <macro id="773" versions="7.00 7.01" description="Call Macro 72" />
+  <macro id="774" versions="7.00 7.01" description="Call Macro 73" />
+  <macro id="775" versions="7.00 7.01" description="Call Macro 74" />
+  <macro id="776" versions="7.00 7.01" description="Call Macro 75" />
+  <macro id="777" versions="7.00 7.01" description="Call Macro 76" />
+  <macro id="778" versions="7.00 7.01" description="Call Macro 77" />
+  <macro id="779" versions="7.00 7.01" description="Call Macro 78" />
+  <macro id="780" versions="7.00 7.01" description="Call Macro 79" />
+  <macro id="781" versions="7.00 7.01" description="Call Macro 80" />
+  <macro id="782" versions="7.00 7.01" description="Call Macro 81" />
+  <macro id="783" versions="7.00 7.01" description="Call Macro 82" />
+  <macro id="784" versions="7.00 7.01" description="Call Macro 83" />
+  <macro id="785" versions="7.00 7.01" description="Call Macro 84" />
+  <macro id="786" versions="7.00 7.01" description="Call Macro 85" />
+  <macro id="787" versions="7.00 7.01" description="Call Macro 86" />
+  <macro id="788" versions="7.00 7.01" description="Call Macro 87" />
+  <macro id="789" versions="7.00 7.01" description="Call Macro 88" />
+  <macro id="790" versions="7.00 7.01" description="Call Macro 89" />
+  <macro id="791" versions="7.00 7.01" description="Call Macro 90" />
+  <macro id="810" versions="7.361" description="Suspend Scheduler Setpoint 1" />
+  <macro id="811" versions="7.361" description="Suspend Scheduler Setpoint 2" />
+  <macro id="812" versions="7.361" description="Suspend Scheduler Setpoint 3" />
+  <macro id="813" versions="7.361" description="Suspend Scheduler Setpoint 4" />
+  <macro id="814" versions="7.361" description="Suspend Scheduler Setpoint 5" />
+  <macro id="815" versions="7.361" description="Suspend Scheduler Setpoint 6" />
+  <macro id="816" versions="7.361" description="Suspend Scheduler Setpoint 7" />
+  <macro id="817" versions="7.361" description="Suspend Scheduler Setpoint 8" />
+  <macro id="818" versions="7.361" description="Suspend Scheduler Setpoint 9" />
+  <macro id="819" versions="7.361" description="Suspend Scheduler Setpoint 10" />
+  <macro id="820" versions="7.361" description="Suspend Scheduler Setpoint 11" />
+  <macro id="821" versions="7.361" description="Suspend Scheduler Setpoint 12" />
+  <macro id="822" versions="7.361" description="Suspend Scheduler Setpoint 13" />
+  <macro id="823" versions="7.361" description="Suspend Scheduler Setpoint 14" />
+  <macro id="824" versions="7.361" description="Suspend Scheduler Setpoint 15" />
+  <macro id="825" versions="7.361" description="Suspend Scheduler Setpoint 16" />
+  <macro id="826" versions="7.361" description="Suspend Scheduler Setpoint 17" />
+  <macro id="827" versions="7.361" description="Suspend Scheduler Setpoint 18" />
+  <macro id="828" versions="7.361" description="Suspend Scheduler Setpoint 19" />
+  <macro id="829" versions="7.361" description="Suspend Scheduler Setpoint 20" />
+  <macro id="830" versions="7.361" description="Suspend Scheduler Setpoint 21" />
+  <macro id="831" versions="7.361" description="Suspend Scheduler Setpoint 22" />
+  <macro id="832" versions="7.361" description="Suspend Scheduler Setpoint 23" />
+  <macro id="833" versions="7.361" description="Suspend Scheduler Setpoint 24" />
+  <macro id="834" versions="7.361" description="Suspend Scheduler Setpoint 25" />
+  <macro id="835" versions="7.361" description="Suspend Scheduler Setpoint 26" />
+  <macro id="836" versions="7.361" description="Suspend Scheduler Setpoint 27" />
+  <macro id="837" versions="7.361" description="Suspend Scheduler Setpoint 28" />
+  <macro id="838" versions="7.361" description="Suspend Scheduler Setpoint 29" />
+  <macro id="839" versions="7.361" description="Suspend Scheduler Setpoint 30" />
+  <macro id="840" versions="7.361" description="Suspend Scheduler Setpoint 31" />
+  <macro id="841" versions="7.361" description="Suspend Scheduler Setpoint 32" />
+  <macro id="842" versions="7.361" description="Suspend Scheduler Setpoint 33" />
+  <macro id="843" versions="7.361" description="Suspend Scheduler Setpoint 34" />
+  <macro id="844" versions="7.361" description="Suspend Scheduler Setpoint 35" />
+  <macro id="845" versions="7.361" description="Suspend Scheduler Setpoint 36" />
+  <macro id="846" versions="7.361" description="Suspend Scheduler Setpoint 37" />
+  <macro id="847" versions="7.361" description="Suspend Scheduler Setpoint 38" />
+  <macro id="848" versions="7.361" description="Suspend Scheduler Setpoint 39" />
+  <macro id="849" versions="7.361" description="Suspend Scheduler Setpoint 40" />
+  <macro id="850" versions="7.361" description="Resume Scheduler Setpoint 1" />
+  <macro id="851" versions="7.361" description="Resume Scheduler Setpoint 2" />
+  <macro id="852" versions="7.361" description="Resume Scheduler Setpoint 3" />
+  <macro id="853" versions="7.361" description="Resume Scheduler Setpoint 4" />
+  <macro id="854" versions="7.361" description="Resume Scheduler Setpoint 5" />
+  <macro id="355" versions="7.361" description="Resume Scheduler Setpoint 6" />
+  <macro id="856" versions="7.361" description="Resume Scheduler Setpoint 7" />
+  <macro id="857" versions="7.361" description="Resume Scheduler Setpoint 8" />
+  <macro id="858" versions="7.361" description="Resume Scheduler Setpoint 9" />
+  <macro id="859" versions="7.361" description="Resume Scheduler Setpoint 10" />
+  <macro id="860" versions="7.361" description="Resume Scheduler Setpoint 11" />
+  <macro id="861" versions="7.361" description="Resume Scheduler Setpoint 12" />
+  <macro id="862" versions="7.361" description="Resume Scheduler Setpoint 13" />
+  <macro id="863" versions="7.361" description="Resume Scheduler Setpoint 14" />
+  <macro id="864" versions="7.361" description="Resume Scheduler Setpoint 15" />
+  <macro id="865" versions="7.361" description="Resume Scheduler Setpoint 16" />
+  <macro id="866" versions="7.361" description="Resume Scheduler Setpoint 17" />
+  <macro id="867" versions="7.361" description="Resume Scheduler Setpoint 18" />
+  <macro id="868" versions="7.361" description="Resume Scheduler Setpoint 19" />
+  <macro id="869" versions="7.361" description="Resume Scheduler Setpoint 20" />
+  <macro id="870" versions="7.361" description="Resume Scheduler Setpoint 21" />
+  <macro id="871" versions="7.361" description="Resume Scheduler Setpoint 22" />
+  <macro id="872" versions="7.361" description="Resume Scheduler Setpoint 23" />
+  <macro id="873" versions="7.361" description="Resume Scheduler Setpoint 24" />
+  <macro id="874" versions="7.361" description="Resume Scheduler Setpoint 25" />
+  <macro id="875" versions="7.361" description="Resume Scheduler Setpoint 26" />
+  <macro id="876" versions="7.361" description="Resume Scheduler Setpoint 27" />
+  <macro id="877" versions="7.361" description="Resume Scheduler Setpoint 28" />
+  <macro id="878" versions="7.361" description="Resume Scheduler Setpoint 29" />
+  <macro id="879" versions="7.361" description="Resume Scheduler Setpoint 30" />
+  <macro id="880" versions="7.361" description="Resume Scheduler Setpoint 31" />
+  <macro id="881" versions="7.361" description="Resume Scheduler Setpoint 32" />
+  <macro id="882" versions="7.361" description="Resume Scheduler Setpoint 33" />
+  <macro id="883" versions="7.361" description="Resume Scheduler Setpoint 34" />
+  <macro id="884" versions="7.361" description="Resume Scheduler Setpoint 35" />
+  <macro id="885" versions="7.361" description="Resume Scheduler Setpoint 36" />
+  <macro id="886" versions="7.361" description="Resume Scheduler Setpoint 37" />
+  <macro id="887" versions="7.361" description="Resume Scheduler Setpoint 38" />
+  <macro id="888" versions="7.361" description="Resume Scheduler Setpoint 39" />
+  <macro id="889" versions="7.361" description="Resume Scheduler Setpoint 40" />
+  <macro id="860" versions="7.32 7.36" description="Suspend Scheduler Setpoint 1" />
+  <macro id="861" versions="7.32 7.36" description="Suspend Scheduler Setpoint 2" />
+  <macro id="862" versions="7.32 7.36" description="Suspend Scheduler Setpoint 3" />
+  <macro id="863" versions="7.32 7.36" description="Suspend Scheduler Setpoint 4" />
+  <macro id="864" versions="7.32 7.36" description="Suspend Scheduler Setpoint 5" />
+  <macro id="865" versions="7.32 7.36" description="Suspend Scheduler Setpoint 6" />
+  <macro id="866" versions="7.32 7.36" description="Suspend Scheduler Setpoint 7" />
+  <macro id="867" versions="7.32 7.36" description="Suspend Scheduler Setpoint 8" />
+  <macro id="868" versions="7.32 7.36" description="Suspend Scheduler Setpoint 9" />
+  <macro id="869" versions="7.32 7.36" description="Suspend Scheduler Setpoint 10" />
+  <macro id="870" versions="7.32 7.36" description="Suspend Scheduler Setpoint 11" />
+  <macro id="871" versions="7.32 7.36" description="Suspend Scheduler Setpoint 12" />
+  <macro id="872" versions="7.32 7.36" description="Suspend Scheduler Setpoint 13" />
+  <macro id="873" versions="7.32 7.36" description="Suspend Scheduler Setpoint 14" />
+  <macro id="874" versions="7.32 7.36" description="Suspend Scheduler Setpoint 15" />
+  <macro id="875" versions="7.32 7.36" description="Suspend Scheduler Setpoint 16" />
+  <macro id="876" versions="7.32 7.36" description="Suspend Scheduler Setpoint 17" />
+  <macro id="877" versions="7.32 7.36" description="Suspend Scheduler Setpoint 18" />
+  <macro id="878" versions="7.32 7.36" description="Suspend Scheduler Setpoint 19" />
+  <macro id="879" versions="7.32 7.36" description="Suspend Scheduler Setpoint 20" />
+  <macro id="880" versions="7.32 7.36" description="Resume Scheduler Setpoint 1" />
+  <macro id="881" versions="7.32 7.36" description="Resume Scheduler Setpoint 2" />
+  <macro id="882" versions="7.32 7.36" description="Resume Scheduler Setpoint 3" />
+  <macro id="883" versions="7.32 7.36" description="Resume Scheduler Setpoint 4" />
+  <macro id="884" versions="7.32 7.36" description="Resume Scheduler Setpoint 5" />
+  <macro id="885" versions="7.32 7.36" description="Resume Scheduler Setpoint 6" />
+  <macro id="886" versions="7.32 7.36" description="Resume Scheduler Setpoint 7" />
+  <macro id="887" versions="7.32 7.36" description="Resume Scheduler Setpoint 8" />
+  <macro id="888" versions="7.32 7.36" description="Resume Scheduler Setpoint 9" />
+  <macro id="889" versions="7.32 7.36" description="Resume Scheduler Setpoint 10" />
+  <macro id="890" versions="7.32 7.36" description="Resume Scheduler Setpoint 11" />
+  <macro id="891" versions="7.32 7.36" description="Resume Scheduler Setpoint 12" />
+  <macro id="892" versions="7.32 7.36" description="Resume Scheduler Setpoint 13" />
+  <macro id="893" versions="7.32 7.36" description="Resume Scheduler Setpoint 14" />
+  <macro id="894" versions="7.32 7.36" description="Resume Scheduler Setpoint 15" />
+  <macro id="895" versions="7.32 7.36" description="Resume Scheduler Setpoint 16" />
+  <macro id="896" versions="7.32 7.36" description="Resume Scheduler Setpoint 17" />
+  <macro id="897" versions="7.32 7.36" description="Resume Scheduler Setpoint 18" />
+  <macro id="898" versions="7.32 7.36" description="Resume Scheduler Setpoint 19" />
+  <macro id="899" versions="7.32 7.36" description="Resume Scheduler Setpoint 20" />
+  <macro id="901" versions="7.32 7.36 7.361" description="Call Macro 1" />
+  <macro id="902" versions="7.32 7.36 7.361" description="Call Macro 2" />
+  <macro id="903" versions="7.32 7.36 7.361" description="Call Macro 3" />
+  <macro id="904" versions="7.32 7.36 7.361" description="Call Macro 4" />
+  <macro id="905" versions="7.32 7.36 7.361" description="Call Macro 5" />
+  <macro id="906" versions="7.32 7.36 7.361" description="Call Macro 6" />
+  <macro id="907" versions="7.32 7.36 7.361" description="Call Macro 7" />
+  <macro id="908" versions="7.32 7.36 7.361" description="Call Macro 8" />
+  <macro id="909" versions="7.32 7.36 7.361" description="Call Macro 9" />
+  <macro id="910" versions="7.32 7.36 7.361" description="Call Macro 10" />
+  <macro id="911" versions="7.32 7.36 7.361" description="Call Macro 11" />
+  <macro id="912" versions="7.32 7.36 7.361" description="Call Macro 12" />
+  <macro id="913" versions="7.32 7.36 7.361" description="Call Macro 13" />
+  <macro id="914" versions="7.32 7.36 7.361" description="Call Macro 14" />
+  <macro id="915" versions="7.32 7.36 7.361" description="Call Macro 15" />
+  <macro id="916" versions="7.32 7.36 7.361" description="Call Macro 16" />
+  <macro id="917" versions="7.32 7.36 7.361" description="Call Macro 17" />
+  <macro id="918" versions="7.32 7.36 7.361" description="Call Macro 18" />
+  <macro id="919" versions="7.32 7.36 7.361" description="Call Macro 19" />
+  <macro id="920" versions="7.32 7.36 7.361" description="Call Macro 20" />
+  <macro id="921" versions="7.32 7.36 7.361" description="Call Macro 21" />
+  <macro id="922" versions="7.32 7.36 7.361" description="Call Macro 22" />
+  <macro id="923" versions="7.32 7.36 7.361" description="Call Macro 23" />
+  <macro id="924" versions="7.32 7.36 7.361" description="Call Macro 24" />
+  <macro id="925" versions="7.32 7.36 7.361" description="Call Macro 25" />
+  <macro id="926" versions="7.32 7.36 7.361" description="Call Macro 26" />
+  <macro id="927" versions="7.32 7.36 7.361" description="Call Macro 27" />
+  <macro id="928" versions="7.32 7.36 7.361" description="Call Macro 28" />
+  <macro id="929" versions="7.32 7.36 7.361" description="Call Macro 29" />
+  <macro id="930" versions="7.32 7.36 7.361" description="Call Macro 30" />
+  <macro id="931" versions="7.32 7.36 7.361" description="Call Macro 31" />
+  <macro id="932" versions="7.32 7.36 7.361" description="Call Macro 32" />
+  <macro id="933" versions="7.32 7.36 7.361" description="Call Macro 33" />
+  <macro id="934" versions="7.32 7.36 7.361" description="Call Macro 34" />
+  <macro id="935" versions="7.32 7.36 7.361" description="Call Macro 35" />
+  <macro id="936" versions="7.32 7.36 7.361" description="Call Macro 36" />
+  <macro id="937" versions="7.32 7.36 7.361" description="Call Macro 37" />
+  <macro id="938" versions="7.32 7.36 7.361" description="Call Macro 38" />
+  <macro id="939" versions="7.32 7.36 7.361" description="Call Macro 39" />
+  <macro id="940" versions="7.32 7.36 7.361" description="Call Macro 40" />
+  <macro id="941" versions="7.32 7.36 7.361" description="Call Macro 41" />
+  <macro id="942" versions="7.32 7.36 7.361" description="Call Macro 42" />
+  <macro id="943" versions="7.32 7.36 7.361" description="Call Macro 43" />
+  <macro id="944" versions="7.32 7.36 7.361" description="Call Macro 44" />
+  <macro id="945" versions="7.32 7.36 7.361" description="Call Macro 45" />
+  <macro id="946" versions="7.32 7.36 7.361" description="Call Macro 46" />
+  <macro id="947" versions="7.32 7.36 7.361" description="Call Macro 47" />
+  <macro id="948" versions="7.32 7.36 7.361" description="Call Macro 48" />
+  <macro id="949" versions="7.32 7.36 7.361" description="Call Macro 49" />
+  <macro id="950" versions="7.32 7.36 7.361" description="Call Macro 50" />
+  <macro id="951" versions="7.32 7.36 7.361" description="Call Macro 51" />
+  <macro id="952" versions="7.32 7.36 7.361" description="Call Macro 52" />
+  <macro id="953" versions="7.32 7.36 7.361" description="Call Macro 53" />
+  <macro id="954" versions="7.32 7.36 7.361" description="Call Macro 54" />
+  <macro id="955" versions="7.32 7.36 7.361" description="Call Macro 55" />
+  <macro id="956" versions="7.32 7.36 7.361" description="Call Macro 56" />
+  <macro id="957" versions="7.32 7.36 7.361" description="Call Macro 57" />
+  <macro id="958" versions="7.32 7.36 7.361" description="Call Macro 58" />
+  <macro id="959" versions="7.32 7.36 7.361" description="Call Macro 59" />
+  <macro id="960" versions="7.32 7.36 7.361" description="Call Macro 60" />
+  <macro id="961" versions="7.32 7.36 7.361" description="Call Macro 61" />
+  <macro id="962" versions="7.32 7.36 7.361" description="Call Macro 62" />
+  <macro id="963" versions="7.32 7.36 7.361" description="Call Macro 63" />
+  <macro id="964" versions="7.32 7.36 7.361" description="Call Macro 64" />
+  <macro id="965" versions="7.32 7.36 7.361" description="Call Macro 65" />
+  <macro id="966" versions="7.32 7.36 7.361" description="Call Macro 66" />
+  <macro id="967" versions="7.32 7.36 7.361" description="Call Macro 67" />
+  <macro id="968" versions="7.32 7.36 7.361" description="Call Macro 68" />
+  <macro id="969" versions="7.32 7.36 7.361" description="Call Macro 69" />
+  <macro id="970" versions="7.32 7.36 7.361" description="Call Macro 70" />
+  <macro id="971" versions="7.32 7.36 7.361" description="Call Macro 71" />
+  <macro id="972" versions="7.32 7.36 7.361" description="Call Macro 72" />
+  <macro id="973" versions="7.32 7.36 7.361" description="Call Macro 73" />
+  <macro id="974" versions="7.32 7.36 7.361" description="Call Macro 74" />
+  <macro id="975" versions="7.32 7.36 7.361" description="Call Macro 75" />
+  <macro id="976" versions="7.32 7.36 7.361" description="Call Macro 76" />
+  <macro id="977" versions="7.32 7.36 7.361" description="Call Macro 77" />
+  <macro id="978" versions="7.32 7.36 7.361" description="Call Macro 78" />
+  <macro id="979" versions="7.32 7.36 7.361" description="Call Macro 79" />
+  <macro id="980" versions="7.32 7.36 7.361" description="Call Macro 80" />
+  <macro id="981" versions="7.32 7.36 7.361" description="Call Macro 81" />
+  <macro id="982" versions="7.32 7.36 7.361" description="Call Macro 82" />
+  <macro id="983" versions="7.32 7.36 7.361" description="Call Macro 83" />
+  <macro id="984" versions="7.32 7.36 7.361" description="Call Macro 84" />
+  <macro id="985" versions="7.32 7.36 7.361" description="Call Macro 85" />
+  <macro id="986" versions="7.32 7.36 7.361" description="Call Macro 86" />
+  <macro id="987" versions="7.32 7.36 7.361" description="Call Macro 87" />
+  <macro id="988" versions="7.32 7.36 7.361" description="Call Macro 88" />
+  <macro id="989" versions="7.32 7.36 7.361" description="Call Macro 89" />
+  <macro id="990" versions="7.32 7.36 7.361" description="Call Macro 90" />
+</macros>

--- a/XML/Ver8_macro_def.xml
+++ b/XML/Ver8_macro_def.xml
@@ -1,0 +1,1037 @@
+<macros version="3.000">
+  <macro id="1" versions="7.39 7.60" description="Port 1 CTCSS Access" />
+  <macro id="2" versions="7.39 7.60" description="Port 2 CTCSS Access" />
+  <macro id="3" versions="7.39 7.60" description="Port 3 CTCSS Access" />
+  <macro id="4" versions="7.39 7.60" description="Port 1 Carrier Access" />
+  <macro id="5" versions="7.39 7.60" description="Port 2 Carrier Access" />
+  <macro id="6" versions="7.39 7.60" description="Port 3 Carrier Access" />
+  <macro id="7" versions="7.39 7.60" description="Port 1 DTMF Covertone ON" />
+  <macro id="8" versions="7.39 7.60" description="Port 2 DTMF Covertone ON" />
+  <macro id="9" versions="7.39 7.60" description="Port 3 DTMF Covertone ON" />
+  <macro id="10" versions="7.39 7.60" description="Port 1 DTMF Covertone OFF" />
+  <macro id="11" versions="7.39 7.60" description="Port 2 DTMF Covertone OFF" />
+  <macro id="12" versions="7.39 7.60" description="Port 3 DTMF Covertone OFF" />
+  <macro id="13" versions="7.39 7.60" description="Port 1 Enable" />
+  <macro id="14" versions="7.39 7.60" description="Port 2 Enable" />
+  <macro id="15" versions="7.39 7.60" description="Port 3 Enable" />
+  <macro id="16" versions="7.39 7.60" description="Port 1 Disable" />
+  <macro id="17" versions="7.39 7.60" description="Port 2 Disable" />
+  <macro id="18" versions="7.39 7.60" description="Port 3 Disable" />
+  <macro id="19" versions="7.39 7.60" description="Monitor Port 1 from Port 2" />
+  <macro id="20" versions="7.39 7.60" description="Monitor Port 1 from Port 3" />
+  <macro id="21" versions="7.39 7.60" description="Disconnect Port 1 from Port 2" />
+  <macro id="22" versions="7.39 7.60" description="Disconnect Port 1 from Port 3" />
+  <macro id="23" versions="7.39 7.60" description="Monitor Port 2 from Port 1" />
+  <macro id="24" versions="7.39 7.60" description="Monitor Port 2 from Port 3" />
+  <macro id="25" versions="7.39 7.60" description="Disconnect Port 2 from Port 1" />
+  <macro id="26" versions="7.39 7.60" description="Disconnect Port 2 from Port 3" />
+  <macro id="27" versions="7.39 7.60" description="Monitor Port 3 from Port 1" />
+  <macro id="28" versions="7.39 7.60" description="Monitor Port 3 from Port 2" />
+  <macro id="29" versions="7.39 7.60" description="Disconnect Port 3 from Port 1" />
+  <macro id="30" versions="7.39 7.60" description="Disconnect Port 3 from Port 2" />
+  <macro id="31" versions="7.39 7.60" description="Port 1 Monitor Mute" />
+  <macro id="32" versions="7.39 7.60" description="Port 2 Monitor Mute" />
+  <macro id="33" versions="7.39 7.60" description="Port 3 Monitor Mute" />
+  <macro id="34" versions="7.39 7.60" description="Port 1 Monitor Mix" />
+  <macro id="35" versions="7.39 7.60" description="Port 2 Monitor Mix" />
+  <macro id="36" versions="7.39 7.60" description="Port 3 Monitor Mix" />
+  <macro id="37" versions="7.39 7.60" description="Port 1 Repeat ON" />
+  <macro id="38" versions="7.39 7.60" description="Port 2 Repeat ON" />
+  <macro id="39" versions="7.39 7.60" description="Port 3 Repeat ON" />
+  <macro id="40" versions="7.39 7.60" description="Port 1 Repeat OFF" />
+  <macro id="41" versions="7.39 7.60" description="Port 2 Repeat OFF" />
+  <macro id="42" versions="7.39 7.60" description="Port 3 Repeat OFF" />
+  <macro id="43" versions="7.39 7.60" description="Port 1 Speech OverrideON" />
+  <macro id="44" versions="7.39 7.60" description="Port 2 Speech OverrideON" />
+  <macro id="45" versions="7.39 7.60" description="Port 3 Speech OverrideON" />
+  <macro id="46" versions="7.39 7.60" description="Port 1 Speech Override OFF" />
+  <macro id="47" versions="7.39 7.60" description="Port 2 Speech Override OFF" />
+  <macro id="48" versions="7.39 7.60" description="Port 3 Speech Override OFF" />
+  <macro id="49" versions="7.39 7.60" description="Port 1 Courtesy Tone 1" />
+  <macro id="50" versions="7.39 7.60" description="Port 1 Courtesy Tone 2" />
+  <macro id="51" versions="7.39 7.60" description="Port 1 Courtesy Tone 3" />
+  <macro id="52" versions="7.39 7.60" description="Port 1 Courtesy Tone 4" />
+  <macro id="53" versions="7.39 7.60" description="Port 1 Courtesy Tone 5" />
+  <macro id="54" versions="7.39 7.60" description="Port 1 Courtesy Tone 6" />
+  <macro id="55" versions="7.39 7.60" description="Port 1 Courtesy Tone 7" />
+  <macro id="56" versions="7.39 7.60" description="Port 1 Courtesy Tone 8" />
+  <macro id="57" versions="7.39 7.60" description="Port 1 Courtesy Tone 9" />
+  <macro id="58" versions="7.39 7.60" description="Port 1 Courtesy Tone 10" />
+  <macro id="59" versions="7.39 7.60" description="Port 2 Courtesy Tone 1" />
+  <macro id="60" versions="7.39 7.60" description="Port 2 Courtesy Tone 2" />
+  <macro id="61" versions="7.39 7.60" description="Port 2 Courtesy Tone 3" />
+  <macro id="62" versions="7.39 7.60" description="Port 2 Courtesy Tone 4" />
+  <macro id="63" versions="7.39 7.60" description="Port 2 Courtesy Tone 5" />
+  <macro id="64" versions="7.39 7.60" description="Port 2 Courtesy Tone 6" />
+  <macro id="65" versions="7.39 7.60" description="Port 2 Courtesy Tone 7" />
+  <macro id="66" versions="7.39 7.60" description="Port 2 Courtesy Tone 8" />
+  <macro id="67" versions="7.39 7.60" description="Port 2 Courtesy Tone 9" />
+  <macro id="68" versions="7.39 7.60" description="Port 2 Courtesy Tone 10" />
+  <macro id="69" versions="7.39 7.60" description="Port 3 Courtesy Tone 1" />
+  <macro id="70" versions="7.39 7.60" description="Port 3 Courtesy Tone 2" />
+  <macro id="71" versions="7.39 7.60" description="Port 3 Courtesy Tone 3" />
+  <macro id="72" versions="7.39 7.60" description="Port 3 Courtesy Tone 4" />
+  <macro id="73" versions="7.39 7.60" description="Port 3 Courtesy Tone 5" />
+  <macro id="74" versions="7.39 7.60" description="Port 3 Courtesy Tone 6" />
+  <macro id="75" versions="7.39 7.60" description="Port 3 Courtesy Tone 7" />
+  <macro id="76" versions="7.39 7.60" description="Port 3 Courtesy Tone 8" />
+  <macro id="77" versions="7.39 7.60" description="Port 3 Courtesy Tone 9" />
+  <macro id="78" versions="7.39 7.60" description="Port 3 Courtesy Tone 10" />
+  <macro id="79" versions="7.39 7.60" description="Port 1 DTMF Muting ON" />
+  <macro id="80" versions="7.39 7.60" description="Port 2 DTMF Muting ON" />
+  <macro id="81" versions="7.39 7.60" description="Port 3 DTMF Muting ON" />
+  <macro id="82" versions="7.39 7.60" description="Port 1 DTMF Muting OFF" />
+  <macro id="83" versions="7.39 7.60" description="Port 2 DTMF Muting OFF" />
+  <macro id="84" versions="7.39 7.60" description="Port 3 DTMF Muting OFF" />
+  <macro id="85" versions="7.39 7.60" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="86" versions="7.39 7.60" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="87" versions="7.39 7.60" description="Read ADC Channel 1" />
+  <macro id="88" versions="7.39 7.60" description="Read ADC Channel 2" />
+  <macro id="89" versions="7.39 7.60" description="Read ADC Channel 3" />
+  <macro id="90" versions="7.39 7.60" description="Read ADC Channel 4" />
+  <macro id="91" versions="7.39 7.60" description="Read ADC Channel 5" />
+  <macro id="92" versions="7.39 7.60" description="Read ADC Channel 6" />
+  <macro id="93" versions="7.39 7.60" description="Read ADC Channel 7" />
+  <macro id="94" versions="7.39 7.60" description="Read ADC Channel 8" />
+  <macro id="95" versions="7.39 7.60" description="UF1 ON" />
+  <macro id="96" versions="7.39 7.60" description="UF2 ON" />
+  <macro id="97" versions="7.39 7.60" description="UF3 ON" />
+  <macro id="98" versions="7.39 7.60" description="UF4 ON" />
+  <macro id="99" versions="7.39 7.60" description="UF5 ON" />
+  <macro id="100" versions="7.39 7.60" description="UF6 ON" />
+  <macro id="101" versions="7.39 7.60" description="UF7 ON" />
+  <macro id="102" versions="7.39 7.60" description="UF1 OFF" />
+  <macro id="103" versions="7.39 7.60" description="UF2 OFF" />
+  <macro id="104" versions="7.39 7.60" description="UF3 OFF" />
+  <macro id="105" versions="7.39 7.60" description="UF4 OFF" />
+  <macro id="106" versions="7.39 7.60" description="UF5 OFF" />
+  <macro id="107" versions="7.39 7.60" description="UF6 OFF" />
+  <macro id="108" versions="7.39 7.60" description="UF7 OFF" />
+  <macro id="109" versions="7.39 7.60" description="UF1 Pulse" />
+  <macro id="110" versions="7.39 7.60" description="UF2 Pulse" />
+  <macro id="111" versions="7.39 7.60" description="UF3 Pulse" />
+  <macro id="112" versions="7.39 7.60" description="UF4 Pulse" />
+  <macro id="113" versions="7.39 7.60" description="UF5 Pulse" />
+  <macro id="114" versions="7.39 7.60" description="UF6 Pulse" />
+  <macro id="115" versions="7.39 7.60" description="UF7 Pulse" />
+  <macro id="116" versions="7.39 7.60" description="Say Time" />
+  <macro id="117" versions="7.39 7.60" description="Say Date" />
+  <macro id="118" versions="7.39 7.60" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="7.39 7.60" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="7.39 7.60" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="7.39 7.60" description="Link All Ports" />
+  <macro id="122" versions="7.39 7.60" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="7.39 7.60" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="7.39 7.60" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="7.39 7.60" description="UnLink All Ports" />
+  <macro id="126" versions="7.39 7.60" description="Play DVR Track 1" />
+  <macro id="127" versions="7.39 7.60" description="Play DVR Track 2" />
+  <macro id="128" versions="7.39 7.60" description="Play DVR Track 3" />
+  <macro id="129" versions="7.39 7.60" description="Play DVR Track 4" />
+  <macro id="130" versions="7.39 7.60" description="Play DVR Track 5" />
+  <macro id="131" versions="7.39 7.60" description="Play DVR Track 6" />
+  <macro id="132" versions="7.39 7.60" description="Play DVR Track 7" />
+  <macro id="133" versions="7.39 7.60" description="Play DVR Track 8" />
+  <macro id="134" versions="7.39 7.60" description="Play DVR Track 9" />
+  <macro id="135" versions="7.39 7.60" description="Play DVR Track 10" />
+  <macro id="136" versions="7.39 7.60" description="Play DVR Track 11" />
+  <macro id="137" versions="7.39 7.60" description="Play DVR Track 12" />
+  <macro id="138" versions="7.39 7.60" description="Play DVR Track 13" />
+  <macro id="139" versions="7.39 7.60" description="Play DVR Track 14" />
+  <macro id="140" versions="7.39 7.60" description="Play DVR Track 15" />
+  <macro id="141" versions="7.39 7.60" description="Play DVR Track 16" />
+  <macro id="142" versions="7.39 7.60" description="Play DVR Track 17" />
+  <macro id="143" versions="7.39 7.60" description="Play DVR Track 18" />
+  <macro id="144" versions="7.39 7.60" description="Play DVR Track 19" />
+  <macro id="145" versions="7.39 7.60" description="Play DVR Track 20" />
+  <macro id="146" versions="7.39 7.60" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="7.39 7.60" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="7.39 7.60" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="7.39 7.60" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="7.39 7.60" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="7.39 7.60" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="7.39 7.60" description="Alarm 1 ON" />
+  <macro id="153" versions="7.39 7.60" description="Alarm 2 ON" />
+  <macro id="154" versions="7.39 7.60" description="Alarm 3 ON" />
+  <macro id="155" versions="7.39 7.60" description="Alarm 4 ON" />
+  <macro id="156" versions="7.39 7.60" description="Alarm 5 ON" />
+  <macro id="157" versions="7.39 7.60" description="Alarm 1 OFF" />
+  <macro id="158" versions="7.39 7.60" description="Alarm 2 OFF" />
+  <macro id="159" versions="7.39 7.60" description="Alarm 3 OFF" />
+  <macro id="160" versions="7.39 7.60" description="Alarm 4 OFF" />
+  <macro id="161" versions="7.39 7.60" description="Alarm 5 OFF" />
+  <macro id="162" versions="7.39 7.60" description="Speech Out Port 1" />
+  <macro id="163" versions="7.39 7.60" description="Speech Out Port 2" />
+  <macro id="164" versions="7.39 7.60" description="Speech Out Port 3" />
+  <macro id="165" versions="7.39 7.60" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="7.39 7.60" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="7.39 7.60" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="7.39 7.60" description="Speech Out All Ports" />
+  <macro id="169" versions="7.39 7.60" description="DTMF Enable Port 1" />
+  <macro id="170" versions="7.39 7.60" description="DTMF Enable Port 2" />
+  <macro id="171" versions="7.39 7.60" description="DTMF Enable Port 3" />
+  <macro id="172" versions="7.39 7.60" description="DTMF Disable Port 1" />
+  <macro id="173" versions="7.39 7.60" description="DTMF Disable Port 2" />
+  <macro id="174" versions="7.39 7.60" description="DTMF Disable Port 3" />
+  <macro id="175" versions="7.39 7.60" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="7.39 7.60" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="7.39 7.60" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="7.39 7.60" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="7.39 7.60" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="7.39 7.60" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="7.39 7.60" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="7.39 7.60" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="7.39 7.60" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="7.39 7.60" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="7.39 7.60" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="7.39 7.60" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="7.39 7.60" description="Play Message Macro 1" />
+  <macro id="188" versions="7.39 7.60" description="Play Message Macro 2" />
+  <macro id="189" versions="7.39 7.60" description="Play Message Macro 3" />
+  <macro id="190" versions="7.39 7.60" description="Play Message Macro 4" />
+  <macro id="191" versions="7.39 7.60" description="Play Message Macro 5" />
+  <macro id="192" versions="7.39 7.60" description="Play Message Macro 6" />
+  <macro id="193" versions="7.39 7.60" description="Play Message Macro 7" />
+  <macro id="194" versions="7.39 7.60" description="Play Message Macro 8" />
+  <macro id="195" versions="7.39 7.60" description="Play Message Macro 9" />
+  <macro id="196" versions="7.39 7.60" description="Play Message Macro 10" />
+  <macro id="197" versions="7.39 7.60" description="Play Message Macro 11" />
+  <macro id="198" versions="7.39 7.60" description="Play Message Macro 12" />
+  <macro id="199" versions="7.39 7.60" description="Play Message Macro 13" />
+  <macro id="200" versions="7.39 7.60" description="Play Message Macro 14" />
+  <macro id="201" versions="7.39 7.60" description="Play Message Macro 15" />
+  <macro id="202" versions="7.39 7.60" description="Play Message Macro 16" />
+  <macro id="203" versions="7.39 7.60" description="Play Message Macro 17" />
+  <macro id="204" versions="7.39 7.60" description="Play Message Macro 18" />
+  <macro id="205" versions="7.39 7.60" description="Play Message Macro 19" />
+  <macro id="206" versions="7.39 7.60" description="Play Message Macro 20" />
+  <macro id="207" versions="7.39 7.60" description="Play Message Macro 21" />
+  <macro id="208" versions="7.39 7.60" description="Play Message Macro 22" />
+  <macro id="209" versions="7.39 7.60" description="Play Message Macro 23" />
+  <macro id="210" versions="7.39 7.60" description="Play Message Macro 24" />
+  <macro id="211" versions="7.39 7.60" description="Play Message Macro 25" />
+  <macro id="212" versions="7.39 7.60" description="Play Message Macro 26" />
+  <macro id="213" versions="7.39 7.60" description="Play Message Macro 27" />
+  <macro id="214" versions="7.39 7.60" description="Play Message Macro 28" />
+  <macro id="215" versions="7.39 7.60" description="Play Message Macro 29" />
+  <macro id="216" versions="7.39 7.60" description="Play Message Macro 30" />
+  <macro id="217" versions="7.39 7.60" description="Play Message Macro 31" />
+  <macro id="218" versions="7.39 7.60" description="Play Message Macro 32" />
+  <macro id="219" versions="7.39 7.60" description="Play Message Macro 33" />
+  <macro id="220" versions="7.39 7.60" description="Play Message Macro 34" />
+  <macro id="221" versions="7.39 7.60" description="Play Message Macro 35" />
+  <macro id="222" versions="7.39 7.60" description="Play Message Macro 36" />
+  <macro id="223" versions="7.39 7.60" description="Play Message Macro 37" />
+  <macro id="224" versions="7.39 7.60" description="Play Message Macro 38" />
+  <macro id="225" versions="7.39 7.60" description="Play Message Macro 39" />
+  <macro id="226" versions="7.39 7.60" description="Play Message Macro 40" />
+  <macro id="227" versions="7.39 7.60" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="7.39 7.60" description="Macro Priority High" />
+  <macro id="229" versions="7.39 7.60" description="Macro Priority Low" />
+  <macro id="230" versions="7.39 7.60" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="7.39 7.60" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="7.39 7.60" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="7.39 7.60" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="7.39 7.60" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="7.39 7.60" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="7.39 7.60" description="Enable Receiver Port 1" />
+  <macro id="237" versions="7.39 7.60" description="Enable Receiver Port 2" />
+  <macro id="238" versions="7.39 7.60" description="Enable Receiver Port 3" />
+  <macro id="239" versions="7.39 7.60" description="Disable Receiver Port 1" />
+  <macro id="240" versions="7.39 7.60" description="Disable Receiver Port 2" />
+  <macro id="241" versions="7.39 7.60" description="Disable Receiver Port 3" />
+  <macro id="242" versions="7.39 7.60" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="7.39 7.60" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="7.39 7.60" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="7.39 7.60" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="7.39 7.60" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="7.39 7.60" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="7.39 7.60" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="7.39 7.60" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="7.39 7.60" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="7.39 7.60" description="Force Audio To Entered Port" />
+  <macro id="252" versions="7.39 7.60" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="7.39 7.60" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="7.39 7.60" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="7.39 7.60" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="7.39 7.60" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="7.39 7.60" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="7.39 7.60" description="Send DTMF Memory 1" />
+  <macro id="260" versions="7.39 7.60" description="Send DTMF Memory 2" />
+  <macro id="261" versions="7.39 7.60" description="Send DTMF Memory 3" />
+  <macro id="262" versions="7.39 7.60" description="Send DTMF Memory 4" />
+  <macro id="263" versions="7.39 7.60" description="Send DTMF Memory 5" />
+  <macro id="264" versions="7.39 7.60" description="Send DTMF Memory 6" />
+  <macro id="265" versions="7.39 7.60" description="Send DTMF Memory 7" />
+  <macro id="266" versions="7.39 7.60" description="Send DTMF Memory 8" />
+  <macro id="267" versions="7.39 7.60" description="Send DTMF Memory 9" />
+  <macro id="268" versions="7.39 7.60" description="Send DTMF Memory 10" />
+  <macro id="269" versions="7.39 7.60" description="Send DTMF Memory 11" />
+  <macro id="270" versions="7.39 7.60" description="Send DTMF Memory 12" />
+  <macro id="271" versions="7.39 7.60" description="Send DTMF Memory 13" />
+  <macro id="272" versions="7.39 7.60" description="Send DTMF Memory 14" />
+  <macro id="273" versions="7.39 7.60" description="Send DTMF Memory 15" />
+  <macro id="274" versions="7.39 7.60" description="Send DTMF Memory 16" />
+  <macro id="275" versions="7.39 7.60" description="Send DTMF Memory 17" />
+  <macro id="276" versions="7.39 7.60" description="Send DTMF Memory 18" />
+  <macro id="277" versions="7.39 7.60" description="Send DTMF Memory 19" />
+  <macro id="278" versions="7.39 7.60" description="Send DTMF Memory 20" />
+  <macro id="279" versions="7.39 7.60" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="7.39 7.60" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="7.39 7.60" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="7.39 7.60" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="7.39 7.60" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="7.39 7.60" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="7.39 7.60" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="7.39 7.60" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="7.39 7.60" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="7.39 7.60" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="7.39 7.60" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="7.39 7.60" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="7.39 7.60" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="7.39 7.60" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="7.39 7.60" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="7.39 7.60" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="7.39 7.60" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="7.39 7.60" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="7.39 7.60" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="7.39 7.60" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="7.39 7.60" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="7.39 7.60" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="7.39 7.60" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="7.39 7.60" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="7.39 7.60" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="7.39 7.60" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="7.39 7.60" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="7.39 7.60" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="7.39 7.60" description="Say year as part of date" />
+  <macro id="308" versions="7.39 7.60" description="Don't say year as part of date" />
+  <macro id="309" versions="7.39 7.60" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="7.39 7.60" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="7.39 7.60" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="7.39 7.60" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="7.39 7.60" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="7.39 7.60" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="7.39 7.60" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="7.39 7.60" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="7.39 7.60" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="7.39 7.60" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="7.39 7.60" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="7.39 7.60" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="7.39 7.60" description="Remote Base Memory 1" />
+  <macro id="322" versions="7.39 7.60" description="Remote Base Memory 2" />
+  <macro id="323" versions="7.39 7.60" description="Remote Base Memory 3" />
+  <macro id="324" versions="7.39 7.60" description="Remote Base Memory 4" />
+  <macro id="325" versions="7.39 7.60" description="Remote Base Memory 5" />
+  <macro id="326" versions="7.39 7.60" description="Remote Base Memory 6" />
+  <macro id="327" versions="7.39 7.60" description="Remote Base Memory 7" />
+  <macro id="328" versions="7.39 7.60" description="Remote Base Memory 8" />
+  <macro id="329" versions="7.39 7.60" description="Remote Base Memory 9" />
+  <macro id="330" versions="7.39 7.60" description="Remote Base Memory 10" />
+  <macro id="331" versions="7.39 7.60" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="7.39 7.60" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="7.39 7.60" description="Port 3 Zero Hang Time Select" />
+  <macro id="336" versions="7.39 7.60" description="Dial 911" />
+  <macro id="337" versions="7.39 7.60" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="7.39 7.60" description="Disable Autopatch" />
+  <macro id="339" versions="7.39 7.60" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="7.39 7.60" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="7.39 7.60" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="7.39 7.60" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="7.39 7.60" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="7.39 7.60" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="7.39 7.60" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="7.39 7.60" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="7.39 7.60" description="Start General Timer 1" />
+  <macro id="348" versions="7.39 7.60" description="Start General Timer 2" />
+  <macro id="349" versions="7.39 7.60" description="Start General Timer 3" />
+  <macro id="350" versions="7.39 7.60" description="Stop General Timer 1" />
+  <macro id="351" versions="7.39 7.60" description="Stop General Timer 2" />
+  <macro id="352" versions="7.39 7.60" description="Stop General Timer 3" />
+  <macro id="353" versions="7.39 7.60" description="Remote Base Power Select 1" />
+  <macro id="354" versions="7.39 7.60" description="Remote Base Power Select 2" />
+  <macro id="355" versions="7.39 7.60" description="Remote Base Power Select 3" />
+  <macro id="356" versions="7.39 7.60" description="Guest Macros Enabled" />
+  <macro id="357" versions="7.39 7.60" description="Guest Macros Disabled" />
+  <macro id="358" versions="7.39 7.60" description="Receiver 1 Macros On" />
+  <macro id="359" versions="7.39 7.60" description="Receiver 2 Macros On" />
+  <macro id="360" versions="7.39 7.60" description="Receiver 3 Macros On" />
+  <macro id="361" versions="7.39 7.60" description="Receiver 1 Macros Off" />
+  <macro id="362" versions="7.39 7.60" description="Receiver 2 Macros Off" />
+  <macro id="363" versions="7.39 7.60" description="Receiver 3 Macros Off" />
+  <macro id="364" versions="7.39 7.60" description="Extended Logic 1 Output ON" />
+  <macro id="365" versions="7.39 7.60" description="Extended Logic 2 Output ON" />
+  <macro id="366" versions="7.39 7.60" description="Extended Logic 3 Output ON" />
+  <macro id="367" versions="7.39 7.60" description="Extended Logic 4 Output ON" />
+  <macro id="368" versions="7.39 7.60" description="Extended Logic 5 Output ON" />
+  <macro id="369" versions="7.39 7.60" description="Extended Logic 6 Output ON" />
+  <macro id="370" versions="7.39 7.60" description="Extended Logic 7 Output ON" />
+  <macro id="371" versions="7.39 7.60" description="Extended Logic 8 Output ON" />
+  <macro id="372" versions="7.39 7.60" description="Extended Logic 9 Output ON" />
+  <macro id="373" versions="7.39 7.60" description="Extended Logic 10 Output ON" />
+  <macro id="374" versions="7.39 7.60" description="Extended Logic 11 Output ON" />
+  <macro id="375" versions="7.39 7.60" description="Extended Logic 12 Output ON" />
+  <macro id="376" versions="7.39 7.60" description="Extended Logic 13 Output ON" />
+  <macro id="377" versions="7.39 7.60" description="Extended Logic 14 Output ON" />
+  <macro id="378" versions="7.39 7.60" description="Extended Logic 15 Output ON" />
+  <macro id="379" versions="7.39 7.60" description="Extended Logic 16 Output ON" />
+  <macro id="380" versions="7.39 7.60" description="Extended Logic 17 Output ON" />
+  <macro id="381" versions="7.39 7.60" description="Extended Logic 18 Output ON" />
+  <macro id="382" versions="7.39 7.60" description="Extended Logic 19 Output ON" />
+  <macro id="383" versions="7.39 7.60" description="Extended Logic 20 Output ON" />
+  <macro id="384" versions="7.39 7.60" description="Extended Logic 21 Output ON" />
+  <macro id="385" versions="7.39 7.60" description="Extended Logic 22 Output ON" />
+  <macro id="386" versions="7.39 7.60" description="Extended Logic 23 Output ON" />
+  <macro id="387" versions="7.39 7.60" description="Extended Logic 24 Output ON" />
+  <macro id="388" versions="7.39 7.60" description="Extended Logic 25 Output ON" />
+  <macro id="389" versions="7.39 7.60" description="Extended Logic 26 Output ON" />
+  <macro id="390" versions="7.39 7.60" description="Extended Logic 27 Output ON" />
+  <macro id="391" versions="7.39 7.60" description="Extended Logic 28 Output ON" />
+  <macro id="392" versions="7.39 7.60" description="Extended Logic 29 Output ON" />
+  <macro id="393" versions="7.39 7.60" description="Extended Logic 30 Output ON" />
+  <macro id="394" versions="7.39 7.60" description="Extended Logic 31 Output ON" />
+  <macro id="395" versions="7.39 7.60" description="Extended Logic 32 Output ON" />
+  <macro id="396" versions="7.39 7.60" description="Extended Logic 1 Output Pulse" />
+  <macro id="397" versions="7.39 7.60" description="Extended Logic 2 Output Pulse" />
+  <macro id="398" versions="7.39 7.60" description="Extended Logic 3 Output Pulse" />
+  <macro id="399" versions="7.39 7.60" description="Extended Logic 4 Output Pulse" />
+  <macro id="400" versions="7.39 7.60" description="Extended Logic 5 Output Pulse" />
+  <macro id="401" versions="7.39 7.60" description="Extended Logic 6 Output Pulse" />
+  <macro id="402" versions="7.39 7.60" description="Extended Logic 7 Output Pulse" />
+  <macro id="403" versions="7.39 7.60" description="Extended Logic 8 Output Pulse" />
+  <macro id="404" versions="7.39 7.60" description="Extended Logic 9 Output Pulse" />
+  <macro id="405" versions="7.39 7.60" description="Extended Logic 10 Output Pulse" />
+  <macro id="406" versions="7.39 7.60" description="Extended Logic 11 Output Pulse" />
+  <macro id="407" versions="7.39 7.60" description="Extended Logic 12 Output Pulse" />
+  <macro id="408" versions="7.39 7.60" description="Extended Logic 13 Output Pulse" />
+  <macro id="409" versions="7.39 7.60" description="Extended Logic 14 Output Pulse" />
+  <macro id="410" versions="7.39 7.60" description="Extended Logic 15 Output Pulse" />
+  <macro id="411" versions="7.39 7.60" description="Extended Logic 16 Output Pulse" />
+  <macro id="412" versions="7.39 7.60" description="Extended Logic 17 Output Pulse" />
+  <macro id="413" versions="7.39 7.60" description="Extended Logic 18 Output Pulse" />
+  <macro id="414" versions="7.39 7.60" description="Extended Logic 19 Output Pulse" />
+  <macro id="415" versions="7.39 7.60" description="Extended Logic 20 Output Pulse" />
+  <macro id="416" versions="7.39 7.60" description="Extended Logic 21 Output Pulse" />
+  <macro id="417" versions="7.39 7.60" description="Extended Logic 22 Output Pulse" />
+  <macro id="418" versions="7.39 7.60" description="Extended Logic 23 Output Pulse" />
+  <macro id="419" versions="7.39 7.60" description="Extended Logic 24 Output Pulse" />
+  <macro id="420" versions="7.39 7.60" description="Extended Logic 25 Output Pulse" />
+  <macro id="421" versions="7.39 7.60" description="Extended Logic 26 Output Pulse" />
+  <macro id="422" versions="7.39 7.60" description="Extended Logic 27 Output Pulse" />
+  <macro id="423" versions="7.39 7.60" description="Extended Logic 28 Output Pulse" />
+  <macro id="424" versions="7.39 7.60" description="Extended Logic 29 Output Pulse" />
+  <macro id="425" versions="7.39 7.60" description="Extended Logic 30 Output Pulse" />
+  <macro id="426" versions="7.39 7.60" description="Extended Logic 31 Output Pulse" />
+  <macro id="427" versions="7.39 7.60" description="Extended Logic 32 Output Pulse" />
+  <macro id="428" versions="7.39 7.60" description="Extended Logic 1 Output OFF" />
+  <macro id="429" versions="7.39 7.60" description="Extended Logic 2 Output OFF" />
+  <macro id="430" versions="7.39 7.60" description="Extended Logic 3 Output OFF" />
+  <macro id="431" versions="7.39 7.60" description="Extended Logic 4 Output OFF" />
+  <macro id="432" versions="7.39 7.60" description="Extended Logic 5 Output OFF" />
+  <macro id="433" versions="7.39 7.60" description="Extended Logic 6 Output OFF" />
+  <macro id="434" versions="7.39 7.60" description="Extended Logic 7 Output OFF" />
+  <macro id="435" versions="7.39 7.60" description="Extended Logic 8 Output OFF" />
+  <macro id="436" versions="7.39 7.60" description="Extended Logic 9 Output OFF" />
+  <macro id="437" versions="7.39 7.60" description="Extended Logic 10 Output OFF" />
+  <macro id="438" versions="7.39 7.60" description="Extended Logic 11 Output OFF" />
+  <macro id="439" versions="7.39 7.60" description="Extended Logic 12 Output OFF" />
+  <macro id="440" versions="7.39 7.60" description="Extended Logic 13 Output OFF" />
+  <macro id="441" versions="7.39 7.60" description="Extended Logic 14 Output OFF" />
+  <macro id="442" versions="7.39 7.60" description="Extended Logic 15 Output OFF" />
+  <macro id="443" versions="7.39 7.60" description="Extended Logic 16 Output OFF" />
+  <macro id="444" versions="7.39 7.60" description="Extended Logic 17 Output OFF" />
+  <macro id="445" versions="7.39 7.60" description="Extended Logic 18 Output OFF" />
+  <macro id="446" versions="7.39 7.60" description="Extended Logic 19 Output OFF" />
+  <macro id="447" versions="7.39 7.60" description="Extended Logic 20 Output OFF" />
+  <macro id="448" versions="7.39 7.60" description="Extended Logic 21 Output OFF" />
+  <macro id="449" versions="7.39 7.60" description="Extended Logic 22 Output OFF" />
+  <macro id="450" versions="7.39 7.60" description="Extended Logic 23 Output OFF" />
+  <macro id="451" versions="7.39 7.60" description="Extended Logic 24 Output OFF" />
+  <macro id="452" versions="7.39 7.60" description="Extended Logic 25 Output OFF" />
+  <macro id="453" versions="7.39 7.60" description="Extended Logic 26 Output OFF" />
+  <macro id="454" versions="7.39 7.60" description="Extended Logic 27 Output OFF" />
+  <macro id="455" versions="7.39 7.60" description="Extended Logic 28 Output OFF" />
+  <macro id="456" versions="7.39 7.60" description="Extended Logic 29 Output OFF" />
+  <macro id="457" versions="7.39 7.60" description="Extended Logic 30 Output OFF" />
+  <macro id="458" versions="7.39 7.60" description="Extended Logic 31 Output OFF" />
+  <macro id="459" versions="7.39 7.60" description="Extended Logic 32 Output OFF" />
+  <macro id="460" versions="7.39 7.60" description="Play Message Macro 41" />
+  <macro id="461" versions="7.39 7.60" description="Play Message Macro 42" />
+  <macro id="462" versions="7.39 7.60" description="Play Message Macro 43" />
+  <macro id="463" versions="7.39 7.60" description="Play Message Macro 44" />
+  <macro id="464" versions="7.39 7.60" description="Play Message Macro 45" />
+  <macro id="465" versions="7.39 7.60" description="Play Message Macro 46" />
+  <macro id="466" versions="7.39 7.60" description="Play Message Macro 47" />
+  <macro id="467" versions="7.39 7.60" description="Play Message Macro 48" />
+  <macro id="468" versions="7.39 7.60" description="Play Message Macro 49" />
+  <macro id="469" versions="7.39 7.60" description="Play Message Macro 50" />
+  <macro id="470" versions="7.39 7.60" description="Play Message Macro 51" />
+  <macro id="471" versions="7.39 7.60" description="Play Message Macro 52" />
+  <macro id="472" versions="7.39 7.60" description="Play Message Macro 53" />
+  <macro id="473" versions="7.39 7.60" description="Play Message Macro 54" />
+  <macro id="474" versions="7.39 7.60" description="Play Message Macro 55" />
+  <macro id="475" versions="7.39 7.60" description="Play Message Macro 56" />
+  <macro id="476" versions="7.39 7.60" description="Play Message Macro 57" />
+  <macro id="477" versions="7.39 7.60" description="Play Message Macro 58" />
+  <macro id="478" versions="7.39 7.60" description="Play Message Macro 59" />
+  <macro id="479" versions="7.39 7.60" description="Play Message Macro 60" />
+  <macro id="480" versions="7.39 7.60" description="Play Message Macro 61" />
+  <macro id="481" versions="7.39 7.60" description="Play Message Macro 62" />
+  <macro id="482" versions="7.39 7.60" description="Play Message Macro 63" />
+  <macro id="483" versions="7.39 7.60" description="Play Message Macro 64" />
+  <macro id="484" versions="7.39 7.60" description="Play Message Macro 65" />
+  <macro id="485" versions="7.39 7.60" description="Play Message Macro 66" />
+  <macro id="486" versions="7.39 7.60" description="Play Message Macro 67" />
+  <macro id="487" versions="7.39 7.60" description="Play Message Macro 68" />
+  <macro id="488" versions="7.39 7.60" description="Play Message Macro 69" />
+  <macro id="489" versions="7.39 7.60" description="Play Message Macro 70" />
+  <macro id="490" versions="7.39 7.60" description="Remote Base Memory 11" />
+  <macro id="491" versions="7.39 7.60" description="Remote Base Memory 12" />
+  <macro id="492" versions="7.39 7.60" description="Remote Base Memory 13" />
+  <macro id="493" versions="7.39 7.60" description="Remote Base Memory 14" />
+  <macro id="494" versions="7.39 7.60" description="Remote Base Memory 15" />
+  <macro id="495" versions="7.39 7.60" description="Remote Base Memory 16" />
+  <macro id="496" versions="7.39 7.60" description="Remote Base Memory 17" />
+  <macro id="497" versions="7.39 7.60" description="Remote Base Memory 18" />
+  <macro id="498" versions="7.39 7.60" description="Remote Base Memory 19" />
+  <macro id="499" versions="7.39 7.60" description="Remote Base Memory 20" />
+  <macro id="500" versions="7.39 7.60" description="Remote Base Memory 21" />
+  <macro id="501" versions="7.39 7.60" description="Remote Base Memory 22" />
+  <macro id="502" versions="7.39 7.60" description="Remote Base Memory 23" />
+  <macro id="503" versions="7.39 7.60" description="Remote Base Memory 24" />
+  <macro id="504" versions="7.39 7.60" description="Remote Base Memory 25" />
+  <macro id="505" versions="7.39 7.60" description="Remote Base Memory 26" />
+  <macro id="506" versions="7.39 7.60" description="Remote Base Memory 27" />
+  <macro id="507" versions="7.39 7.60" description="Remote Base Memory 28" />
+  <macro id="508" versions="7.39 7.60" description="Remote Base Memory 29" />
+  <macro id="509" versions="7.39 7.60" description="Remote Base Memory 30" />
+  <macro id="511" versions="7.39 7.60" description="Remote Base Memory 31" />
+  <macro id="512" versions="7.39 7.60" description="Remote Base Memory 32" />
+  <macro id="513" versions="7.39 7.60" description="Remote Base Memory 33" />
+  <macro id="514" versions="7.39 7.60" description="Remote Base Memory 34" />
+  <macro id="515" versions="7.39 7.60" description="Remote Base Memory 35" />
+  <macro id="516" versions="7.39 7.60" description="Remote Base Memory 36" />
+  <macro id="517" versions="7.39 7.60" description="Remote Base Memory 37" />
+  <macro id="518" versions="7.39 7.60" description="Remote Base Memory 38" />
+  <macro id="519" versions="7.39 7.60" description="Remote Base Memory 39" />
+  <macro id="520" versions="7.39 7.60" description="Remote Base Memory 40" />
+  <macro id="521" versions="7.39 7.60" description="Send DTMF Memory 21" />
+  <macro id="522" versions="7.39 7.60" description="Send DTMF Memory 22" />
+  <macro id="523" versions="7.39 7.60" description="Send DTMF Memory 23" />
+  <macro id="524" versions="7.39 7.60" description="Send DTMF Memory 24" />
+  <macro id="525" versions="7.39 7.60" description="Send DTMF Memory 25" />
+  <macro id="526" versions="7.39 7.60" description="Send DTMF Memory 26" />
+  <macro id="527" versions="7.39 7.60" description="Send DTMF Memory 27" />
+  <macro id="528" versions="7.39 7.60" description="Send DTMF Memory 28" />
+  <macro id="529" versions="7.39 7.60" description="Send DTMF Memory 29" />
+  <macro id="530" versions="7.39 7.60" description="Send DTMF Memory 30" />
+  <macro id="531" versions="7.39 7.60" description="Send DTMF Memory 31" />
+  <macro id="532" versions="7.39 7.60" description="Send DTMF Memory 32" />
+  <macro id="533" versions="7.39 7.60" description="Send DTMF Memory 33" />
+  <macro id="534" versions="7.39 7.60" description="Send DTMF Memory 34" />
+  <macro id="535" versions="7.39 7.60" description="Send DTMF Memory 35" />
+  <macro id="536" versions="7.39 7.60" description="Send DTMF Memory 36" />
+  <macro id="537" versions="7.39 7.60" description="Send DTMF Memory 37" />
+  <macro id="538" versions="7.39 7.60" description="Send DTMF Memory 38" />
+  <macro id="539" versions="7.39 7.60" description="Send DTMF Memory 39" />
+  <macro id="540" versions="7.39 7.60" description="Send DTMF Memory 40" />
+  <macro id="541" versions="7.39 7.60" description="Send DTMF Memory 41" />
+  <macro id="542" versions="7.39 7.60" description="Send DTMF Memory 42" />
+  <macro id="543" versions="7.39 7.60" description="Send DTMF Memory 43" />
+  <macro id="544" versions="7.39 7.60" description="Send DTMF Memory 44" />
+  <macro id="545" versions="7.39 7.60" description="Send DTMF Memory 45" />
+  <macro id="546" versions="7.39 7.60" description="Send DTMF Memory 46" />
+  <macro id="547" versions="7.39 7.60" description="Send DTMF Memory 47" />
+  <macro id="548" versions="7.39 7.60" description="Send DTMF Memory 48" />
+  <macro id="549" versions="7.39 7.60" description="Send DTMF Memory 49" />
+  <macro id="550" versions="7.39 7.60" description="Send DTMF Memory 50" />
+  <macro id="551" versions="7.39 7.60" description="Get RTC Time and Date" />
+  <macro id="552" versions="7.39 7.60" description="CTCSS During ID ON" />
+  <macro id="553" versions="7.39 7.60" description="CTCSS During ID OFF" />
+  <macro id="554" versions="7.39 7.60" description="Port 1 Time Transmitter Active since Last Reset" />
+  <macro id="555" versions="7.39 7.60" description="Port 2 Time Transmitter Active since Last Reset" />
+  <macro id="556" versions="7.39 7.60" description="Port 3 Time Transmitter Active since Last Reset" />
+  <macro id="557" versions="7.39 7.60" description="Reset Port 1 Transmitter Activity Timer" />
+  <macro id="558" versions="7.39 7.60" description="Reset Port 2 Transmitter Activity Timer" />
+  <macro id="559" versions="7.39 7.60" description="Reset Port 3 Transmitter Activity Timer" />
+  <macro id="560" versions="7.39 7.60" description="Give RSSI Report" />
+  <macro id="561" versions="7.39 7.60" description="Restart Controller" />
+  <macro id="562" versions="7.39 7.60" description="Readback Number of Keyups Port 1" />
+  <macro id="563" versions="7.39 7.60" description="Readback Number of Keyups Port 2" />
+  <macro id="564" versions="7.39 7.60" description="Readback Number of Keyups Port 3" />
+  <macro id="565" versions="7.39 7.60" description="Reset Keyup Counter Port 1" />
+  <macro id="566" versions="7.39 7.60" description="Reset Keyup Counter Port 2" />
+  <macro id="567" versions="7.39 7.60" description="Reset Keyup Counter Port 3" />
+  <macro id="570" versions="7.39 7.60" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="571" versions="7.39 7.60" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="572" versions="7.39 7.60" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="573" versions="7.39 7.60" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="574" versions="7.39 7.60" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="575" versions="7.39 7.60" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="576" versions="7.39 7.60" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="577" versions="7.39 7.60" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="578" versions="7.39 7.60" description="Readback A/D Channel 1 Stored High" />
+  <macro id="579" versions="7.39 7.60" description="Readback A/D Channel 2 Stored High" />
+  <macro id="580" versions="7.39 7.60" description="Readback A/D Channel 3 Stored High" />
+  <macro id="581" versions="7.39 7.60" description="Readback A/D Channel 4 Stored High" />
+  <macro id="582" versions="7.39 7.60" description="Readback A/D Channel 5 Stored High" />
+  <macro id="583" versions="7.39 7.60" description="Readback A/D Channel 6 Stored High" />
+  <macro id="584" versions="7.39 7.60" description="Readback A/D Channel 7 Stored High" />
+  <macro id="585" versions="7.39 7.60" description="Readback A/D Channel 8 Stored High" />
+  <macro id="586" versions="7.39 7.60" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="7.39 7.60" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="7.39 7.60" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="7.39 7.60" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="7.39 7.60" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="7.39 7.60" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="592" versions="7.39 7.60" description="Current wind speed and direction" />
+  <macro id="593" versions="7.39 7.60" description="Current Outdoor temperature" />
+  <macro id="594" versions="7.39 7.60" description="Indoor humidity" />
+  <macro id="595" versions="7.39 7.60" description="Outdoor humidity" />
+  <macro id="596" versions="7.39 7.60" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="597" versions="7.39 7.60" description="Outdoor Temp High (since Midnight)" />
+  <macro id="598" versions="7.39 7.60" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="605" versions="7.39 7.60" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="606" versions="7.39 7.60" description="Start General Timer 4" />
+  <macro id="607" versions="7.39 7.60" description="Start General Timer 5" />
+  <macro id="608" versions="7.39 7.60" description="Start General Timer 6" />
+  <macro id="609" versions="7.39 7.60" description="Stop General Timer 4" />
+  <macro id="610" versions="7.39 7.60" description="Stop General Timer 5" />
+  <macro id="611" versions="7.39 7.60" description="Stop General Timer 6" />
+  <macro id="612" versions="7.39 7.60" description="Disable Port 1 Inactivity Timer" />
+  <macro id="613" versions="7.39 7.60" description="Disable Port 2 Inactivity Timer" />
+  <macro id="614" versions="7.39 7.60" description="Disable Port 3 Inactivity Timer" />
+  <macro id="615" versions="7.39 7.60" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="7.39 7.60" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="7.39 7.60" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="618" versions="7.39 7.60" description="1 Second Execution Delay" />
+  <macro id="619" versions="7.39 7.60" description="2 Second Execution Delay" />
+  <macro id="620" versions="7.39 7.60" description="4 Second Execution Delay" />
+  <macro id="621" versions="7.39 7.60" description="Port 1 Hangtimer 1 Select" />
+  <macro id="622" versions="7.39 7.60" description="Port 1 Hangtimer 2 Select" />
+  <macro id="623" versions="7.39 7.60" description="Port 1 Hangtimer 3 Select" />
+  <macro id="624" versions="7.39 7.60" description="Port 2 Hangtimer 1 Select" />
+  <macro id="625" versions="7.39 7.60" description="Port 2 Hangtimer 2 Select" />
+  <macro id="626" versions="7.39 7.60" description="Port 2 Hangtimer 3 Select" />
+  <macro id="627" versions="7.39 7.60" description="Port 3 Hangtimer 1 Select" />
+  <macro id="628" versions="7.39 7.60" description="Port 3 Hangtimer 2 Select" />
+  <macro id="629" versions="7.39 7.60" description="Port 3 Hangtimer 3 Select" />
+  <macro id="630" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 1" />
+  <macro id="631" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 2" />
+  <macro id="632" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 3" />
+  <macro id="633" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 4" />
+  <macro id="634" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 5" />
+  <macro id="635" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 6" />
+  <macro id="636" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 7" />
+  <macro id="637" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 8" />
+  <macro id="638" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 9" />
+  <macro id="639" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 10" />
+  <macro id="640" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 1" />
+  <macro id="641" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 2" />
+  <macro id="642" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 3" />
+  <macro id="643" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 4" />
+  <macro id="644" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 5" />
+  <macro id="645" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 6" />
+  <macro id="646" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 7" />
+  <macro id="647" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 8" />
+  <macro id="648" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 9" />
+  <macro id="649" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 10" />
+  <macro id="650" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="651" versions="7.39 7.60" description="Port 2 Next Courtesy Tone1" />
+  <macro id="652" versions="7.39 7.60" description="Port 2 Next Courtesy Tone2" />
+  <macro id="653" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="654" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="655" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="656" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="657" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="658" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
+  <macro id="659" versions="7.39 7.60" description="Port 2 Next Courtesy Tone 10" />
+  <macro id="660" versions="7.01" description="Suspend Scheduler Setpoint 1" />
+  <macro id="660" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 1" />
+  <macro id="661" versions="7.01" description="Suspend Scheduler Setpoint 2" />
+  <macro id="661" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 2" />
+  <macro id="662" versions="7.01" description="Suspend Scheduler Setpoint 3" />
+  <macro id="662" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 3" />
+  <macro id="663" versions="7.01" description="Suspend Scheduler Setpoint 4" />
+  <macro id="663" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 4" />
+  <macro id="664" versions="7.01" description="Suspend Scheduler Setpoint 5" />
+  <macro id="664" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 5" />
+  <macro id="665" versions="7.01" description="Suspend Scheduler Setpoint 6" />
+  <macro id="665" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 6" />
+  <macro id="666" versions="7.01" description="Suspend Scheduler Setpoint 7" />
+  <macro id="666" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 7" />
+  <macro id="667" versions="7.01" description="Suspend Scheduler Setpoint 8" />
+  <macro id="667" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 8" />
+  <macro id="668" versions="7.01" description="Suspend Scheduler Setpoint 9" />
+  <macro id="668" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 9" />
+  <macro id="669" versions="7.01" description="Suspend Scheduler Setpoint 10" />
+  <macro id="669" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 10" />
+  <macro id="670" versions="7.01" description="Suspend Scheduler Setpoint 11" />
+  <macro id="670" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 1" />
+  <macro id="671" versions="7.01" description="Suspend Scheduler Setpoint 12" />
+  <macro id="671" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 2" />
+  <macro id="672" versions="7.01" description="Suspend Scheduler Setpoint 13" />
+  <macro id="672" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 3" />
+  <macro id="673" versions="7.01" description="Suspend Scheduler Setpoint 14" />
+  <macro id="673" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 4" />
+  <macro id="674" versions="7.01" description="Suspend Scheduler Setpoint 15" />
+  <macro id="674" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 5" />
+  <macro id="675" versions="7.01" description="Suspend Scheduler Setpoint 16" />
+  <macro id="675" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 6" />
+  <macro id="676" versions="7.01" description="Suspend Scheduler Setpoint 17" />
+  <macro id="676" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 7" />
+  <macro id="677" versions="7.01" description="Suspend Scheduler Setpoint 18" />
+  <macro id="677" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 8" />
+  <macro id="678" versions="7.01" description="Suspend Scheduler Setpoint 19" />
+  <macro id="678" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 9" />
+  <macro id="679" versions="7.01" description="Suspend Scheduler Setpoint 20" />
+  <macro id="679" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 10" />
+  <macro id="680" versions="7.01" description="Resume Scheduler Setpoint 1" />
+  <macro id="680" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 1" />
+  <macro id="681" versions="7.01" description="Resume Scheduler Setpoint 2" />
+  <macro id="681" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="682" versions="7.01" description="Resume Scheduler Setpoint 3" />
+  <macro id="682" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="683" versions="7.01" description="Resume Scheduler Setpoint 4" />
+  <macro id="683" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 4" />
+  <macro id="684" versions="7.01" description="Resume Scheduler Setpoint 5" />
+  <macro id="684" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 5" />
+  <macro id="685" versions="7.01" description="Resume Scheduler Setpoint 6" />
+  <macro id="685" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 6" />
+  <macro id="686" versions="7.01" description="Resume Scheduler Setpoint 7" />
+  <macro id="686" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 7" />
+  <macro id="687" versions="7.01" description="Resume Scheduler Setpoint 8" />
+  <macro id="687" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 8" />
+  <macro id="688" versions="7.01" description="Resume Scheduler Setpoint 9" />
+  <macro id="688" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 9" />
+  <macro id="689" versions="7.01" description="Resume Scheduler Setpoint 10" />
+  <macro id="689" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 10" />
+  <macro id="690" versions="7.01" description="Resume Scheduler Setpoint 11" />
+  <macro id="691" versions="7.01" description="Resume Scheduler Setpoint 12" />
+  <macro id="692" versions="7.01" description="Resume Scheduler Setpoint 13" />
+  <macro id="692" versions="7.39 7.60" description="Play Port 1 Pending ID" />
+  <macro id="693" versions="7.01" description="Resume Scheduler Setpoint 14" />
+  <macro id="693" versions="7.39 7.60" description="Play Port 2 Pending ID" />
+  <macro id="694" versions="7.01" description="Resume Scheduler Setpoint 15" />
+  <macro id="694" versions="7.39 7.60" description="Play Port 3 Pending ID" />
+  <macro id="695" versions="7.01" description="Resume Scheduler Setpoint 16" />
+  <macro id="696" versions="7.01" description="Resume Scheduler Setpoint 17" />
+  <macro id="697" versions="7.01" description="Resume Scheduler Setpoint 18" />
+  <macro id="698" versions="7.01" description="Resume Scheduler Setpoint 19" />
+  <macro id="699" versions="7.01" description="Resume Scheduler Setpoint 20" />
+  <macro id="701" versions="7.01" description="Call Macro 1" />
+  <macro id="702" versions="7.01" description="Call Macro 2" />
+  <macro id="703" versions="7.01" description="Call Macro 3" />
+  <macro id="704" versions="7.01" description="Call Macro 4" />
+  <macro id="705" versions="7.01" description="Call Macro 5" />
+  <macro id="706" versions="7.01" description="Call Macro 6" />
+  <macro id="707" versions="7.01" description="Call Macro 7" />
+  <macro id="708" versions="7.01" description="Call Macro 8" />
+  <macro id="709" versions="7.01" description="Call Macro 9" />
+  <macro id="710" versions="7.01" description="Call Macro 10" />
+  <macro id="711" versions="7.01" description="Call Macro 11" />
+  <macro id="712" versions="7.01" description="Call Macro 12" />
+  <macro id="713" versions="7.01" description="Call Macro 13" />
+  <macro id="714" versions="7.01" description="Call Macro 14" />
+  <macro id="715" versions="7.01" description="Call Macro 15" />
+  <macro id="716" versions="7.01" description="Call Macro 16" />
+  <macro id="717" versions="7.01" description="Call Macro 17" />
+  <macro id="718" versions="7.01" description="Call Macro 18" />
+  <macro id="719" versions="7.01" description="Call Macro 19" />
+  <macro id="720" versions="7.01" description="Call Macro 20" />
+  <macro id="721" versions="7.01" description="Call Macro 21" />
+  <macro id="722" versions="7.01" description="Call Macro 22" />
+  <macro id="723" versions="7.01" description="Call Macro 23" />
+  <macro id="724" versions="7.01" description="Call Macro 24" />
+  <macro id="725" versions="7.01" description="Call Macro 25" />
+  <macro id="726" versions="7.01" description="Call Macro 26" />
+  <macro id="727" versions="7.01" description="Call Macro 27" />
+  <macro id="728" versions="7.01" description="Call Macro 28" />
+  <macro id="729" versions="7.01" description="Call Macro 29" />
+  <macro id="730" versions="7.01" description="Call Macro 30" />
+  <macro id="731" versions="7.01" description="Call Macro 31" />
+  <macro id="732" versions="7.01" description="Call Macro 32" />
+  <macro id="733" versions="7.01" description="Call Macro 33" />
+  <macro id="734" versions="7.01" description="Call Macro 34" />
+  <macro id="735" versions="7.01" description="Call Macro 35" />
+  <macro id="736" versions="7.01" description="Call Macro 36" />
+  <macro id="737" versions="7.01" description="Call Macro 37" />
+  <macro id="738" versions="7.01" description="Call Macro 38" />
+  <macro id="739" versions="7.01" description="Call Macro 39" />
+  <macro id="740" versions="7.01" description="Call Macro 40" />
+  <macro id="741" versions="7.01" description="Call Macro 41" />
+  <macro id="742" versions="7.01" description="Call Macro 42" />
+  <macro id="743" versions="7.01" description="Call Macro 43" />
+  <macro id="744" versions="7.01" description="Call Macro 44" />
+  <macro id="745" versions="7.01" description="Call Macro 45" />
+  <macro id="746" versions="7.01" description="Call Macro 46" />
+  <macro id="747" versions="7.01" description="Call Macro 47" />
+  <macro id="748" versions="7.01" description="Call Macro 48" />
+  <macro id="749" versions="7.01" description="Call Macro 49" />
+  <macro id="750" versions="7.01" description="Call Macro 50" />
+  <macro id="751" versions="7.01" description="Call Macro 51" />
+  <macro id="752" versions="7.01" description="Call Macro 52" />
+  <macro id="753" versions="7.01" description="Call Macro 53" />
+  <macro id="754" versions="7.01" description="Call Macro 54" />
+  <macro id="755" versions="7.01" description="Call Macro 55" />
+  <macro id="756" versions="7.01" description="Call Macro 56" />
+  <macro id="757" versions="7.01" description="Call Macro 57" />
+  <macro id="758" versions="7.01" description="Call Macro 58" />
+  <macro id="759" versions="7.01" description="Call Macro 59" />
+  <macro id="760" versions="7.01" description="Call Macro 60" />
+  <macro id="761" versions="7.01" description="Call Macro 61" />
+  <macro id="762" versions="7.01" description="Call Macro 62" />
+  <macro id="763" versions="7.01" description="Call Macro 63" />
+  <macro id="764" versions="7.01" description="Call Macro 64" />
+  <macro id="766" versions="7.01" description="Call Macro 65" />
+  <macro id="767" versions="7.01" description="Call Macro 66" />
+  <macro id="768" versions="7.01" description="Call Macro 67" />
+  <macro id="769" versions="7.01" description="Call Macro 68" />
+  <macro id="770" versions="7.01" description="Call Macro 69" />
+  <macro id="771" versions="7.01" description="Call Macro 70" />
+  <macro id="772" versions="7.01" description="Call Macro 71" />
+  <macro id="773" versions="7.01" description="Call Macro 72" />
+  <macro id="774" versions="7.01" description="Call Macro 73" />
+  <macro id="775" versions="7.01" description="Call Macro 74" />
+  <macro id="776" versions="7.01" description="Call Macro 75" />
+  <macro id="777" versions="7.01" description="Call Macro 76" />
+  <macro id="778" versions="7.01" description="Call Macro 77" />
+  <macro id="779" versions="7.01" description="Call Macro 78" />
+  <macro id="780" versions="7.01" description="Call Macro 79" />
+  <macro id="781" versions="7.01" description="Call Macro 80" />
+  <macro id="782" versions="7.01" description="Call Macro 81" />
+  <macro id="783" versions="7.01" description="Call Macro 82" />
+  <macro id="784" versions="7.01" description="Call Macro 83" />
+  <macro id="785" versions="7.01" description="Call Macro 84" />
+  <macro id="786" versions="7.01" description="Call Macro 85" />
+  <macro id="787" versions="7.01" description="Call Macro 86" />
+  <macro id="788" versions="7.01" description="Call Macro 87" />
+  <macro id="789" versions="7.01" description="Call Macro 88" />
+  <macro id="790" versions="7.01" description="Call Macro 89" />
+  <macro id="791" versions="7.01" description="Call Macro 90" />
+  <macro id="810" versions="7.39 7.60" description="Suspend Scheduler Setpoint 1" />
+  <macro id="811" versions="7.39 7.60" description="Suspend Scheduler Setpoint 2" />
+  <macro id="812" versions="7.39 7.60" description="Suspend Scheduler Setpoint 3" />
+  <macro id="813" versions="7.39 7.60" description="Suspend Scheduler Setpoint 4" />
+  <macro id="814" versions="7.39 7.60" description="Suspend Scheduler Setpoint 5" />
+  <macro id="815" versions="7.39 7.60" description="Suspend Scheduler Setpoint 6" />
+  <macro id="816" versions="7.39 7.60" description="Suspend Scheduler Setpoint 7" />
+  <macro id="817" versions="7.39 7.60" description="Suspend Scheduler Setpoint 8" />
+  <macro id="818" versions="7.39 7.60" description="Suspend Scheduler Setpoint 9" />
+  <macro id="819" versions="7.39 7.60" description="Suspend Scheduler Setpoint 10" />
+  <macro id="820" versions="7.39 7.60" description="Suspend Scheduler Setpoint 11" />
+  <macro id="821" versions="7.39 7.60" description="Suspend Scheduler Setpoint 12" />
+  <macro id="822" versions="7.39 7.60" description="Suspend Scheduler Setpoint 13" />
+  <macro id="823" versions="7.39 7.60" description="Suspend Scheduler Setpoint 14" />
+  <macro id="824" versions="7.39 7.60" description="Suspend Scheduler Setpoint 15" />
+  <macro id="825" versions="7.39 7.60" description="Suspend Scheduler Setpoint 16" />
+  <macro id="826" versions="7.39 7.60" description="Suspend Scheduler Setpoint 17" />
+  <macro id="827" versions="7.39 7.60" description="Suspend Scheduler Setpoint 18" />
+  <macro id="828" versions="7.39 7.60" description="Suspend Scheduler Setpoint 19" />
+  <macro id="829" versions="7.39 7.60" description="Suspend Scheduler Setpoint 20" />
+  <macro id="830" versions="7.39 7.60" description="Suspend Scheduler Setpoint 21" />
+  <macro id="831" versions="7.39 7.60" description="Suspend Scheduler Setpoint 22" />
+  <macro id="832" versions="7.39 7.60" description="Suspend Scheduler Setpoint 23" />
+  <macro id="833" versions="7.39 7.60" description="Suspend Scheduler Setpoint 24" />
+  <macro id="834" versions="7.39 7.60" description="Suspend Scheduler Setpoint 25" />
+  <macro id="835" versions="7.39 7.60" description="Suspend Scheduler Setpoint 26" />
+  <macro id="836" versions="7.39 7.60" description="Suspend Scheduler Setpoint 27" />
+  <macro id="837" versions="7.39 7.60" description="Suspend Scheduler Setpoint 28" />
+  <macro id="838" versions="7.39 7.60" description="Suspend Scheduler Setpoint 29" />
+  <macro id="839" versions="7.39 7.60" description="Suspend Scheduler Setpoint 30" />
+  <macro id="840" versions="7.39 7.60" description="Suspend Scheduler Setpoint 31" />
+  <macro id="841" versions="7.39 7.60" description="Suspend Scheduler Setpoint 32" />
+  <macro id="842" versions="7.39 7.60" description="Suspend Scheduler Setpoint 33" />
+  <macro id="843" versions="7.39 7.60" description="Suspend Scheduler Setpoint 34" />
+  <macro id="844" versions="7.39 7.60" description="Suspend Scheduler Setpoint 35" />
+  <macro id="845" versions="7.39 7.60" description="Suspend Scheduler Setpoint 36" />
+  <macro id="846" versions="7.39 7.60" description="Suspend Scheduler Setpoint 37" />
+  <macro id="847" versions="7.39 7.60" description="Suspend Scheduler Setpoint 38" />
+  <macro id="848" versions="7.39 7.60" description="Suspend Scheduler Setpoint 39" />
+  <macro id="849" versions="7.39 7.60" description="Suspend Scheduler Setpoint 40" />
+  <macro id="850" versions="7.39 7.60" description="Resume Scheduler Setpoint 1" />
+  <macro id="851" versions="7.39 7.60" description="Resume Scheduler Setpoint 2" />
+  <macro id="852" versions="7.39 7.60" description="Resume Scheduler Setpoint 3" />
+  <macro id="853" versions="7.39 7.60" description="Resume Scheduler Setpoint 4" />
+  <macro id="854" versions="7.39 7.60" description="Resume Scheduler Setpoint 5" />
+  <macro id="355" versions="7.39 7.60" description="Resume Scheduler Setpoint 6" />
+  <macro id="856" versions="7.39 7.60" description="Resume Scheduler Setpoint 7" />
+  <macro id="857" versions="7.39 7.60" description="Resume Scheduler Setpoint 8" />
+  <macro id="858" versions="7.39 7.60" description="Resume Scheduler Setpoint 9" />
+  <macro id="859" versions="7.39 7.60" description="Resume Scheduler Setpoint 10" />
+  <macro id="860" versions="7.39 7.60" description="Resume Scheduler Setpoint 11" />
+  <macro id="861" versions="7.39 7.60" description="Resume Scheduler Setpoint 12" />
+  <macro id="862" versions="7.39 7.60" description="Resume Scheduler Setpoint 13" />
+  <macro id="863" versions="7.39 7.60" description="Resume Scheduler Setpoint 14" />
+  <macro id="864" versions="7.39 7.60" description="Resume Scheduler Setpoint 15" />
+  <macro id="865" versions="7.39 7.60" description="Resume Scheduler Setpoint 16" />
+  <macro id="866" versions="7.39 7.60" description="Resume Scheduler Setpoint 17" />
+  <macro id="867" versions="7.39 7.60" description="Resume Scheduler Setpoint 18" />
+  <macro id="868" versions="7.39 7.60" description="Resume Scheduler Setpoint 19" />
+  <macro id="869" versions="7.39 7.60" description="Resume Scheduler Setpoint 20" />
+  <macro id="870" versions="7.39 7.60" description="Resume Scheduler Setpoint 21" />
+  <macro id="871" versions="7.39 7.60" description="Resume Scheduler Setpoint 22" />
+  <macro id="872" versions="7.39 7.60" description="Resume Scheduler Setpoint 23" />
+  <macro id="873" versions="7.39 7.60" description="Resume Scheduler Setpoint 24" />
+  <macro id="874" versions="7.39 7.60" description="Resume Scheduler Setpoint 25" />
+  <macro id="875" versions="7.39 7.60" description="Resume Scheduler Setpoint 26" />
+  <macro id="876" versions="7.39 7.60" description="Resume Scheduler Setpoint 27" />
+  <macro id="877" versions="7.39 7.60" description="Resume Scheduler Setpoint 28" />
+  <macro id="878" versions="7.39 7.60" description="Resume Scheduler Setpoint 29" />
+  <macro id="879" versions="7.39 7.60" description="Resume Scheduler Setpoint 30" />
+  <macro id="880" versions="7.39 7.60" description="Resume Scheduler Setpoint 31" />
+  <macro id="881" versions="7.39 7.60" description="Resume Scheduler Setpoint 32" />
+  <macro id="882" versions="7.39 7.60" description="Resume Scheduler Setpoint 33" />
+  <macro id="883" versions="7.39 7.60" description="Resume Scheduler Setpoint 34" />
+  <macro id="884" versions="7.39 7.60" description="Resume Scheduler Setpoint 35" />
+  <macro id="885" versions="7.39 7.60" description="Resume Scheduler Setpoint 36" />
+  <macro id="886" versions="7.39 7.60" description="Resume Scheduler Setpoint 37" />
+  <macro id="887" versions="7.39 7.60" description="Resume Scheduler Setpoint 38" />
+  <macro id="888" versions="7.39 7.60" description="Resume Scheduler Setpoint 39" />
+  <macro id="889" versions="7.39 7.60" description="Resume Scheduler Setpoint 40" />
+  <macro id="860" versions="7.36" description="Suspend Scheduler Setpoint 1" />
+  <macro id="861" versions="7.36" description="Suspend Scheduler Setpoint 2" />
+  <macro id="862" versions="7.36" description="Suspend Scheduler Setpoint 3" />
+  <macro id="863" versions="7.36" description="Suspend Scheduler Setpoint 4" />
+  <macro id="864" versions="7.36" description="Suspend Scheduler Setpoint 5" />
+  <macro id="865" versions="7.36" description="Suspend Scheduler Setpoint 6" />
+  <macro id="866" versions="7.36" description="Suspend Scheduler Setpoint 7" />
+  <macro id="867" versions="7.36" description="Suspend Scheduler Setpoint 8" />
+  <macro id="868" versions="7.36" description="Suspend Scheduler Setpoint 9" />
+  <macro id="869" versions="7.36" description="Suspend Scheduler Setpoint 10" />
+  <macro id="870" versions="7.36" description="Suspend Scheduler Setpoint 11" />
+  <macro id="871" versions="7.36" description="Suspend Scheduler Setpoint 12" />
+  <macro id="872" versions="7.36" description="Suspend Scheduler Setpoint 13" />
+  <macro id="873" versions="7.36" description="Suspend Scheduler Setpoint 14" />
+  <macro id="874" versions="7.36" description="Suspend Scheduler Setpoint 15" />
+  <macro id="875" versions="7.36" description="Suspend Scheduler Setpoint 16" />
+  <macro id="876" versions="7.36" description="Suspend Scheduler Setpoint 17" />
+  <macro id="877" versions="7.36" description="Suspend Scheduler Setpoint 18" />
+  <macro id="878" versions="7.36" description="Suspend Scheduler Setpoint 19" />
+  <macro id="879" versions="7.36" description="Suspend Scheduler Setpoint 20" />
+  <macro id="880" versions="7.36" description="Resume Scheduler Setpoint 1" />
+  <macro id="881" versions="7.36" description="Resume Scheduler Setpoint 2" />
+  <macro id="882" versions="7.36" description="Resume Scheduler Setpoint 3" />
+  <macro id="883" versions="7.36" description="Resume Scheduler Setpoint 4" />
+  <macro id="884" versions="7.36" description="Resume Scheduler Setpoint 5" />
+  <macro id="885" versions="7.36" description="Resume Scheduler Setpoint 6" />
+  <macro id="886" versions="7.36" description="Resume Scheduler Setpoint 7" />
+  <macro id="887" versions="7.36" description="Resume Scheduler Setpoint 8" />
+  <macro id="888" versions="7.36" description="Resume Scheduler Setpoint 9" />
+  <macro id="889" versions="7.36" description="Resume Scheduler Setpoint 10" />
+  <macro id="890" versions="7.36" description="Resume Scheduler Setpoint 11" />
+  <macro id="891" versions="7.36" description="Resume Scheduler Setpoint 12" />
+  <macro id="892" versions="7.36" description="Resume Scheduler Setpoint 13" />
+  <macro id="893" versions="7.36" description="Resume Scheduler Setpoint 14" />
+  <macro id="894" versions="7.36" description="Resume Scheduler Setpoint 15" />
+  <macro id="895" versions="7.36" description="Resume Scheduler Setpoint 16" />
+  <macro id="896" versions="7.36" description="Resume Scheduler Setpoint 17" />
+  <macro id="897" versions="7.36" description="Resume Scheduler Setpoint 18" />
+  <macro id="898" versions="7.36" description="Resume Scheduler Setpoint 19" />
+  <macro id="899" versions="7.36" description="Resume Scheduler Setpoint 20" />
+  <macro id="901" versions="7.39 7.60" description="Call Macro 1" />
+  <macro id="902" versions="7.39 7.60" description="Call Macro 2" />
+  <macro id="903" versions="7.39 7.60" description="Call Macro 3" />
+  <macro id="904" versions="7.39 7.60" description="Call Macro 4" />
+  <macro id="905" versions="7.39 7.60" description="Call Macro 5" />
+  <macro id="906" versions="7.39 7.60" description="Call Macro 6" />
+  <macro id="907" versions="7.39 7.60" description="Call Macro 7" />
+  <macro id="908" versions="7.39 7.60" description="Call Macro 8" />
+  <macro id="909" versions="7.39 7.60" description="Call Macro 9" />
+  <macro id="910" versions="7.39 7.60" description="Call Macro 10" />
+  <macro id="911" versions="7.39 7.60" description="Call Macro 11" />
+  <macro id="912" versions="7.39 7.60" description="Call Macro 12" />
+  <macro id="913" versions="7.39 7.60" description="Call Macro 13" />
+  <macro id="914" versions="7.39 7.60" description="Call Macro 14" />
+  <macro id="915" versions="7.39 7.60" description="Call Macro 15" />
+  <macro id="916" versions="7.39 7.60" description="Call Macro 16" />
+  <macro id="917" versions="7.39 7.60" description="Call Macro 17" />
+  <macro id="918" versions="7.39 7.60" description="Call Macro 18" />
+  <macro id="919" versions="7.39 7.60" description="Call Macro 19" />
+  <macro id="920" versions="7.39 7.60" description="Call Macro 20" />
+  <macro id="921" versions="7.39 7.60" description="Call Macro 21" />
+  <macro id="922" versions="7.39 7.60" description="Call Macro 22" />
+  <macro id="923" versions="7.39 7.60" description="Call Macro 23" />
+  <macro id="924" versions="7.39 7.60" description="Call Macro 24" />
+  <macro id="925" versions="7.39 7.60" description="Call Macro 25" />
+  <macro id="926" versions="7.39 7.60" description="Call Macro 26" />
+  <macro id="927" versions="7.39 7.60" description="Call Macro 27" />
+  <macro id="928" versions="7.39 7.60" description="Call Macro 28" />
+  <macro id="929" versions="7.39 7.60" description="Call Macro 29" />
+  <macro id="930" versions="7.39 7.60" description="Call Macro 30" />
+  <macro id="931" versions="7.39 7.60" description="Call Macro 31" />
+  <macro id="932" versions="7.39 7.60" description="Call Macro 32" />
+  <macro id="933" versions="7.39 7.60" description="Call Macro 33" />
+  <macro id="934" versions="7.39 7.60" description="Call Macro 34" />
+  <macro id="935" versions="7.39 7.60" description="Call Macro 35" />
+  <macro id="936" versions="7.39 7.60" description="Call Macro 36" />
+  <macro id="937" versions="7.39 7.60" description="Call Macro 37" />
+  <macro id="938" versions="7.39 7.60" description="Call Macro 38" />
+  <macro id="939" versions="7.39 7.60" description="Call Macro 39" />
+  <macro id="940" versions="7.39 7.60" description="Call Macro 40" />
+  <macro id="941" versions="7.39 7.60" description="Call Macro 41" />
+  <macro id="942" versions="7.39 7.60" description="Call Macro 42" />
+  <macro id="943" versions="7.39 7.60" description="Call Macro 43" />
+  <macro id="944" versions="7.39 7.60" description="Call Macro 44" />
+  <macro id="945" versions="7.39 7.60" description="Call Macro 45" />
+  <macro id="946" versions="7.39 7.60" description="Call Macro 46" />
+  <macro id="947" versions="7.39 7.60" description="Call Macro 47" />
+  <macro id="948" versions="7.39 7.60" description="Call Macro 48" />
+  <macro id="949" versions="7.39 7.60" description="Call Macro 49" />
+  <macro id="950" versions="7.39 7.60" description="Call Macro 50" />
+  <macro id="951" versions="7.39 7.60" description="Call Macro 51" />
+  <macro id="952" versions="7.39 7.60" description="Call Macro 52" />
+  <macro id="953" versions="7.39 7.60" description="Call Macro 53" />
+  <macro id="954" versions="7.39 7.60" description="Call Macro 54" />
+  <macro id="955" versions="7.39 7.60" description="Call Macro 55" />
+  <macro id="956" versions="7.39 7.60" description="Call Macro 56" />
+  <macro id="957" versions="7.39 7.60" description="Call Macro 57" />
+  <macro id="958" versions="7.39 7.60" description="Call Macro 58" />
+  <macro id="959" versions="7.39 7.60" description="Call Macro 59" />
+  <macro id="960" versions="7.39 7.60" description="Call Macro 60" />
+  <macro id="961" versions="7.39 7.60" description="Call Macro 61" />
+  <macro id="962" versions="7.39 7.60" description="Call Macro 62" />
+  <macro id="963" versions="7.39 7.60" description="Call Macro 63" />
+  <macro id="964" versions="7.39 7.60" description="Call Macro 64" />
+  <macro id="965" versions="7.39 7.60" description="Call Macro 65" />
+  <macro id="966" versions="7.39 7.60" description="Call Macro 66" />
+  <macro id="967" versions="7.39 7.60" description="Call Macro 67" />
+  <macro id="968" versions="7.39 7.60" description="Call Macro 68" />
+  <macro id="969" versions="7.39 7.60" description="Call Macro 69" />
+  <macro id="970" versions="7.39 7.60" description="Call Macro 70" />
+  <macro id="971" versions="7.39 7.60" description="Call Macro 71" />
+  <macro id="972" versions="7.39 7.60" description="Call Macro 72" />
+  <macro id="973" versions="7.39 7.60" description="Call Macro 73" />
+  <macro id="974" versions="7.39 7.60" description="Call Macro 74" />
+  <macro id="975" versions="7.39 7.60" description="Call Macro 75" />
+  <macro id="976" versions="7.39 7.60" description="Call Macro 76" />
+  <macro id="977" versions="7.39 7.60" description="Call Macro 77" />
+  <macro id="978" versions="7.39 7.60" description="Call Macro 78" />
+  <macro id="979" versions="7.39 7.60" description="Call Macro 79" />
+  <macro id="980" versions="7.39 7.60" description="Call Macro 80" />
+  <macro id="981" versions="7.39 7.60" description="Call Macro 81" />
+  <macro id="982" versions="7.39 7.60" description="Call Macro 82" />
+  <macro id="983" versions="7.39 7.60" description="Call Macro 83" />
+  <macro id="984" versions="7.39 7.60" description="Call Macro 84" />
+  <macro id="985" versions="7.39 7.60" description="Call Macro 85" />
+  <macro id="986" versions="7.39 7.60" description="Call Macro 86" />
+  <macro id="987" versions="7.39 7.60" description="Call Macro 87" />
+  <macro id="988" versions="7.39 7.60" description="Call Macro 88" />
+  <macro id="989" versions="7.39 7.60" description="Call Macro 89" />
+  <macro id="990" versions="7.39 7.60" description="Call Macro 90" />
+  <macro id="991" versions="7.39 7.60" description="Call Macro 91" />
+  <macro id="992" versions="7.39 7.60" description="Call Macro 92" />
+  <macro id="993" versions="7.39 7.60" description="Call Macro 93" />
+  <macro id="994" versions="7.39 7.60" description="Call Macro 94" />
+  <macro id="995" versions="7.39 7.60" description="Call Macro 95" />
+  <macro id="996" versions="7.39 7.60" description="Call Macro 96" />
+  <macro id="997" versions="7.39 7.60" description="Call Macro 97" />
+  <macro id="998" versions="7.39 7.60" description="Call Macro 98" />
+  <macro id="999" versions="7.39 7.60" description="Call Macro 99" />
+  <macro id="1000" versions="7.39 7.60" description="Call Macro 100" />
+  <macro id="1001" versions="7.39 7.60" description="Call Macro 101" />
+  <macro id="1002" versions="7.39 7.60" description="Call Macro 102" />
+  <macro id="1003" versions="7.39 7.60" description="Call Macro 103" />
+  <macro id="1004" versions="7.39 7.60" description="Call Macro 104" />
+  <macro id="1005" versions="7.39 7.60" description="Call Macro 105" />
+</macros>

--- a/XML/Ver8_macro_def.xml
+++ b/XML/Ver8_macro_def.xml
@@ -1,1037 +1,866 @@
 <macros version="3.000">
-  <macro id="1" versions="7.39 7.60" description="Port 1 CTCSS Access" />
-  <macro id="2" versions="7.39 7.60" description="Port 2 CTCSS Access" />
-  <macro id="3" versions="7.39 7.60" description="Port 3 CTCSS Access" />
-  <macro id="4" versions="7.39 7.60" description="Port 1 Carrier Access" />
-  <macro id="5" versions="7.39 7.60" description="Port 2 Carrier Access" />
-  <macro id="6" versions="7.39 7.60" description="Port 3 Carrier Access" />
-  <macro id="7" versions="7.39 7.60" description="Port 1 DTMF Covertone ON" />
-  <macro id="8" versions="7.39 7.60" description="Port 2 DTMF Covertone ON" />
-  <macro id="9" versions="7.39 7.60" description="Port 3 DTMF Covertone ON" />
-  <macro id="10" versions="7.39 7.60" description="Port 1 DTMF Covertone OFF" />
-  <macro id="11" versions="7.39 7.60" description="Port 2 DTMF Covertone OFF" />
-  <macro id="12" versions="7.39 7.60" description="Port 3 DTMF Covertone OFF" />
-  <macro id="13" versions="7.39 7.60" description="Port 1 Enable" />
-  <macro id="14" versions="7.39 7.60" description="Port 2 Enable" />
-  <macro id="15" versions="7.39 7.60" description="Port 3 Enable" />
-  <macro id="16" versions="7.39 7.60" description="Port 1 Disable" />
-  <macro id="17" versions="7.39 7.60" description="Port 2 Disable" />
-  <macro id="18" versions="7.39 7.60" description="Port 3 Disable" />
-  <macro id="19" versions="7.39 7.60" description="Monitor Port 1 from Port 2" />
-  <macro id="20" versions="7.39 7.60" description="Monitor Port 1 from Port 3" />
-  <macro id="21" versions="7.39 7.60" description="Disconnect Port 1 from Port 2" />
-  <macro id="22" versions="7.39 7.60" description="Disconnect Port 1 from Port 3" />
-  <macro id="23" versions="7.39 7.60" description="Monitor Port 2 from Port 1" />
-  <macro id="24" versions="7.39 7.60" description="Monitor Port 2 from Port 3" />
-  <macro id="25" versions="7.39 7.60" description="Disconnect Port 2 from Port 1" />
-  <macro id="26" versions="7.39 7.60" description="Disconnect Port 2 from Port 3" />
-  <macro id="27" versions="7.39 7.60" description="Monitor Port 3 from Port 1" />
-  <macro id="28" versions="7.39 7.60" description="Monitor Port 3 from Port 2" />
-  <macro id="29" versions="7.39 7.60" description="Disconnect Port 3 from Port 1" />
-  <macro id="30" versions="7.39 7.60" description="Disconnect Port 3 from Port 2" />
-  <macro id="31" versions="7.39 7.60" description="Port 1 Monitor Mute" />
-  <macro id="32" versions="7.39 7.60" description="Port 2 Monitor Mute" />
-  <macro id="33" versions="7.39 7.60" description="Port 3 Monitor Mute" />
-  <macro id="34" versions="7.39 7.60" description="Port 1 Monitor Mix" />
-  <macro id="35" versions="7.39 7.60" description="Port 2 Monitor Mix" />
-  <macro id="36" versions="7.39 7.60" description="Port 3 Monitor Mix" />
-  <macro id="37" versions="7.39 7.60" description="Port 1 Repeat ON" />
-  <macro id="38" versions="7.39 7.60" description="Port 2 Repeat ON" />
-  <macro id="39" versions="7.39 7.60" description="Port 3 Repeat ON" />
-  <macro id="40" versions="7.39 7.60" description="Port 1 Repeat OFF" />
-  <macro id="41" versions="7.39 7.60" description="Port 2 Repeat OFF" />
-  <macro id="42" versions="7.39 7.60" description="Port 3 Repeat OFF" />
-  <macro id="43" versions="7.39 7.60" description="Port 1 Speech OverrideON" />
-  <macro id="44" versions="7.39 7.60" description="Port 2 Speech OverrideON" />
-  <macro id="45" versions="7.39 7.60" description="Port 3 Speech OverrideON" />
-  <macro id="46" versions="7.39 7.60" description="Port 1 Speech Override OFF" />
-  <macro id="47" versions="7.39 7.60" description="Port 2 Speech Override OFF" />
-  <macro id="48" versions="7.39 7.60" description="Port 3 Speech Override OFF" />
-  <macro id="49" versions="7.39 7.60" description="Port 1 Courtesy Tone 1" />
-  <macro id="50" versions="7.39 7.60" description="Port 1 Courtesy Tone 2" />
-  <macro id="51" versions="7.39 7.60" description="Port 1 Courtesy Tone 3" />
-  <macro id="52" versions="7.39 7.60" description="Port 1 Courtesy Tone 4" />
-  <macro id="53" versions="7.39 7.60" description="Port 1 Courtesy Tone 5" />
-  <macro id="54" versions="7.39 7.60" description="Port 1 Courtesy Tone 6" />
-  <macro id="55" versions="7.39 7.60" description="Port 1 Courtesy Tone 7" />
-  <macro id="56" versions="7.39 7.60" description="Port 1 Courtesy Tone 8" />
-  <macro id="57" versions="7.39 7.60" description="Port 1 Courtesy Tone 9" />
-  <macro id="58" versions="7.39 7.60" description="Port 1 Courtesy Tone 10" />
-  <macro id="59" versions="7.39 7.60" description="Port 2 Courtesy Tone 1" />
-  <macro id="60" versions="7.39 7.60" description="Port 2 Courtesy Tone 2" />
-  <macro id="61" versions="7.39 7.60" description="Port 2 Courtesy Tone 3" />
-  <macro id="62" versions="7.39 7.60" description="Port 2 Courtesy Tone 4" />
-  <macro id="63" versions="7.39 7.60" description="Port 2 Courtesy Tone 5" />
-  <macro id="64" versions="7.39 7.60" description="Port 2 Courtesy Tone 6" />
-  <macro id="65" versions="7.39 7.60" description="Port 2 Courtesy Tone 7" />
-  <macro id="66" versions="7.39 7.60" description="Port 2 Courtesy Tone 8" />
-  <macro id="67" versions="7.39 7.60" description="Port 2 Courtesy Tone 9" />
-  <macro id="68" versions="7.39 7.60" description="Port 2 Courtesy Tone 10" />
-  <macro id="69" versions="7.39 7.60" description="Port 3 Courtesy Tone 1" />
-  <macro id="70" versions="7.39 7.60" description="Port 3 Courtesy Tone 2" />
-  <macro id="71" versions="7.39 7.60" description="Port 3 Courtesy Tone 3" />
-  <macro id="72" versions="7.39 7.60" description="Port 3 Courtesy Tone 4" />
-  <macro id="73" versions="7.39 7.60" description="Port 3 Courtesy Tone 5" />
-  <macro id="74" versions="7.39 7.60" description="Port 3 Courtesy Tone 6" />
-  <macro id="75" versions="7.39 7.60" description="Port 3 Courtesy Tone 7" />
-  <macro id="76" versions="7.39 7.60" description="Port 3 Courtesy Tone 8" />
-  <macro id="77" versions="7.39 7.60" description="Port 3 Courtesy Tone 9" />
-  <macro id="78" versions="7.39 7.60" description="Port 3 Courtesy Tone 10" />
-  <macro id="79" versions="7.39 7.60" description="Port 1 DTMF Muting ON" />
-  <macro id="80" versions="7.39 7.60" description="Port 2 DTMF Muting ON" />
-  <macro id="81" versions="7.39 7.60" description="Port 3 DTMF Muting ON" />
-  <macro id="82" versions="7.39 7.60" description="Port 1 DTMF Muting OFF" />
-  <macro id="83" versions="7.39 7.60" description="Port 2 DTMF Muting OFF" />
-  <macro id="84" versions="7.39 7.60" description="Port 3 DTMF Muting OFF" />
-  <macro id="85" versions="7.39 7.60" description="CTCSS Encode ON (for the duration of this Macro)" />
-  <macro id="86" versions="7.39 7.60" description="CTCSS Encode OFF (for the duration of this Macro)" />
-  <macro id="87" versions="7.39 7.60" description="Read ADC Channel 1" />
-  <macro id="88" versions="7.39 7.60" description="Read ADC Channel 2" />
-  <macro id="89" versions="7.39 7.60" description="Read ADC Channel 3" />
-  <macro id="90" versions="7.39 7.60" description="Read ADC Channel 4" />
-  <macro id="91" versions="7.39 7.60" description="Read ADC Channel 5" />
-  <macro id="92" versions="7.39 7.60" description="Read ADC Channel 6" />
-  <macro id="93" versions="7.39 7.60" description="Read ADC Channel 7" />
-  <macro id="94" versions="7.39 7.60" description="Read ADC Channel 8" />
-  <macro id="95" versions="7.39 7.60" description="UF1 ON" />
-  <macro id="96" versions="7.39 7.60" description="UF2 ON" />
-  <macro id="97" versions="7.39 7.60" description="UF3 ON" />
-  <macro id="98" versions="7.39 7.60" description="UF4 ON" />
-  <macro id="99" versions="7.39 7.60" description="UF5 ON" />
-  <macro id="100" versions="7.39 7.60" description="UF6 ON" />
-  <macro id="101" versions="7.39 7.60" description="UF7 ON" />
-  <macro id="102" versions="7.39 7.60" description="UF1 OFF" />
-  <macro id="103" versions="7.39 7.60" description="UF2 OFF" />
-  <macro id="104" versions="7.39 7.60" description="UF3 OFF" />
-  <macro id="105" versions="7.39 7.60" description="UF4 OFF" />
-  <macro id="106" versions="7.39 7.60" description="UF5 OFF" />
-  <macro id="107" versions="7.39 7.60" description="UF6 OFF" />
-  <macro id="108" versions="7.39 7.60" description="UF7 OFF" />
-  <macro id="109" versions="7.39 7.60" description="UF1 Pulse" />
-  <macro id="110" versions="7.39 7.60" description="UF2 Pulse" />
-  <macro id="111" versions="7.39 7.60" description="UF3 Pulse" />
-  <macro id="112" versions="7.39 7.60" description="UF4 Pulse" />
-  <macro id="113" versions="7.39 7.60" description="UF5 Pulse" />
-  <macro id="114" versions="7.39 7.60" description="UF6 Pulse" />
-  <macro id="115" versions="7.39 7.60" description="UF7 Pulse" />
-  <macro id="116" versions="7.39 7.60" description="Say Time" />
-  <macro id="117" versions="7.39 7.60" description="Say Date" />
-  <macro id="118" versions="7.39 7.60" description="Link Port 1 to Port 2" />
-  <macro id="119" versions="7.39 7.60" description="Link Port 1 to Port 3" />
-  <macro id="120" versions="7.39 7.60" description="Link Port 2 to Port 3" />
-  <macro id="121" versions="7.39 7.60" description="Link All Ports" />
-  <macro id="122" versions="7.39 7.60" description="Unlink Port 1 from Port 2" />
-  <macro id="123" versions="7.39 7.60" description="Unlink Port 1 from Port 3" />
-  <macro id="124" versions="7.39 7.60" description="Unlink Port 2 from Port 3" />
-  <macro id="125" versions="7.39 7.60" description="UnLink All Ports" />
-  <macro id="126" versions="7.39 7.60" description="Play DVR Track 1" />
-  <macro id="127" versions="7.39 7.60" description="Play DVR Track 2" />
-  <macro id="128" versions="7.39 7.60" description="Play DVR Track 3" />
-  <macro id="129" versions="7.39 7.60" description="Play DVR Track 4" />
-  <macro id="130" versions="7.39 7.60" description="Play DVR Track 5" />
-  <macro id="131" versions="7.39 7.60" description="Play DVR Track 6" />
-  <macro id="132" versions="7.39 7.60" description="Play DVR Track 7" />
-  <macro id="133" versions="7.39 7.60" description="Play DVR Track 8" />
-  <macro id="134" versions="7.39 7.60" description="Play DVR Track 9" />
-  <macro id="135" versions="7.39 7.60" description="Play DVR Track 10" />
-  <macro id="136" versions="7.39 7.60" description="Play DVR Track 11" />
-  <macro id="137" versions="7.39 7.60" description="Play DVR Track 12" />
-  <macro id="138" versions="7.39 7.60" description="Play DVR Track 13" />
-  <macro id="139" versions="7.39 7.60" description="Play DVR Track 14" />
-  <macro id="140" versions="7.39 7.60" description="Play DVR Track 15" />
-  <macro id="141" versions="7.39 7.60" description="Play DVR Track 16" />
-  <macro id="142" versions="7.39 7.60" description="Play DVR Track 17" />
-  <macro id="143" versions="7.39 7.60" description="Play DVR Track 18" />
-  <macro id="144" versions="7.39 7.60" description="Play DVR Track 19" />
-  <macro id="145" versions="7.39 7.60" description="Play DVR Track 20" />
-  <macro id="146" versions="7.39 7.60" description="Auxiliary Audio 1 ON" />
-  <macro id="147" versions="7.39 7.60" description="Auxiliary Audio 2 ON" />
-  <macro id="148" versions="7.39 7.60" description="Auxiliary Audio 3 ON" />
-  <macro id="149" versions="7.39 7.60" description="Auxiliary Audio 1 OFF" />
-  <macro id="150" versions="7.39 7.60" description="Auxiliary Audio 2 OFF" />
-  <macro id="151" versions="7.39 7.60" description="Auxiliary Audio 3 OFF" />
-  <macro id="152" versions="7.39 7.60" description="Alarm 1 ON" />
-  <macro id="153" versions="7.39 7.60" description="Alarm 2 ON" />
-  <macro id="154" versions="7.39 7.60" description="Alarm 3 ON" />
-  <macro id="155" versions="7.39 7.60" description="Alarm 4 ON" />
-  <macro id="156" versions="7.39 7.60" description="Alarm 5 ON" />
-  <macro id="157" versions="7.39 7.60" description="Alarm 1 OFF" />
-  <macro id="158" versions="7.39 7.60" description="Alarm 2 OFF" />
-  <macro id="159" versions="7.39 7.60" description="Alarm 3 OFF" />
-  <macro id="160" versions="7.39 7.60" description="Alarm 4 OFF" />
-  <macro id="161" versions="7.39 7.60" description="Alarm 5 OFF" />
-  <macro id="162" versions="7.39 7.60" description="Speech Out Port 1" />
-  <macro id="163" versions="7.39 7.60" description="Speech Out Port 2" />
-  <macro id="164" versions="7.39 7.60" description="Speech Out Port 3" />
-  <macro id="165" versions="7.39 7.60" description="Speech Out Ports 1 and 2" />
-  <macro id="166" versions="7.39 7.60" description="Speech Out Ports 1 and 3" />
-  <macro id="167" versions="7.39 7.60" description="Speech Out Ports 2 and 3" />
-  <macro id="168" versions="7.39 7.60" description="Speech Out All Ports" />
-  <macro id="169" versions="7.39 7.60" description="DTMF Enable Port 1" />
-  <macro id="170" versions="7.39 7.60" description="DTMF Enable Port 2" />
-  <macro id="171" versions="7.39 7.60" description="DTMF Enable Port 3" />
-  <macro id="172" versions="7.39 7.60" description="DTMF Disable Port 1" />
-  <macro id="173" versions="7.39 7.60" description="DTMF Disable Port 2" />
-  <macro id="174" versions="7.39 7.60" description="DTMF Disable Port 3" />
-  <macro id="175" versions="7.39 7.60" description="DTMF Require CTCSS Port 1" />
-  <macro id="176" versions="7.39 7.60" description="DTMF Require CTCSS Port 2" />
-  <macro id="177" versions="7.39 7.60" description="DTMF Require CTCSS Port 3" />
-  <macro id="178" versions="7.39 7.60" description="DTMF Not Require CTCSS Port 1" />
-  <macro id="179" versions="7.39 7.60" description="DTMF Not Require CTCSS Port 2" />
-  <macro id="180" versions="7.39 7.60" description="DTMF Not Require CTCSS Port 3" />
-  <macro id="181" versions="7.39 7.60" description="Force Next Voice ID In Rotation On Port 1" />
-  <macro id="182" versions="7.39 7.60" description="Force Next Voice ID In Rotation On Port 2" />
-  <macro id="183" versions="7.39 7.60" description="Force Next Voice ID In Rotation On Port 3" />
-  <macro id="184" versions="7.39 7.60" description="Force Next CW ID In Rotation On Port 1" />
-  <macro id="185" versions="7.39 7.60" description="Force Next CW ID In Rotation On Port 2" />
-  <macro id="186" versions="7.39 7.60" description="Force Next CW ID In Rotation On Port 3" />
-  <macro id="187" versions="7.39 7.60" description="Play Message Macro 1" />
-  <macro id="188" versions="7.39 7.60" description="Play Message Macro 2" />
-  <macro id="189" versions="7.39 7.60" description="Play Message Macro 3" />
-  <macro id="190" versions="7.39 7.60" description="Play Message Macro 4" />
-  <macro id="191" versions="7.39 7.60" description="Play Message Macro 5" />
-  <macro id="192" versions="7.39 7.60" description="Play Message Macro 6" />
-  <macro id="193" versions="7.39 7.60" description="Play Message Macro 7" />
-  <macro id="194" versions="7.39 7.60" description="Play Message Macro 8" />
-  <macro id="195" versions="7.39 7.60" description="Play Message Macro 9" />
-  <macro id="196" versions="7.39 7.60" description="Play Message Macro 10" />
-  <macro id="197" versions="7.39 7.60" description="Play Message Macro 11" />
-  <macro id="198" versions="7.39 7.60" description="Play Message Macro 12" />
-  <macro id="199" versions="7.39 7.60" description="Play Message Macro 13" />
-  <macro id="200" versions="7.39 7.60" description="Play Message Macro 14" />
-  <macro id="201" versions="7.39 7.60" description="Play Message Macro 15" />
-  <macro id="202" versions="7.39 7.60" description="Play Message Macro 16" />
-  <macro id="203" versions="7.39 7.60" description="Play Message Macro 17" />
-  <macro id="204" versions="7.39 7.60" description="Play Message Macro 18" />
-  <macro id="205" versions="7.39 7.60" description="Play Message Macro 19" />
-  <macro id="206" versions="7.39 7.60" description="Play Message Macro 20" />
-  <macro id="207" versions="7.39 7.60" description="Play Message Macro 21" />
-  <macro id="208" versions="7.39 7.60" description="Play Message Macro 22" />
-  <macro id="209" versions="7.39 7.60" description="Play Message Macro 23" />
-  <macro id="210" versions="7.39 7.60" description="Play Message Macro 24" />
-  <macro id="211" versions="7.39 7.60" description="Play Message Macro 25" />
-  <macro id="212" versions="7.39 7.60" description="Play Message Macro 26" />
-  <macro id="213" versions="7.39 7.60" description="Play Message Macro 27" />
-  <macro id="214" versions="7.39 7.60" description="Play Message Macro 28" />
-  <macro id="215" versions="7.39 7.60" description="Play Message Macro 29" />
-  <macro id="216" versions="7.39 7.60" description="Play Message Macro 30" />
-  <macro id="217" versions="7.39 7.60" description="Play Message Macro 31" />
-  <macro id="218" versions="7.39 7.60" description="Play Message Macro 32" />
-  <macro id="219" versions="7.39 7.60" description="Play Message Macro 33" />
-  <macro id="220" versions="7.39 7.60" description="Play Message Macro 34" />
-  <macro id="221" versions="7.39 7.60" description="Play Message Macro 35" />
-  <macro id="222" versions="7.39 7.60" description="Play Message Macro 36" />
-  <macro id="223" versions="7.39 7.60" description="Play Message Macro 37" />
-  <macro id="224" versions="7.39 7.60" description="Play Message Macro 38" />
-  <macro id="225" versions="7.39 7.60" description="Play Message Macro 39" />
-  <macro id="226" versions="7.39 7.60" description="Play Message Macro 40" />
-  <macro id="227" versions="7.39 7.60" description="Good Morning/Afternoon/Evening Runtime Variable" />
-  <macro id="228" versions="7.39 7.60" description="Macro Priority High" />
-  <macro id="229" versions="7.39 7.60" description="Macro Priority Low" />
-  <macro id="230" versions="7.39 7.60" description="Enable Kerchunk Filter Port 1" />
-  <macro id="231" versions="7.39 7.60" description="Enable Kerchunk Filter Port 2" />
-  <macro id="232" versions="7.39 7.60" description="Enable Kerchunk Filter Port 3" />
-  <macro id="233" versions="7.39 7.60" description="Disable Kerchunk Filter Port 1" />
-  <macro id="234" versions="7.39 7.60" description="Disable Kerchunk Filter Port 2" />
-  <macro id="235" versions="7.39 7.60" description="Disable Kerchunk Filter Port 3" />
-  <macro id="236" versions="7.39 7.60" description="Enable Receiver Port 1" />
-  <macro id="237" versions="7.39 7.60" description="Enable Receiver Port 2" />
-  <macro id="238" versions="7.39 7.60" description="Enable Receiver Port 3" />
-  <macro id="239" versions="7.39 7.60" description="Disable Receiver Port 1" />
-  <macro id="240" versions="7.39 7.60" description="Disable Receiver Port 2" />
-  <macro id="241" versions="7.39 7.60" description="Disable Receiver Port 3" />
-  <macro id="242" versions="7.39 7.60" description="Port 1 Speech ID Override ON" />
-  <macro id="243" versions="7.39 7.60" description="Port 2 Speech ID Override ON" />
-  <macro id="244" versions="7.39 7.60" description="Port 3 Speech ID Override ON" />
-  <macro id="245" versions="7.39 7.60" description="Port 1 Speech ID Override OFF" />
-  <macro id="246" versions="7.39 7.60" description="Port 2 Speech ID Override OFF" />
-  <macro id="247" versions="7.39 7.60" description="Port 3 Speech ID Override OFF" />
-  <macro id="248" versions="7.39 7.60" description="All Courtesy Tones OFF Port 1" />
-  <macro id="249" versions="7.39 7.60" description="All Courtesy Tones OFF Port 2" />
-  <macro id="250" versions="7.39 7.60" description="All Courtesy Tones OFF Port 3" />
-  <macro id="251" versions="7.39 7.60" description="Force Audio To Entered Port" />
-  <macro id="252" versions="7.39 7.60" description="Stop ID/Disable Timeout Timer Port 1" />
-  <macro id="253" versions="7.39 7.60" description="Stop ID/Disable Timeout Timer Port 2" />
-  <macro id="254" versions="7.39 7.60" description="Stop ID/Disable Timeout Timer Port 3" />
-  <macro id="256" versions="7.39 7.60" description="Resume ID/Enable Timeout Timer Port 1" />
-  <macro id="257" versions="7.39 7.60" description="Resume ID/Enable Timeout Timer Port 2" />
-  <macro id="258" versions="7.39 7.60" description="Resume ID/Enable Timeout Timer Port 3" />
-  <macro id="259" versions="7.39 7.60" description="Send DTMF Memory 1" />
-  <macro id="260" versions="7.39 7.60" description="Send DTMF Memory 2" />
-  <macro id="261" versions="7.39 7.60" description="Send DTMF Memory 3" />
-  <macro id="262" versions="7.39 7.60" description="Send DTMF Memory 4" />
-  <macro id="263" versions="7.39 7.60" description="Send DTMF Memory 5" />
-  <macro id="264" versions="7.39 7.60" description="Send DTMF Memory 6" />
-  <macro id="265" versions="7.39 7.60" description="Send DTMF Memory 7" />
-  <macro id="266" versions="7.39 7.60" description="Send DTMF Memory 8" />
-  <macro id="267" versions="7.39 7.60" description="Send DTMF Memory 9" />
-  <macro id="268" versions="7.39 7.60" description="Send DTMF Memory 10" />
-  <macro id="269" versions="7.39 7.60" description="Send DTMF Memory 11" />
-  <macro id="270" versions="7.39 7.60" description="Send DTMF Memory 12" />
-  <macro id="271" versions="7.39 7.60" description="Send DTMF Memory 13" />
-  <macro id="272" versions="7.39 7.60" description="Send DTMF Memory 14" />
-  <macro id="273" versions="7.39 7.60" description="Send DTMF Memory 15" />
-  <macro id="274" versions="7.39 7.60" description="Send DTMF Memory 16" />
-  <macro id="275" versions="7.39 7.60" description="Send DTMF Memory 17" />
-  <macro id="276" versions="7.39 7.60" description="Send DTMF Memory 18" />
-  <macro id="277" versions="7.39 7.60" description="Send DTMF Memory 19" />
-  <macro id="278" versions="7.39 7.60" description="Send DTMF Memory 20" />
-  <macro id="279" versions="7.39 7.60" description="Clear All Meter Hi/Low Trippoints" />
-  <macro id="280" versions="7.39 7.60" description="Clear Meter 1 Hi/Low Trippoint" />
-  <macro id="281" versions="7.39 7.60" description="Clear Meter 2 Hi/Low Trippoint" />
-  <macro id="282" versions="7.39 7.60" description="Clear Meter 3 Hi/Low Trippoint" />
-  <macro id="283" versions="7.39 7.60" description="Clear Meter 4 Hi/Low Trippoint" />
-  <macro id="284" versions="7.39 7.60" description="Clear Meter 5 Hi/Low Trippoint" />
-  <macro id="285" versions="7.39 7.60" description="Clear Meter 6 Hi/Low Trippoint" />
-  <macro id="286" versions="7.39 7.60" description="Clear Meter 7 Hi/Low Trippoint" />
-  <macro id="287" versions="7.39 7.60" description="Clear Meter 8 Hi/Low Trippoint" />
-  <macro id="288" versions="7.39 7.60" description="Enable Meter 1 Alarm" />
-  <macro id="289" versions="7.39 7.60" description="Enable Meter 2 Alarm" />
-  <macro id="290" versions="7.39 7.60" description="Enable Meter 3 Alarm" />
-  <macro id="291" versions="7.39 7.60" description="Enable Meter 4 Alarm" />
-  <macro id="292" versions="7.39 7.60" description="Enable Meter 5 Alarm" />
-  <macro id="293" versions="7.39 7.60" description="Enable Meter 6 Alarm" />
-  <macro id="294" versions="7.39 7.60" description="Enable Meter 7 Alarm" />
-  <macro id="295" versions="7.39 7.60" description="Enable Meter 8 Alarm" />
-  <macro id="296" versions="7.39 7.60" description="Disable Meter 1 Alarm" />
-  <macro id="297" versions="7.39 7.60" description="Disable Meter 2 Alarm" />
-  <macro id="298" versions="7.39 7.60" description="Disable Meter 3 Alarm" />
-  <macro id="299" versions="7.39 7.60" description="Disable Meter 4 Alarm" />
-  <macro id="300" versions="7.39 7.60" description="Disable Meter 5 Alarm" />
-  <macro id="301" versions="7.39 7.60" description="Disable Meter 6 Alarm" />
-  <macro id="302" versions="7.39 7.60" description="Disable Meter 7 Alarm" />
-  <macro id="303" versions="7.39 7.60" description="Disable Meter 8 Alarm" />
-  <macro id="304" versions="7.39 7.60" description="CTCSS Encode Force OFF" />
-  <macro id="305" versions="7.39 7.60" description="CTCSS Encode to Programmed Value" />
-  <macro id="306" versions="7.39 7.60" description="Bump Clock By Correction Factor" />
-  <macro id="307" versions="7.39 7.60" description="Say year as part of date" />
-  <macro id="308" versions="7.39 7.60" description="Don't say year as part of date" />
-  <macro id="309" versions="7.39 7.60" description="Port 1 Tail Message OFF" />
-  <macro id="310" versions="7.39 7.60" description="Port 2 Tail Message OFF" />
-  <macro id="311" versions="7.39 7.60" description="Port 3 Tail Message OFF" />
-  <macro id="312" versions="7.39 7.60" description="Port 1 Tail Message 1" />
-  <macro id="313" versions="7.39 7.60" description="Port 2 Tail Message 1" />
-  <macro id="314" versions="7.39 7.60" description="Port 3 Tail Message 1" />
-  <macro id="315" versions="7.39 7.60" description="Port 1 Tail Message 2" />
-  <macro id="316" versions="7.39 7.60" description="Port 2 Tail Message 2" />
-  <macro id="317" versions="7.39 7.60" description="Port 3 Tail Message 2" />
-  <macro id="318" versions="7.39 7.60" description="Port 1 Tail Message 3" />
-  <macro id="319" versions="7.39 7.60" description="Port 2 Tail Message 3" />
-  <macro id="320" versions="7.39 7.60" description="Port 3 Tail Message 3" />
-  <macro id="321" versions="7.39 7.60" description="Remote Base Memory 1" />
-  <macro id="322" versions="7.39 7.60" description="Remote Base Memory 2" />
-  <macro id="323" versions="7.39 7.60" description="Remote Base Memory 3" />
-  <macro id="324" versions="7.39 7.60" description="Remote Base Memory 4" />
-  <macro id="325" versions="7.39 7.60" description="Remote Base Memory 5" />
-  <macro id="326" versions="7.39 7.60" description="Remote Base Memory 6" />
-  <macro id="327" versions="7.39 7.60" description="Remote Base Memory 7" />
-  <macro id="328" versions="7.39 7.60" description="Remote Base Memory 8" />
-  <macro id="329" versions="7.39 7.60" description="Remote Base Memory 9" />
-  <macro id="330" versions="7.39 7.60" description="Remote Base Memory 10" />
-  <macro id="331" versions="7.39 7.60" description="Port 1 Zero Hang Time Select" />
-  <macro id="332" versions="7.39 7.60" description="Port 2 Zero Hang Time Select" />
-  <macro id="333" versions="7.39 7.60" description="Port 3 Zero Hang Time Select" />
-  <macro id="336" versions="7.39 7.60" description="Dial 911" />
-  <macro id="337" versions="7.39 7.60" description="Allow Autopatch from programmed Ports" />
-  <macro id="338" versions="7.39 7.60" description="Disable Autopatch" />
-  <macro id="339" versions="7.39 7.60" description="Enable Speech ID's Port 1" />
-  <macro id="340" versions="7.39 7.60" description="Enable Speech ID's Port 2" />
-  <macro id="341" versions="7.39 7.60" description="Enable Speech ID's Port 3" />
-  <macro id="342" versions="7.39 7.60" description="Disable Speech ID's Port 1" />
-  <macro id="343" versions="7.39 7.60" description="Disable Speech ID's Port 2" />
-  <macro id="344" versions="7.39 7.60" description="Disable Speech ID's Port 3" />
-  <macro id="345" versions="7.39 7.60" description="User DVR Record test, erase after auto playback" />
-  <macro id="346" versions="7.39 7.60" description="User DVR Record test, don't erase after auto playback" />
-  <macro id="347" versions="7.39 7.60" description="Start General Timer 1" />
-  <macro id="348" versions="7.39 7.60" description="Start General Timer 2" />
-  <macro id="349" versions="7.39 7.60" description="Start General Timer 3" />
-  <macro id="350" versions="7.39 7.60" description="Stop General Timer 1" />
-  <macro id="351" versions="7.39 7.60" description="Stop General Timer 2" />
-  <macro id="352" versions="7.39 7.60" description="Stop General Timer 3" />
-  <macro id="353" versions="7.39 7.60" description="Remote Base Power Select 1" />
-  <macro id="354" versions="7.39 7.60" description="Remote Base Power Select 2" />
-  <macro id="355" versions="7.39 7.60" description="Remote Base Power Select 3" />
-  <macro id="356" versions="7.39 7.60" description="Guest Macros Enabled" />
-  <macro id="357" versions="7.39 7.60" description="Guest Macros Disabled" />
-  <macro id="358" versions="7.39 7.60" description="Receiver 1 Macros On" />
-  <macro id="359" versions="7.39 7.60" description="Receiver 2 Macros On" />
-  <macro id="360" versions="7.39 7.60" description="Receiver 3 Macros On" />
-  <macro id="361" versions="7.39 7.60" description="Receiver 1 Macros Off" />
-  <macro id="362" versions="7.39 7.60" description="Receiver 2 Macros Off" />
-  <macro id="363" versions="7.39 7.60" description="Receiver 3 Macros Off" />
-  <macro id="364" versions="7.39 7.60" description="Extended Logic 1 Output ON" />
-  <macro id="365" versions="7.39 7.60" description="Extended Logic 2 Output ON" />
-  <macro id="366" versions="7.39 7.60" description="Extended Logic 3 Output ON" />
-  <macro id="367" versions="7.39 7.60" description="Extended Logic 4 Output ON" />
-  <macro id="368" versions="7.39 7.60" description="Extended Logic 5 Output ON" />
-  <macro id="369" versions="7.39 7.60" description="Extended Logic 6 Output ON" />
-  <macro id="370" versions="7.39 7.60" description="Extended Logic 7 Output ON" />
-  <macro id="371" versions="7.39 7.60" description="Extended Logic 8 Output ON" />
-  <macro id="372" versions="7.39 7.60" description="Extended Logic 9 Output ON" />
-  <macro id="373" versions="7.39 7.60" description="Extended Logic 10 Output ON" />
-  <macro id="374" versions="7.39 7.60" description="Extended Logic 11 Output ON" />
-  <macro id="375" versions="7.39 7.60" description="Extended Logic 12 Output ON" />
-  <macro id="376" versions="7.39 7.60" description="Extended Logic 13 Output ON" />
-  <macro id="377" versions="7.39 7.60" description="Extended Logic 14 Output ON" />
-  <macro id="378" versions="7.39 7.60" description="Extended Logic 15 Output ON" />
-  <macro id="379" versions="7.39 7.60" description="Extended Logic 16 Output ON" />
-  <macro id="380" versions="7.39 7.60" description="Extended Logic 17 Output ON" />
-  <macro id="381" versions="7.39 7.60" description="Extended Logic 18 Output ON" />
-  <macro id="382" versions="7.39 7.60" description="Extended Logic 19 Output ON" />
-  <macro id="383" versions="7.39 7.60" description="Extended Logic 20 Output ON" />
-  <macro id="384" versions="7.39 7.60" description="Extended Logic 21 Output ON" />
-  <macro id="385" versions="7.39 7.60" description="Extended Logic 22 Output ON" />
-  <macro id="386" versions="7.39 7.60" description="Extended Logic 23 Output ON" />
-  <macro id="387" versions="7.39 7.60" description="Extended Logic 24 Output ON" />
-  <macro id="388" versions="7.39 7.60" description="Extended Logic 25 Output ON" />
-  <macro id="389" versions="7.39 7.60" description="Extended Logic 26 Output ON" />
-  <macro id="390" versions="7.39 7.60" description="Extended Logic 27 Output ON" />
-  <macro id="391" versions="7.39 7.60" description="Extended Logic 28 Output ON" />
-  <macro id="392" versions="7.39 7.60" description="Extended Logic 29 Output ON" />
-  <macro id="393" versions="7.39 7.60" description="Extended Logic 30 Output ON" />
-  <macro id="394" versions="7.39 7.60" description="Extended Logic 31 Output ON" />
-  <macro id="395" versions="7.39 7.60" description="Extended Logic 32 Output ON" />
-  <macro id="396" versions="7.39 7.60" description="Extended Logic 1 Output Pulse" />
-  <macro id="397" versions="7.39 7.60" description="Extended Logic 2 Output Pulse" />
-  <macro id="398" versions="7.39 7.60" description="Extended Logic 3 Output Pulse" />
-  <macro id="399" versions="7.39 7.60" description="Extended Logic 4 Output Pulse" />
-  <macro id="400" versions="7.39 7.60" description="Extended Logic 5 Output Pulse" />
-  <macro id="401" versions="7.39 7.60" description="Extended Logic 6 Output Pulse" />
-  <macro id="402" versions="7.39 7.60" description="Extended Logic 7 Output Pulse" />
-  <macro id="403" versions="7.39 7.60" description="Extended Logic 8 Output Pulse" />
-  <macro id="404" versions="7.39 7.60" description="Extended Logic 9 Output Pulse" />
-  <macro id="405" versions="7.39 7.60" description="Extended Logic 10 Output Pulse" />
-  <macro id="406" versions="7.39 7.60" description="Extended Logic 11 Output Pulse" />
-  <macro id="407" versions="7.39 7.60" description="Extended Logic 12 Output Pulse" />
-  <macro id="408" versions="7.39 7.60" description="Extended Logic 13 Output Pulse" />
-  <macro id="409" versions="7.39 7.60" description="Extended Logic 14 Output Pulse" />
-  <macro id="410" versions="7.39 7.60" description="Extended Logic 15 Output Pulse" />
-  <macro id="411" versions="7.39 7.60" description="Extended Logic 16 Output Pulse" />
-  <macro id="412" versions="7.39 7.60" description="Extended Logic 17 Output Pulse" />
-  <macro id="413" versions="7.39 7.60" description="Extended Logic 18 Output Pulse" />
-  <macro id="414" versions="7.39 7.60" description="Extended Logic 19 Output Pulse" />
-  <macro id="415" versions="7.39 7.60" description="Extended Logic 20 Output Pulse" />
-  <macro id="416" versions="7.39 7.60" description="Extended Logic 21 Output Pulse" />
-  <macro id="417" versions="7.39 7.60" description="Extended Logic 22 Output Pulse" />
-  <macro id="418" versions="7.39 7.60" description="Extended Logic 23 Output Pulse" />
-  <macro id="419" versions="7.39 7.60" description="Extended Logic 24 Output Pulse" />
-  <macro id="420" versions="7.39 7.60" description="Extended Logic 25 Output Pulse" />
-  <macro id="421" versions="7.39 7.60" description="Extended Logic 26 Output Pulse" />
-  <macro id="422" versions="7.39 7.60" description="Extended Logic 27 Output Pulse" />
-  <macro id="423" versions="7.39 7.60" description="Extended Logic 28 Output Pulse" />
-  <macro id="424" versions="7.39 7.60" description="Extended Logic 29 Output Pulse" />
-  <macro id="425" versions="7.39 7.60" description="Extended Logic 30 Output Pulse" />
-  <macro id="426" versions="7.39 7.60" description="Extended Logic 31 Output Pulse" />
-  <macro id="427" versions="7.39 7.60" description="Extended Logic 32 Output Pulse" />
-  <macro id="428" versions="7.39 7.60" description="Extended Logic 1 Output OFF" />
-  <macro id="429" versions="7.39 7.60" description="Extended Logic 2 Output OFF" />
-  <macro id="430" versions="7.39 7.60" description="Extended Logic 3 Output OFF" />
-  <macro id="431" versions="7.39 7.60" description="Extended Logic 4 Output OFF" />
-  <macro id="432" versions="7.39 7.60" description="Extended Logic 5 Output OFF" />
-  <macro id="433" versions="7.39 7.60" description="Extended Logic 6 Output OFF" />
-  <macro id="434" versions="7.39 7.60" description="Extended Logic 7 Output OFF" />
-  <macro id="435" versions="7.39 7.60" description="Extended Logic 8 Output OFF" />
-  <macro id="436" versions="7.39 7.60" description="Extended Logic 9 Output OFF" />
-  <macro id="437" versions="7.39 7.60" description="Extended Logic 10 Output OFF" />
-  <macro id="438" versions="7.39 7.60" description="Extended Logic 11 Output OFF" />
-  <macro id="439" versions="7.39 7.60" description="Extended Logic 12 Output OFF" />
-  <macro id="440" versions="7.39 7.60" description="Extended Logic 13 Output OFF" />
-  <macro id="441" versions="7.39 7.60" description="Extended Logic 14 Output OFF" />
-  <macro id="442" versions="7.39 7.60" description="Extended Logic 15 Output OFF" />
-  <macro id="443" versions="7.39 7.60" description="Extended Logic 16 Output OFF" />
-  <macro id="444" versions="7.39 7.60" description="Extended Logic 17 Output OFF" />
-  <macro id="445" versions="7.39 7.60" description="Extended Logic 18 Output OFF" />
-  <macro id="446" versions="7.39 7.60" description="Extended Logic 19 Output OFF" />
-  <macro id="447" versions="7.39 7.60" description="Extended Logic 20 Output OFF" />
-  <macro id="448" versions="7.39 7.60" description="Extended Logic 21 Output OFF" />
-  <macro id="449" versions="7.39 7.60" description="Extended Logic 22 Output OFF" />
-  <macro id="450" versions="7.39 7.60" description="Extended Logic 23 Output OFF" />
-  <macro id="451" versions="7.39 7.60" description="Extended Logic 24 Output OFF" />
-  <macro id="452" versions="7.39 7.60" description="Extended Logic 25 Output OFF" />
-  <macro id="453" versions="7.39 7.60" description="Extended Logic 26 Output OFF" />
-  <macro id="454" versions="7.39 7.60" description="Extended Logic 27 Output OFF" />
-  <macro id="455" versions="7.39 7.60" description="Extended Logic 28 Output OFF" />
-  <macro id="456" versions="7.39 7.60" description="Extended Logic 29 Output OFF" />
-  <macro id="457" versions="7.39 7.60" description="Extended Logic 30 Output OFF" />
-  <macro id="458" versions="7.39 7.60" description="Extended Logic 31 Output OFF" />
-  <macro id="459" versions="7.39 7.60" description="Extended Logic 32 Output OFF" />
-  <macro id="460" versions="7.39 7.60" description="Play Message Macro 41" />
-  <macro id="461" versions="7.39 7.60" description="Play Message Macro 42" />
-  <macro id="462" versions="7.39 7.60" description="Play Message Macro 43" />
-  <macro id="463" versions="7.39 7.60" description="Play Message Macro 44" />
-  <macro id="464" versions="7.39 7.60" description="Play Message Macro 45" />
-  <macro id="465" versions="7.39 7.60" description="Play Message Macro 46" />
-  <macro id="466" versions="7.39 7.60" description="Play Message Macro 47" />
-  <macro id="467" versions="7.39 7.60" description="Play Message Macro 48" />
-  <macro id="468" versions="7.39 7.60" description="Play Message Macro 49" />
-  <macro id="469" versions="7.39 7.60" description="Play Message Macro 50" />
-  <macro id="470" versions="7.39 7.60" description="Play Message Macro 51" />
-  <macro id="471" versions="7.39 7.60" description="Play Message Macro 52" />
-  <macro id="472" versions="7.39 7.60" description="Play Message Macro 53" />
-  <macro id="473" versions="7.39 7.60" description="Play Message Macro 54" />
-  <macro id="474" versions="7.39 7.60" description="Play Message Macro 55" />
-  <macro id="475" versions="7.39 7.60" description="Play Message Macro 56" />
-  <macro id="476" versions="7.39 7.60" description="Play Message Macro 57" />
-  <macro id="477" versions="7.39 7.60" description="Play Message Macro 58" />
-  <macro id="478" versions="7.39 7.60" description="Play Message Macro 59" />
-  <macro id="479" versions="7.39 7.60" description="Play Message Macro 60" />
-  <macro id="480" versions="7.39 7.60" description="Play Message Macro 61" />
-  <macro id="481" versions="7.39 7.60" description="Play Message Macro 62" />
-  <macro id="482" versions="7.39 7.60" description="Play Message Macro 63" />
-  <macro id="483" versions="7.39 7.60" description="Play Message Macro 64" />
-  <macro id="484" versions="7.39 7.60" description="Play Message Macro 65" />
-  <macro id="485" versions="7.39 7.60" description="Play Message Macro 66" />
-  <macro id="486" versions="7.39 7.60" description="Play Message Macro 67" />
-  <macro id="487" versions="7.39 7.60" description="Play Message Macro 68" />
-  <macro id="488" versions="7.39 7.60" description="Play Message Macro 69" />
-  <macro id="489" versions="7.39 7.60" description="Play Message Macro 70" />
-  <macro id="490" versions="7.39 7.60" description="Remote Base Memory 11" />
-  <macro id="491" versions="7.39 7.60" description="Remote Base Memory 12" />
-  <macro id="492" versions="7.39 7.60" description="Remote Base Memory 13" />
-  <macro id="493" versions="7.39 7.60" description="Remote Base Memory 14" />
-  <macro id="494" versions="7.39 7.60" description="Remote Base Memory 15" />
-  <macro id="495" versions="7.39 7.60" description="Remote Base Memory 16" />
-  <macro id="496" versions="7.39 7.60" description="Remote Base Memory 17" />
-  <macro id="497" versions="7.39 7.60" description="Remote Base Memory 18" />
-  <macro id="498" versions="7.39 7.60" description="Remote Base Memory 19" />
-  <macro id="499" versions="7.39 7.60" description="Remote Base Memory 20" />
-  <macro id="500" versions="7.39 7.60" description="Remote Base Memory 21" />
-  <macro id="501" versions="7.39 7.60" description="Remote Base Memory 22" />
-  <macro id="502" versions="7.39 7.60" description="Remote Base Memory 23" />
-  <macro id="503" versions="7.39 7.60" description="Remote Base Memory 24" />
-  <macro id="504" versions="7.39 7.60" description="Remote Base Memory 25" />
-  <macro id="505" versions="7.39 7.60" description="Remote Base Memory 26" />
-  <macro id="506" versions="7.39 7.60" description="Remote Base Memory 27" />
-  <macro id="507" versions="7.39 7.60" description="Remote Base Memory 28" />
-  <macro id="508" versions="7.39 7.60" description="Remote Base Memory 29" />
-  <macro id="509" versions="7.39 7.60" description="Remote Base Memory 30" />
-  <macro id="511" versions="7.39 7.60" description="Remote Base Memory 31" />
-  <macro id="512" versions="7.39 7.60" description="Remote Base Memory 32" />
-  <macro id="513" versions="7.39 7.60" description="Remote Base Memory 33" />
-  <macro id="514" versions="7.39 7.60" description="Remote Base Memory 34" />
-  <macro id="515" versions="7.39 7.60" description="Remote Base Memory 35" />
-  <macro id="516" versions="7.39 7.60" description="Remote Base Memory 36" />
-  <macro id="517" versions="7.39 7.60" description="Remote Base Memory 37" />
-  <macro id="518" versions="7.39 7.60" description="Remote Base Memory 38" />
-  <macro id="519" versions="7.39 7.60" description="Remote Base Memory 39" />
-  <macro id="520" versions="7.39 7.60" description="Remote Base Memory 40" />
-  <macro id="521" versions="7.39 7.60" description="Send DTMF Memory 21" />
-  <macro id="522" versions="7.39 7.60" description="Send DTMF Memory 22" />
-  <macro id="523" versions="7.39 7.60" description="Send DTMF Memory 23" />
-  <macro id="524" versions="7.39 7.60" description="Send DTMF Memory 24" />
-  <macro id="525" versions="7.39 7.60" description="Send DTMF Memory 25" />
-  <macro id="526" versions="7.39 7.60" description="Send DTMF Memory 26" />
-  <macro id="527" versions="7.39 7.60" description="Send DTMF Memory 27" />
-  <macro id="528" versions="7.39 7.60" description="Send DTMF Memory 28" />
-  <macro id="529" versions="7.39 7.60" description="Send DTMF Memory 29" />
-  <macro id="530" versions="7.39 7.60" description="Send DTMF Memory 30" />
-  <macro id="531" versions="7.39 7.60" description="Send DTMF Memory 31" />
-  <macro id="532" versions="7.39 7.60" description="Send DTMF Memory 32" />
-  <macro id="533" versions="7.39 7.60" description="Send DTMF Memory 33" />
-  <macro id="534" versions="7.39 7.60" description="Send DTMF Memory 34" />
-  <macro id="535" versions="7.39 7.60" description="Send DTMF Memory 35" />
-  <macro id="536" versions="7.39 7.60" description="Send DTMF Memory 36" />
-  <macro id="537" versions="7.39 7.60" description="Send DTMF Memory 37" />
-  <macro id="538" versions="7.39 7.60" description="Send DTMF Memory 38" />
-  <macro id="539" versions="7.39 7.60" description="Send DTMF Memory 39" />
-  <macro id="540" versions="7.39 7.60" description="Send DTMF Memory 40" />
-  <macro id="541" versions="7.39 7.60" description="Send DTMF Memory 41" />
-  <macro id="542" versions="7.39 7.60" description="Send DTMF Memory 42" />
-  <macro id="543" versions="7.39 7.60" description="Send DTMF Memory 43" />
-  <macro id="544" versions="7.39 7.60" description="Send DTMF Memory 44" />
-  <macro id="545" versions="7.39 7.60" description="Send DTMF Memory 45" />
-  <macro id="546" versions="7.39 7.60" description="Send DTMF Memory 46" />
-  <macro id="547" versions="7.39 7.60" description="Send DTMF Memory 47" />
-  <macro id="548" versions="7.39 7.60" description="Send DTMF Memory 48" />
-  <macro id="549" versions="7.39 7.60" description="Send DTMF Memory 49" />
-  <macro id="550" versions="7.39 7.60" description="Send DTMF Memory 50" />
-  <macro id="551" versions="7.39 7.60" description="Get RTC Time and Date" />
-  <macro id="552" versions="7.39 7.60" description="CTCSS During ID ON" />
-  <macro id="553" versions="7.39 7.60" description="CTCSS During ID OFF" />
-  <macro id="554" versions="7.39 7.60" description="Port 1 Time Transmitter Active since Last Reset" />
-  <macro id="555" versions="7.39 7.60" description="Port 2 Time Transmitter Active since Last Reset" />
-  <macro id="556" versions="7.39 7.60" description="Port 3 Time Transmitter Active since Last Reset" />
-  <macro id="557" versions="7.39 7.60" description="Reset Port 1 Transmitter Activity Timer" />
-  <macro id="558" versions="7.39 7.60" description="Reset Port 2 Transmitter Activity Timer" />
-  <macro id="559" versions="7.39 7.60" description="Reset Port 3 Transmitter Activity Timer" />
-  <macro id="560" versions="7.39 7.60" description="Give RSSI Report" />
-  <macro id="561" versions="7.39 7.60" description="Restart Controller" />
-  <macro id="562" versions="7.39 7.60" description="Readback Number of Keyups Port 1" />
-  <macro id="563" versions="7.39 7.60" description="Readback Number of Keyups Port 2" />
-  <macro id="564" versions="7.39 7.60" description="Readback Number of Keyups Port 3" />
-  <macro id="565" versions="7.39 7.60" description="Reset Keyup Counter Port 1" />
-  <macro id="566" versions="7.39 7.60" description="Reset Keyup Counter Port 2" />
-  <macro id="567" versions="7.39 7.60" description="Reset Keyup Counter Port 3" />
-  <macro id="570" versions="7.39 7.60" description="Readback A/D Channel 1 Stored Low" />
-  <macro id="571" versions="7.39 7.60" description="Readback A/D Channel 2 Stored Low" />
-  <macro id="572" versions="7.39 7.60" description="Readback A/D Channel 3 Stored Low" />
-  <macro id="573" versions="7.39 7.60" description="Readback A/D Channel 4 Stored Low" />
-  <macro id="574" versions="7.39 7.60" description="Readback A/D Channel 5 Stored Low" />
-  <macro id="575" versions="7.39 7.60" description="Readback A/D Channel 6 Stored Low" />
-  <macro id="576" versions="7.39 7.60" description="Readback A/D Channel 7 Stored Low" />
-  <macro id="577" versions="7.39 7.60" description="Readback A/D Channel 8 Stored Low" />
-  <macro id="578" versions="7.39 7.60" description="Readback A/D Channel 1 Stored High" />
-  <macro id="579" versions="7.39 7.60" description="Readback A/D Channel 2 Stored High" />
-  <macro id="580" versions="7.39 7.60" description="Readback A/D Channel 3 Stored High" />
-  <macro id="581" versions="7.39 7.60" description="Readback A/D Channel 4 Stored High" />
-  <macro id="582" versions="7.39 7.60" description="Readback A/D Channel 5 Stored High" />
-  <macro id="583" versions="7.39 7.60" description="Readback A/D Channel 6 Stored High" />
-  <macro id="584" versions="7.39 7.60" description="Readback A/D Channel 7 Stored High" />
-  <macro id="585" versions="7.39 7.60" description="Readback A/D Channel 8 Stored High" />
-  <macro id="586" versions="7.39 7.60" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
-  <macro id="587" versions="7.39 7.60" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
-  <macro id="588" versions="7.39 7.60" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
-  <macro id="589" versions="7.39 7.60" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
-  <macro id="590" versions="7.39 7.60" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
-  <macro id="591" versions="7.39 7.60" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
-  <macro id="592" versions="7.39 7.60" description="Current wind speed and direction" />
-  <macro id="593" versions="7.39 7.60" description="Current Outdoor temperature" />
-  <macro id="594" versions="7.39 7.60" description="Indoor humidity" />
-  <macro id="595" versions="7.39 7.60" description="Outdoor humidity" />
-  <macro id="596" versions="7.39 7.60" description="Wind Speed high and direction (since Midnight)" />
-  <macro id="597" versions="7.39 7.60" description="Outdoor Temp High (since Midnight)" />
-  <macro id="598" versions="7.39 7.60" description="Outdoor Temp Low (since Midnight)" />
-  <macro id="605" versions="7.39 7.60" description="Speak Current Remote Base Freq and Offset" />
-  <macro id="606" versions="7.39 7.60" description="Start General Timer 4" />
-  <macro id="607" versions="7.39 7.60" description="Start General Timer 5" />
-  <macro id="608" versions="7.39 7.60" description="Start General Timer 6" />
-  <macro id="609" versions="7.39 7.60" description="Stop General Timer 4" />
-  <macro id="610" versions="7.39 7.60" description="Stop General Timer 5" />
-  <macro id="611" versions="7.39 7.60" description="Stop General Timer 6" />
-  <macro id="612" versions="7.39 7.60" description="Disable Port 1 Inactivity Timer" />
-  <macro id="613" versions="7.39 7.60" description="Disable Port 2 Inactivity Timer" />
-  <macro id="614" versions="7.39 7.60" description="Disable Port 3 Inactivity Timer" />
-  <macro id="615" versions="7.39 7.60" description="Enable Port 1 Inactivity Timer to Programmed Value" />
-  <macro id="616" versions="7.39 7.60" description="Enable Port 2 Inactivity Timer to Programmed Value" />
-  <macro id="617" versions="7.39 7.60" description="Enable Port 3 Inactivity Timer to Programmed Value" />
-  <macro id="618" versions="7.39 7.60" description="1 Second Execution Delay" />
-  <macro id="619" versions="7.39 7.60" description="2 Second Execution Delay" />
-  <macro id="620" versions="7.39 7.60" description="4 Second Execution Delay" />
-  <macro id="621" versions="7.39 7.60" description="Port 1 Hangtimer 1 Select" />
-  <macro id="622" versions="7.39 7.60" description="Port 1 Hangtimer 2 Select" />
-  <macro id="623" versions="7.39 7.60" description="Port 1 Hangtimer 3 Select" />
-  <macro id="624" versions="7.39 7.60" description="Port 2 Hangtimer 1 Select" />
-  <macro id="625" versions="7.39 7.60" description="Port 2 Hangtimer 2 Select" />
-  <macro id="626" versions="7.39 7.60" description="Port 2 Hangtimer 3 Select" />
-  <macro id="627" versions="7.39 7.60" description="Port 3 Hangtimer 1 Select" />
-  <macro id="628" versions="7.39 7.60" description="Port 3 Hangtimer 2 Select" />
-  <macro id="629" versions="7.39 7.60" description="Port 3 Hangtimer 3 Select" />
-  <macro id="630" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 1" />
-  <macro id="631" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 2" />
-  <macro id="632" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 3" />
-  <macro id="633" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 4" />
-  <macro id="634" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 5" />
-  <macro id="635" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 6" />
-  <macro id="636" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 7" />
-  <macro id="637" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 8" />
-  <macro id="638" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 9" />
-  <macro id="639" versions="7.39 7.60" description="Port 1 Next Courtesy Tone 10" />
-  <macro id="640" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 1" />
-  <macro id="641" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 2" />
-  <macro id="642" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 3" />
-  <macro id="643" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 4" />
-  <macro id="644" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 5" />
-  <macro id="645" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 6" />
-  <macro id="646" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 7" />
-  <macro id="647" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 8" />
-  <macro id="648" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 9" />
-  <macro id="649" versions="7.39 7.60" description="Port 1 Following Courtesy Tone 10" />
-  <macro id="650" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="651" versions="7.39 7.60" description="Port 2 Next Courtesy Tone1" />
-  <macro id="652" versions="7.39 7.60" description="Port 2 Next Courtesy Tone2" />
-  <macro id="653" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="654" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="655" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="656" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="657" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="658" versions="7.39 7.60" description="Port 2 Next Courtesy Tone" />
-  <macro id="659" versions="7.39 7.60" description="Port 2 Next Courtesy Tone 10" />
-  <macro id="660" versions="7.01" description="Suspend Scheduler Setpoint 1" />
-  <macro id="660" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 1" />
-  <macro id="661" versions="7.01" description="Suspend Scheduler Setpoint 2" />
-  <macro id="661" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 2" />
-  <macro id="662" versions="7.01" description="Suspend Scheduler Setpoint 3" />
-  <macro id="662" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 3" />
-  <macro id="663" versions="7.01" description="Suspend Scheduler Setpoint 4" />
-  <macro id="663" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 4" />
-  <macro id="664" versions="7.01" description="Suspend Scheduler Setpoint 5" />
-  <macro id="664" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 5" />
-  <macro id="665" versions="7.01" description="Suspend Scheduler Setpoint 6" />
-  <macro id="665" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 6" />
-  <macro id="666" versions="7.01" description="Suspend Scheduler Setpoint 7" />
-  <macro id="666" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 7" />
-  <macro id="667" versions="7.01" description="Suspend Scheduler Setpoint 8" />
-  <macro id="667" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 8" />
-  <macro id="668" versions="7.01" description="Suspend Scheduler Setpoint 9" />
-  <macro id="668" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 9" />
-  <macro id="669" versions="7.01" description="Suspend Scheduler Setpoint 10" />
-  <macro id="669" versions="7.39 7.60" description="Port 2 Following Courtesy Tone 10" />
-  <macro id="670" versions="7.01" description="Suspend Scheduler Setpoint 11" />
-  <macro id="670" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 1" />
-  <macro id="671" versions="7.01" description="Suspend Scheduler Setpoint 12" />
-  <macro id="671" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 2" />
-  <macro id="672" versions="7.01" description="Suspend Scheduler Setpoint 13" />
-  <macro id="672" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 3" />
-  <macro id="673" versions="7.01" description="Suspend Scheduler Setpoint 14" />
-  <macro id="673" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 4" />
-  <macro id="674" versions="7.01" description="Suspend Scheduler Setpoint 15" />
-  <macro id="674" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 5" />
-  <macro id="675" versions="7.01" description="Suspend Scheduler Setpoint 16" />
-  <macro id="675" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 6" />
-  <macro id="676" versions="7.01" description="Suspend Scheduler Setpoint 17" />
-  <macro id="676" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 7" />
-  <macro id="677" versions="7.01" description="Suspend Scheduler Setpoint 18" />
-  <macro id="677" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 8" />
-  <macro id="678" versions="7.01" description="Suspend Scheduler Setpoint 19" />
-  <macro id="678" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 9" />
-  <macro id="679" versions="7.01" description="Suspend Scheduler Setpoint 20" />
-  <macro id="679" versions="7.39 7.60" description="Port 3 Next Courtesy Tone 10" />
-  <macro id="680" versions="7.01" description="Resume Scheduler Setpoint 1" />
-  <macro id="680" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 1" />
-  <macro id="681" versions="7.01" description="Resume Scheduler Setpoint 2" />
-  <macro id="681" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 2" />
-  <macro id="682" versions="7.01" description="Resume Scheduler Setpoint 3" />
-  <macro id="682" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 2" />
-  <macro id="683" versions="7.01" description="Resume Scheduler Setpoint 4" />
-  <macro id="683" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 4" />
-  <macro id="684" versions="7.01" description="Resume Scheduler Setpoint 5" />
-  <macro id="684" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 5" />
-  <macro id="685" versions="7.01" description="Resume Scheduler Setpoint 6" />
-  <macro id="685" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 6" />
-  <macro id="686" versions="7.01" description="Resume Scheduler Setpoint 7" />
-  <macro id="686" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 7" />
-  <macro id="687" versions="7.01" description="Resume Scheduler Setpoint 8" />
-  <macro id="687" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 8" />
-  <macro id="688" versions="7.01" description="Resume Scheduler Setpoint 9" />
-  <macro id="688" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 9" />
-  <macro id="689" versions="7.01" description="Resume Scheduler Setpoint 10" />
-  <macro id="689" versions="7.39 7.60" description="Port 3 Following Courtesy Tone 10" />
-  <macro id="690" versions="7.01" description="Resume Scheduler Setpoint 11" />
-  <macro id="691" versions="7.01" description="Resume Scheduler Setpoint 12" />
-  <macro id="692" versions="7.01" description="Resume Scheduler Setpoint 13" />
-  <macro id="692" versions="7.39 7.60" description="Play Port 1 Pending ID" />
-  <macro id="693" versions="7.01" description="Resume Scheduler Setpoint 14" />
-  <macro id="693" versions="7.39 7.60" description="Play Port 2 Pending ID" />
-  <macro id="694" versions="7.01" description="Resume Scheduler Setpoint 15" />
-  <macro id="694" versions="7.39 7.60" description="Play Port 3 Pending ID" />
-  <macro id="695" versions="7.01" description="Resume Scheduler Setpoint 16" />
-  <macro id="696" versions="7.01" description="Resume Scheduler Setpoint 17" />
-  <macro id="697" versions="7.01" description="Resume Scheduler Setpoint 18" />
-  <macro id="698" versions="7.01" description="Resume Scheduler Setpoint 19" />
-  <macro id="699" versions="7.01" description="Resume Scheduler Setpoint 20" />
-  <macro id="701" versions="7.01" description="Call Macro 1" />
-  <macro id="702" versions="7.01" description="Call Macro 2" />
-  <macro id="703" versions="7.01" description="Call Macro 3" />
-  <macro id="704" versions="7.01" description="Call Macro 4" />
-  <macro id="705" versions="7.01" description="Call Macro 5" />
-  <macro id="706" versions="7.01" description="Call Macro 6" />
-  <macro id="707" versions="7.01" description="Call Macro 7" />
-  <macro id="708" versions="7.01" description="Call Macro 8" />
-  <macro id="709" versions="7.01" description="Call Macro 9" />
-  <macro id="710" versions="7.01" description="Call Macro 10" />
-  <macro id="711" versions="7.01" description="Call Macro 11" />
-  <macro id="712" versions="7.01" description="Call Macro 12" />
-  <macro id="713" versions="7.01" description="Call Macro 13" />
-  <macro id="714" versions="7.01" description="Call Macro 14" />
-  <macro id="715" versions="7.01" description="Call Macro 15" />
-  <macro id="716" versions="7.01" description="Call Macro 16" />
-  <macro id="717" versions="7.01" description="Call Macro 17" />
-  <macro id="718" versions="7.01" description="Call Macro 18" />
-  <macro id="719" versions="7.01" description="Call Macro 19" />
-  <macro id="720" versions="7.01" description="Call Macro 20" />
-  <macro id="721" versions="7.01" description="Call Macro 21" />
-  <macro id="722" versions="7.01" description="Call Macro 22" />
-  <macro id="723" versions="7.01" description="Call Macro 23" />
-  <macro id="724" versions="7.01" description="Call Macro 24" />
-  <macro id="725" versions="7.01" description="Call Macro 25" />
-  <macro id="726" versions="7.01" description="Call Macro 26" />
-  <macro id="727" versions="7.01" description="Call Macro 27" />
-  <macro id="728" versions="7.01" description="Call Macro 28" />
-  <macro id="729" versions="7.01" description="Call Macro 29" />
-  <macro id="730" versions="7.01" description="Call Macro 30" />
-  <macro id="731" versions="7.01" description="Call Macro 31" />
-  <macro id="732" versions="7.01" description="Call Macro 32" />
-  <macro id="733" versions="7.01" description="Call Macro 33" />
-  <macro id="734" versions="7.01" description="Call Macro 34" />
-  <macro id="735" versions="7.01" description="Call Macro 35" />
-  <macro id="736" versions="7.01" description="Call Macro 36" />
-  <macro id="737" versions="7.01" description="Call Macro 37" />
-  <macro id="738" versions="7.01" description="Call Macro 38" />
-  <macro id="739" versions="7.01" description="Call Macro 39" />
-  <macro id="740" versions="7.01" description="Call Macro 40" />
-  <macro id="741" versions="7.01" description="Call Macro 41" />
-  <macro id="742" versions="7.01" description="Call Macro 42" />
-  <macro id="743" versions="7.01" description="Call Macro 43" />
-  <macro id="744" versions="7.01" description="Call Macro 44" />
-  <macro id="745" versions="7.01" description="Call Macro 45" />
-  <macro id="746" versions="7.01" description="Call Macro 46" />
-  <macro id="747" versions="7.01" description="Call Macro 47" />
-  <macro id="748" versions="7.01" description="Call Macro 48" />
-  <macro id="749" versions="7.01" description="Call Macro 49" />
-  <macro id="750" versions="7.01" description="Call Macro 50" />
-  <macro id="751" versions="7.01" description="Call Macro 51" />
-  <macro id="752" versions="7.01" description="Call Macro 52" />
-  <macro id="753" versions="7.01" description="Call Macro 53" />
-  <macro id="754" versions="7.01" description="Call Macro 54" />
-  <macro id="755" versions="7.01" description="Call Macro 55" />
-  <macro id="756" versions="7.01" description="Call Macro 56" />
-  <macro id="757" versions="7.01" description="Call Macro 57" />
-  <macro id="758" versions="7.01" description="Call Macro 58" />
-  <macro id="759" versions="7.01" description="Call Macro 59" />
-  <macro id="760" versions="7.01" description="Call Macro 60" />
-  <macro id="761" versions="7.01" description="Call Macro 61" />
-  <macro id="762" versions="7.01" description="Call Macro 62" />
-  <macro id="763" versions="7.01" description="Call Macro 63" />
-  <macro id="764" versions="7.01" description="Call Macro 64" />
-  <macro id="766" versions="7.01" description="Call Macro 65" />
-  <macro id="767" versions="7.01" description="Call Macro 66" />
-  <macro id="768" versions="7.01" description="Call Macro 67" />
-  <macro id="769" versions="7.01" description="Call Macro 68" />
-  <macro id="770" versions="7.01" description="Call Macro 69" />
-  <macro id="771" versions="7.01" description="Call Macro 70" />
-  <macro id="772" versions="7.01" description="Call Macro 71" />
-  <macro id="773" versions="7.01" description="Call Macro 72" />
-  <macro id="774" versions="7.01" description="Call Macro 73" />
-  <macro id="775" versions="7.01" description="Call Macro 74" />
-  <macro id="776" versions="7.01" description="Call Macro 75" />
-  <macro id="777" versions="7.01" description="Call Macro 76" />
-  <macro id="778" versions="7.01" description="Call Macro 77" />
-  <macro id="779" versions="7.01" description="Call Macro 78" />
-  <macro id="780" versions="7.01" description="Call Macro 79" />
-  <macro id="781" versions="7.01" description="Call Macro 80" />
-  <macro id="782" versions="7.01" description="Call Macro 81" />
-  <macro id="783" versions="7.01" description="Call Macro 82" />
-  <macro id="784" versions="7.01" description="Call Macro 83" />
-  <macro id="785" versions="7.01" description="Call Macro 84" />
-  <macro id="786" versions="7.01" description="Call Macro 85" />
-  <macro id="787" versions="7.01" description="Call Macro 86" />
-  <macro id="788" versions="7.01" description="Call Macro 87" />
-  <macro id="789" versions="7.01" description="Call Macro 88" />
-  <macro id="790" versions="7.01" description="Call Macro 89" />
-  <macro id="791" versions="7.01" description="Call Macro 90" />
-  <macro id="810" versions="7.39 7.60" description="Suspend Scheduler Setpoint 1" />
-  <macro id="811" versions="7.39 7.60" description="Suspend Scheduler Setpoint 2" />
-  <macro id="812" versions="7.39 7.60" description="Suspend Scheduler Setpoint 3" />
-  <macro id="813" versions="7.39 7.60" description="Suspend Scheduler Setpoint 4" />
-  <macro id="814" versions="7.39 7.60" description="Suspend Scheduler Setpoint 5" />
-  <macro id="815" versions="7.39 7.60" description="Suspend Scheduler Setpoint 6" />
-  <macro id="816" versions="7.39 7.60" description="Suspend Scheduler Setpoint 7" />
-  <macro id="817" versions="7.39 7.60" description="Suspend Scheduler Setpoint 8" />
-  <macro id="818" versions="7.39 7.60" description="Suspend Scheduler Setpoint 9" />
-  <macro id="819" versions="7.39 7.60" description="Suspend Scheduler Setpoint 10" />
-  <macro id="820" versions="7.39 7.60" description="Suspend Scheduler Setpoint 11" />
-  <macro id="821" versions="7.39 7.60" description="Suspend Scheduler Setpoint 12" />
-  <macro id="822" versions="7.39 7.60" description="Suspend Scheduler Setpoint 13" />
-  <macro id="823" versions="7.39 7.60" description="Suspend Scheduler Setpoint 14" />
-  <macro id="824" versions="7.39 7.60" description="Suspend Scheduler Setpoint 15" />
-  <macro id="825" versions="7.39 7.60" description="Suspend Scheduler Setpoint 16" />
-  <macro id="826" versions="7.39 7.60" description="Suspend Scheduler Setpoint 17" />
-  <macro id="827" versions="7.39 7.60" description="Suspend Scheduler Setpoint 18" />
-  <macro id="828" versions="7.39 7.60" description="Suspend Scheduler Setpoint 19" />
-  <macro id="829" versions="7.39 7.60" description="Suspend Scheduler Setpoint 20" />
-  <macro id="830" versions="7.39 7.60" description="Suspend Scheduler Setpoint 21" />
-  <macro id="831" versions="7.39 7.60" description="Suspend Scheduler Setpoint 22" />
-  <macro id="832" versions="7.39 7.60" description="Suspend Scheduler Setpoint 23" />
-  <macro id="833" versions="7.39 7.60" description="Suspend Scheduler Setpoint 24" />
-  <macro id="834" versions="7.39 7.60" description="Suspend Scheduler Setpoint 25" />
-  <macro id="835" versions="7.39 7.60" description="Suspend Scheduler Setpoint 26" />
-  <macro id="836" versions="7.39 7.60" description="Suspend Scheduler Setpoint 27" />
-  <macro id="837" versions="7.39 7.60" description="Suspend Scheduler Setpoint 28" />
-  <macro id="838" versions="7.39 7.60" description="Suspend Scheduler Setpoint 29" />
-  <macro id="839" versions="7.39 7.60" description="Suspend Scheduler Setpoint 30" />
-  <macro id="840" versions="7.39 7.60" description="Suspend Scheduler Setpoint 31" />
-  <macro id="841" versions="7.39 7.60" description="Suspend Scheduler Setpoint 32" />
-  <macro id="842" versions="7.39 7.60" description="Suspend Scheduler Setpoint 33" />
-  <macro id="843" versions="7.39 7.60" description="Suspend Scheduler Setpoint 34" />
-  <macro id="844" versions="7.39 7.60" description="Suspend Scheduler Setpoint 35" />
-  <macro id="845" versions="7.39 7.60" description="Suspend Scheduler Setpoint 36" />
-  <macro id="846" versions="7.39 7.60" description="Suspend Scheduler Setpoint 37" />
-  <macro id="847" versions="7.39 7.60" description="Suspend Scheduler Setpoint 38" />
-  <macro id="848" versions="7.39 7.60" description="Suspend Scheduler Setpoint 39" />
-  <macro id="849" versions="7.39 7.60" description="Suspend Scheduler Setpoint 40" />
-  <macro id="850" versions="7.39 7.60" description="Resume Scheduler Setpoint 1" />
-  <macro id="851" versions="7.39 7.60" description="Resume Scheduler Setpoint 2" />
-  <macro id="852" versions="7.39 7.60" description="Resume Scheduler Setpoint 3" />
-  <macro id="853" versions="7.39 7.60" description="Resume Scheduler Setpoint 4" />
-  <macro id="854" versions="7.39 7.60" description="Resume Scheduler Setpoint 5" />
-  <macro id="355" versions="7.39 7.60" description="Resume Scheduler Setpoint 6" />
-  <macro id="856" versions="7.39 7.60" description="Resume Scheduler Setpoint 7" />
-  <macro id="857" versions="7.39 7.60" description="Resume Scheduler Setpoint 8" />
-  <macro id="858" versions="7.39 7.60" description="Resume Scheduler Setpoint 9" />
-  <macro id="859" versions="7.39 7.60" description="Resume Scheduler Setpoint 10" />
-  <macro id="860" versions="7.39 7.60" description="Resume Scheduler Setpoint 11" />
-  <macro id="861" versions="7.39 7.60" description="Resume Scheduler Setpoint 12" />
-  <macro id="862" versions="7.39 7.60" description="Resume Scheduler Setpoint 13" />
-  <macro id="863" versions="7.39 7.60" description="Resume Scheduler Setpoint 14" />
-  <macro id="864" versions="7.39 7.60" description="Resume Scheduler Setpoint 15" />
-  <macro id="865" versions="7.39 7.60" description="Resume Scheduler Setpoint 16" />
-  <macro id="866" versions="7.39 7.60" description="Resume Scheduler Setpoint 17" />
-  <macro id="867" versions="7.39 7.60" description="Resume Scheduler Setpoint 18" />
-  <macro id="868" versions="7.39 7.60" description="Resume Scheduler Setpoint 19" />
-  <macro id="869" versions="7.39 7.60" description="Resume Scheduler Setpoint 20" />
-  <macro id="870" versions="7.39 7.60" description="Resume Scheduler Setpoint 21" />
-  <macro id="871" versions="7.39 7.60" description="Resume Scheduler Setpoint 22" />
-  <macro id="872" versions="7.39 7.60" description="Resume Scheduler Setpoint 23" />
-  <macro id="873" versions="7.39 7.60" description="Resume Scheduler Setpoint 24" />
-  <macro id="874" versions="7.39 7.60" description="Resume Scheduler Setpoint 25" />
-  <macro id="875" versions="7.39 7.60" description="Resume Scheduler Setpoint 26" />
-  <macro id="876" versions="7.39 7.60" description="Resume Scheduler Setpoint 27" />
-  <macro id="877" versions="7.39 7.60" description="Resume Scheduler Setpoint 28" />
-  <macro id="878" versions="7.39 7.60" description="Resume Scheduler Setpoint 29" />
-  <macro id="879" versions="7.39 7.60" description="Resume Scheduler Setpoint 30" />
-  <macro id="880" versions="7.39 7.60" description="Resume Scheduler Setpoint 31" />
-  <macro id="881" versions="7.39 7.60" description="Resume Scheduler Setpoint 32" />
-  <macro id="882" versions="7.39 7.60" description="Resume Scheduler Setpoint 33" />
-  <macro id="883" versions="7.39 7.60" description="Resume Scheduler Setpoint 34" />
-  <macro id="884" versions="7.39 7.60" description="Resume Scheduler Setpoint 35" />
-  <macro id="885" versions="7.39 7.60" description="Resume Scheduler Setpoint 36" />
-  <macro id="886" versions="7.39 7.60" description="Resume Scheduler Setpoint 37" />
-  <macro id="887" versions="7.39 7.60" description="Resume Scheduler Setpoint 38" />
-  <macro id="888" versions="7.39 7.60" description="Resume Scheduler Setpoint 39" />
-  <macro id="889" versions="7.39 7.60" description="Resume Scheduler Setpoint 40" />
-  <macro id="860" versions="7.36" description="Suspend Scheduler Setpoint 1" />
-  <macro id="861" versions="7.36" description="Suspend Scheduler Setpoint 2" />
-  <macro id="862" versions="7.36" description="Suspend Scheduler Setpoint 3" />
-  <macro id="863" versions="7.36" description="Suspend Scheduler Setpoint 4" />
-  <macro id="864" versions="7.36" description="Suspend Scheduler Setpoint 5" />
-  <macro id="865" versions="7.36" description="Suspend Scheduler Setpoint 6" />
-  <macro id="866" versions="7.36" description="Suspend Scheduler Setpoint 7" />
-  <macro id="867" versions="7.36" description="Suspend Scheduler Setpoint 8" />
-  <macro id="868" versions="7.36" description="Suspend Scheduler Setpoint 9" />
-  <macro id="869" versions="7.36" description="Suspend Scheduler Setpoint 10" />
-  <macro id="870" versions="7.36" description="Suspend Scheduler Setpoint 11" />
-  <macro id="871" versions="7.36" description="Suspend Scheduler Setpoint 12" />
-  <macro id="872" versions="7.36" description="Suspend Scheduler Setpoint 13" />
-  <macro id="873" versions="7.36" description="Suspend Scheduler Setpoint 14" />
-  <macro id="874" versions="7.36" description="Suspend Scheduler Setpoint 15" />
-  <macro id="875" versions="7.36" description="Suspend Scheduler Setpoint 16" />
-  <macro id="876" versions="7.36" description="Suspend Scheduler Setpoint 17" />
-  <macro id="877" versions="7.36" description="Suspend Scheduler Setpoint 18" />
-  <macro id="878" versions="7.36" description="Suspend Scheduler Setpoint 19" />
-  <macro id="879" versions="7.36" description="Suspend Scheduler Setpoint 20" />
-  <macro id="880" versions="7.36" description="Resume Scheduler Setpoint 1" />
-  <macro id="881" versions="7.36" description="Resume Scheduler Setpoint 2" />
-  <macro id="882" versions="7.36" description="Resume Scheduler Setpoint 3" />
-  <macro id="883" versions="7.36" description="Resume Scheduler Setpoint 4" />
-  <macro id="884" versions="7.36" description="Resume Scheduler Setpoint 5" />
-  <macro id="885" versions="7.36" description="Resume Scheduler Setpoint 6" />
-  <macro id="886" versions="7.36" description="Resume Scheduler Setpoint 7" />
-  <macro id="887" versions="7.36" description="Resume Scheduler Setpoint 8" />
-  <macro id="888" versions="7.36" description="Resume Scheduler Setpoint 9" />
-  <macro id="889" versions="7.36" description="Resume Scheduler Setpoint 10" />
-  <macro id="890" versions="7.36" description="Resume Scheduler Setpoint 11" />
-  <macro id="891" versions="7.36" description="Resume Scheduler Setpoint 12" />
-  <macro id="892" versions="7.36" description="Resume Scheduler Setpoint 13" />
-  <macro id="893" versions="7.36" description="Resume Scheduler Setpoint 14" />
-  <macro id="894" versions="7.36" description="Resume Scheduler Setpoint 15" />
-  <macro id="895" versions="7.36" description="Resume Scheduler Setpoint 16" />
-  <macro id="896" versions="7.36" description="Resume Scheduler Setpoint 17" />
-  <macro id="897" versions="7.36" description="Resume Scheduler Setpoint 18" />
-  <macro id="898" versions="7.36" description="Resume Scheduler Setpoint 19" />
-  <macro id="899" versions="7.36" description="Resume Scheduler Setpoint 20" />
-  <macro id="901" versions="7.39 7.60" description="Call Macro 1" />
-  <macro id="902" versions="7.39 7.60" description="Call Macro 2" />
-  <macro id="903" versions="7.39 7.60" description="Call Macro 3" />
-  <macro id="904" versions="7.39 7.60" description="Call Macro 4" />
-  <macro id="905" versions="7.39 7.60" description="Call Macro 5" />
-  <macro id="906" versions="7.39 7.60" description="Call Macro 6" />
-  <macro id="907" versions="7.39 7.60" description="Call Macro 7" />
-  <macro id="908" versions="7.39 7.60" description="Call Macro 8" />
-  <macro id="909" versions="7.39 7.60" description="Call Macro 9" />
-  <macro id="910" versions="7.39 7.60" description="Call Macro 10" />
-  <macro id="911" versions="7.39 7.60" description="Call Macro 11" />
-  <macro id="912" versions="7.39 7.60" description="Call Macro 12" />
-  <macro id="913" versions="7.39 7.60" description="Call Macro 13" />
-  <macro id="914" versions="7.39 7.60" description="Call Macro 14" />
-  <macro id="915" versions="7.39 7.60" description="Call Macro 15" />
-  <macro id="916" versions="7.39 7.60" description="Call Macro 16" />
-  <macro id="917" versions="7.39 7.60" description="Call Macro 17" />
-  <macro id="918" versions="7.39 7.60" description="Call Macro 18" />
-  <macro id="919" versions="7.39 7.60" description="Call Macro 19" />
-  <macro id="920" versions="7.39 7.60" description="Call Macro 20" />
-  <macro id="921" versions="7.39 7.60" description="Call Macro 21" />
-  <macro id="922" versions="7.39 7.60" description="Call Macro 22" />
-  <macro id="923" versions="7.39 7.60" description="Call Macro 23" />
-  <macro id="924" versions="7.39 7.60" description="Call Macro 24" />
-  <macro id="925" versions="7.39 7.60" description="Call Macro 25" />
-  <macro id="926" versions="7.39 7.60" description="Call Macro 26" />
-  <macro id="927" versions="7.39 7.60" description="Call Macro 27" />
-  <macro id="928" versions="7.39 7.60" description="Call Macro 28" />
-  <macro id="929" versions="7.39 7.60" description="Call Macro 29" />
-  <macro id="930" versions="7.39 7.60" description="Call Macro 30" />
-  <macro id="931" versions="7.39 7.60" description="Call Macro 31" />
-  <macro id="932" versions="7.39 7.60" description="Call Macro 32" />
-  <macro id="933" versions="7.39 7.60" description="Call Macro 33" />
-  <macro id="934" versions="7.39 7.60" description="Call Macro 34" />
-  <macro id="935" versions="7.39 7.60" description="Call Macro 35" />
-  <macro id="936" versions="7.39 7.60" description="Call Macro 36" />
-  <macro id="937" versions="7.39 7.60" description="Call Macro 37" />
-  <macro id="938" versions="7.39 7.60" description="Call Macro 38" />
-  <macro id="939" versions="7.39 7.60" description="Call Macro 39" />
-  <macro id="940" versions="7.39 7.60" description="Call Macro 40" />
-  <macro id="941" versions="7.39 7.60" description="Call Macro 41" />
-  <macro id="942" versions="7.39 7.60" description="Call Macro 42" />
-  <macro id="943" versions="7.39 7.60" description="Call Macro 43" />
-  <macro id="944" versions="7.39 7.60" description="Call Macro 44" />
-  <macro id="945" versions="7.39 7.60" description="Call Macro 45" />
-  <macro id="946" versions="7.39 7.60" description="Call Macro 46" />
-  <macro id="947" versions="7.39 7.60" description="Call Macro 47" />
-  <macro id="948" versions="7.39 7.60" description="Call Macro 48" />
-  <macro id="949" versions="7.39 7.60" description="Call Macro 49" />
-  <macro id="950" versions="7.39 7.60" description="Call Macro 50" />
-  <macro id="951" versions="7.39 7.60" description="Call Macro 51" />
-  <macro id="952" versions="7.39 7.60" description="Call Macro 52" />
-  <macro id="953" versions="7.39 7.60" description="Call Macro 53" />
-  <macro id="954" versions="7.39 7.60" description="Call Macro 54" />
-  <macro id="955" versions="7.39 7.60" description="Call Macro 55" />
-  <macro id="956" versions="7.39 7.60" description="Call Macro 56" />
-  <macro id="957" versions="7.39 7.60" description="Call Macro 57" />
-  <macro id="958" versions="7.39 7.60" description="Call Macro 58" />
-  <macro id="959" versions="7.39 7.60" description="Call Macro 59" />
-  <macro id="960" versions="7.39 7.60" description="Call Macro 60" />
-  <macro id="961" versions="7.39 7.60" description="Call Macro 61" />
-  <macro id="962" versions="7.39 7.60" description="Call Macro 62" />
-  <macro id="963" versions="7.39 7.60" description="Call Macro 63" />
-  <macro id="964" versions="7.39 7.60" description="Call Macro 64" />
-  <macro id="965" versions="7.39 7.60" description="Call Macro 65" />
-  <macro id="966" versions="7.39 7.60" description="Call Macro 66" />
-  <macro id="967" versions="7.39 7.60" description="Call Macro 67" />
-  <macro id="968" versions="7.39 7.60" description="Call Macro 68" />
-  <macro id="969" versions="7.39 7.60" description="Call Macro 69" />
-  <macro id="970" versions="7.39 7.60" description="Call Macro 70" />
-  <macro id="971" versions="7.39 7.60" description="Call Macro 71" />
-  <macro id="972" versions="7.39 7.60" description="Call Macro 72" />
-  <macro id="973" versions="7.39 7.60" description="Call Macro 73" />
-  <macro id="974" versions="7.39 7.60" description="Call Macro 74" />
-  <macro id="975" versions="7.39 7.60" description="Call Macro 75" />
-  <macro id="976" versions="7.39 7.60" description="Call Macro 76" />
-  <macro id="977" versions="7.39 7.60" description="Call Macro 77" />
-  <macro id="978" versions="7.39 7.60" description="Call Macro 78" />
-  <macro id="979" versions="7.39 7.60" description="Call Macro 79" />
-  <macro id="980" versions="7.39 7.60" description="Call Macro 80" />
-  <macro id="981" versions="7.39 7.60" description="Call Macro 81" />
-  <macro id="982" versions="7.39 7.60" description="Call Macro 82" />
-  <macro id="983" versions="7.39 7.60" description="Call Macro 83" />
-  <macro id="984" versions="7.39 7.60" description="Call Macro 84" />
-  <macro id="985" versions="7.39 7.60" description="Call Macro 85" />
-  <macro id="986" versions="7.39 7.60" description="Call Macro 86" />
-  <macro id="987" versions="7.39 7.60" description="Call Macro 87" />
-  <macro id="988" versions="7.39 7.60" description="Call Macro 88" />
-  <macro id="989" versions="7.39 7.60" description="Call Macro 89" />
-  <macro id="990" versions="7.39 7.60" description="Call Macro 90" />
-  <macro id="991" versions="7.39 7.60" description="Call Macro 91" />
-  <macro id="992" versions="7.39 7.60" description="Call Macro 92" />
-  <macro id="993" versions="7.39 7.60" description="Call Macro 93" />
-  <macro id="994" versions="7.39 7.60" description="Call Macro 94" />
-  <macro id="995" versions="7.39 7.60" description="Call Macro 95" />
-  <macro id="996" versions="7.39 7.60" description="Call Macro 96" />
-  <macro id="997" versions="7.39 7.60" description="Call Macro 97" />
-  <macro id="998" versions="7.39 7.60" description="Call Macro 98" />
-  <macro id="999" versions="7.39 7.60" description="Call Macro 99" />
-  <macro id="1000" versions="7.39 7.60" description="Call Macro 100" />
-  <macro id="1001" versions="7.39 7.60" description="Call Macro 101" />
-  <macro id="1002" versions="7.39 7.60" description="Call Macro 102" />
-  <macro id="1003" versions="7.39 7.60" description="Call Macro 103" />
-  <macro id="1004" versions="7.39 7.60" description="Call Macro 104" />
-  <macro id="1005" versions="7.39 7.60" description="Call Macro 105" />
+  <macro id="1" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 CTCSS Access" />
+  <macro id="2" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 CTCSS Access" />
+  <macro id="3" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 CTCSS Access" />
+  <macro id="4" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Carrier Access" />
+  <macro id="5" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Carrier Access" />
+  <macro id="6" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Carrier Access" />
+  <macro id="7" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 DTMF Covertone ON" />
+  <macro id="8" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 DTMF Covertone ON" />
+  <macro id="9" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 DTMF Covertone ON" />
+  <macro id="10" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 DTMF Covertone OFF" />
+  <macro id="11" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 DTMF Covertone OFF" />
+  <macro id="12" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 DTMF Covertone OFF" />
+  <macro id="13" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Enable" />
+  <macro id="14" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Enable" />
+  <macro id="15" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Enable" />
+  <macro id="16" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Disable" />
+  <macro id="17" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Disable" />
+  <macro id="18" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Disable" />
+  <macro id="19" versions="7.39 7.60 7.61 7.611 7.612" description="Monitor Port 1 from Port 2" />
+  <macro id="20" versions="7.39 7.60 7.61 7.611 7.612" description="Monitor Port 1 from Port 3" />
+  <macro id="21" versions="7.39 7.60 7.61 7.611 7.612" description="Disconnect Port 1 from Port 2" />
+  <macro id="22" versions="7.39 7.60 7.61 7.611 7.612" description="Disconnect Port 1 from Port 3" />
+  <macro id="23" versions="7.39 7.60 7.61 7.611 7.612" description="Monitor Port 2 from Port 1" />
+  <macro id="24" versions="7.39 7.60 7.61 7.611 7.612" description="Monitor Port 2 from Port 3" />
+  <macro id="25" versions="7.39 7.60 7.61 7.611 7.612" description="Disconnect Port 2 from Port 1" />
+  <macro id="26" versions="7.39 7.60 7.61 7.611 7.612" description="Disconnect Port 2 from Port 3" />
+  <macro id="27" versions="7.39 7.60 7.61 7.611 7.612" description="Monitor Port 3 from Port 1" />
+  <macro id="28" versions="7.39 7.60 7.61 7.611 7.612" description="Monitor Port 3 from Port 2" />
+  <macro id="29" versions="7.39 7.60 7.61 7.611 7.612" description="Disconnect Port 3 from Port 1" />
+  <macro id="30" versions="7.39 7.60 7.61 7.611 7.612" description="Disconnect Port 3 from Port 2" />
+  <macro id="31" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Monitor Mute" />
+  <macro id="32" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Monitor Mute" />
+  <macro id="33" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Monitor Mute" />
+  <macro id="34" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Monitor Mix" />
+  <macro id="35" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Monitor Mix" />
+  <macro id="36" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Monitor Mix" />
+  <macro id="37" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Repeat ON" />
+  <macro id="38" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Repeat ON" />
+  <macro id="39" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Repeat ON" />
+  <macro id="40" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Repeat OFF" />
+  <macro id="41" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Repeat OFF" />
+  <macro id="42" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Repeat OFF" />
+  <macro id="43" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Speech OverrideON" />
+  <macro id="44" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Speech OverrideON" />
+  <macro id="45" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Speech OverrideON" />
+  <macro id="46" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Speech Override OFF" />
+  <macro id="47" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Speech Override OFF" />
+  <macro id="48" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Speech Override OFF" />
+  <macro id="49" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 1" />
+  <macro id="50" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 2" />
+  <macro id="51" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 3" />
+  <macro id="52" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 4" />
+  <macro id="53" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 5" />
+  <macro id="54" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 6" />
+  <macro id="55" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 7" />
+  <macro id="56" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 8" />
+  <macro id="57" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 9" />
+  <macro id="58" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Courtesy Tone 10" />
+  <macro id="59" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 1" />
+  <macro id="60" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 2" />
+  <macro id="61" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 3" />
+  <macro id="62" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 4" />
+  <macro id="63" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 5" />
+  <macro id="64" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 6" />
+  <macro id="65" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 7" />
+  <macro id="66" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 8" />
+  <macro id="67" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 9" />
+  <macro id="68" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Courtesy Tone 10" />
+  <macro id="69" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 1" />
+  <macro id="70" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 2" />
+  <macro id="71" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 3" />
+  <macro id="72" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 4" />
+  <macro id="73" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 5" />
+  <macro id="74" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 6" />
+  <macro id="75" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 7" />
+  <macro id="76" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 8" />
+  <macro id="77" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 9" />
+  <macro id="78" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Courtesy Tone 10" />
+  <macro id="79" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 DTMF Muting ON" />
+  <macro id="80" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 DTMF Muting ON" />
+  <macro id="81" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 DTMF Muting ON" />
+  <macro id="82" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 DTMF Muting OFF" />
+  <macro id="83" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 DTMF Muting OFF" />
+  <macro id="84" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 DTMF Muting OFF" />
+  <macro id="85" versions="7.39 7.60 7.61 7.611 7.612" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="86" versions="7.39 7.60 7.61 7.611 7.612" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="87" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 1" />
+  <macro id="88" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 2" />
+  <macro id="89" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 3" />
+  <macro id="90" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 4" />
+  <macro id="91" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 5" />
+  <macro id="92" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 6" />
+  <macro id="93" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 7" />
+  <macro id="94" versions="7.39 7.60 7.61 7.611 7.612" description="Read ADC Channel 8" />
+  <macro id="95" versions="7.39 7.60 7.61 7.611 7.612" description="UF1 ON" />
+  <macro id="96" versions="7.39 7.60 7.61 7.611 7.612" description="UF2 ON" />
+  <macro id="97" versions="7.39 7.60 7.61 7.611 7.612" description="UF3 ON" />
+  <macro id="98" versions="7.39 7.60 7.61 7.611 7.612" description="UF4 ON" />
+  <macro id="99" versions="7.39 7.60 7.61 7.611 7.612" description="UF5 ON" />
+  <macro id="100" versions="7.39 7.60 7.61 7.611 7.612" description="UF6 ON" />
+  <macro id="101" versions="7.39 7.60 7.61 7.611 7.612" description="UF7 ON" />
+  <macro id="102" versions="7.39 7.60 7.61 7.611 7.612" description="UF1 OFF" />
+  <macro id="103" versions="7.39 7.60 7.61 7.611 7.612" description="UF2 OFF" />
+  <macro id="104" versions="7.39 7.60 7.61 7.611 7.612" description="UF3 OFF" />
+  <macro id="105" versions="7.39 7.60 7.61 7.611 7.612" description="UF4 OFF" />
+  <macro id="106" versions="7.39 7.60 7.61 7.611 7.612" description="UF5 OFF" />
+  <macro id="107" versions="7.39 7.60 7.61 7.611 7.612" description="UF6 OFF" />
+  <macro id="108" versions="7.39 7.60 7.61 7.611 7.612" description="UF7 OFF" />
+  <macro id="109" versions="7.39 7.60 7.61 7.611 7.612" description="UF1 Pulse" />
+  <macro id="110" versions="7.39 7.60 7.61 7.611 7.612" description="UF2 Pulse" />
+  <macro id="111" versions="7.39 7.60 7.61 7.611 7.612" description="UF3 Pulse" />
+  <macro id="112" versions="7.39 7.60 7.61 7.611 7.612" description="UF4 Pulse" />
+  <macro id="113" versions="7.39 7.60 7.61 7.611 7.612" description="UF5 Pulse" />
+  <macro id="114" versions="7.39 7.60 7.61 7.611 7.612" description="UF6 Pulse" />
+  <macro id="115" versions="7.39 7.60 7.61 7.611 7.612" description="UF7 Pulse" />
+  <macro id="116" versions="7.39 7.60 7.61 7.611 7.612" description="Say Time" />
+  <macro id="117" versions="7.39 7.60 7.61 7.611 7.612" description="Say Date" />
+  <macro id="118" versions="7.39 7.60 7.61 7.611 7.612" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="7.39 7.60 7.61 7.611 7.612" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="7.39 7.60 7.61 7.611 7.612" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="7.39 7.60 7.61 7.611 7.612" description="Link All Ports" />
+  <macro id="122" versions="7.39 7.60 7.61 7.611 7.612" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="7.39 7.60 7.61 7.611 7.612" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="7.39 7.60 7.61 7.611 7.612" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="7.39 7.60 7.61 7.611 7.612" description="UnLink All Ports" />
+  <macro id="126" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 1" />
+  <macro id="127" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 2" />
+  <macro id="128" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 3" />
+  <macro id="129" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 4" />
+  <macro id="130" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 5" />
+  <macro id="131" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 6" />
+  <macro id="132" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 7" />
+  <macro id="133" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 8" />
+  <macro id="134" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 9" />
+  <macro id="135" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 10" />
+  <macro id="136" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 11" />
+  <macro id="137" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 12" />
+  <macro id="138" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 13" />
+  <macro id="139" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 14" />
+  <macro id="140" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 15" />
+  <macro id="141" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 16" />
+  <macro id="142" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 17" />
+  <macro id="143" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 18" />
+  <macro id="144" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 19" />
+  <macro id="145" versions="7.39 7.60 7.61 7.611 7.612" description="Play DVR Track 20" />
+  <macro id="146" versions="7.39 7.60 7.61 7.611 7.612" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="7.39 7.60 7.61 7.611 7.612" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="7.39 7.60 7.61 7.611 7.612" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="7.39 7.60 7.61 7.611 7.612" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="7.39 7.60 7.61 7.611 7.612" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="7.39 7.60 7.61 7.611 7.612" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 1 ON" />
+  <macro id="153" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 2 ON" />
+  <macro id="154" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 3 ON" />
+  <macro id="155" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 4 ON" />
+  <macro id="156" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 5 ON" />
+  <macro id="157" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 1 OFF" />
+  <macro id="158" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 2 OFF" />
+  <macro id="159" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 3 OFF" />
+  <macro id="160" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 4 OFF" />
+  <macro id="161" versions="7.39 7.60 7.61 7.611 7.612" description="Alarm 5 OFF" />
+  <macro id="162" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out Port 1" />
+  <macro id="163" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out Port 2" />
+  <macro id="164" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out Port 3" />
+  <macro id="165" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="7.39 7.60 7.61 7.611 7.612" description="Speech Out All Ports" />
+  <macro id="169" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Enable Port 1" />
+  <macro id="170" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Enable Port 2" />
+  <macro id="171" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Enable Port 3" />
+  <macro id="172" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Disable Port 1" />
+  <macro id="173" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Disable Port 2" />
+  <macro id="174" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Disable Port 3" />
+  <macro id="175" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="7.39 7.60 7.61 7.611 7.612" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="7.39 7.60 7.61 7.611 7.612" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="7.39 7.60 7.61 7.611 7.612" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="7.39 7.60 7.61 7.611 7.612" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="7.39 7.60 7.61 7.611 7.612" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="7.39 7.60 7.61 7.611 7.612" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="7.39 7.60 7.61 7.611 7.612" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 1" />
+  <macro id="188" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 2" />
+  <macro id="189" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 3" />
+  <macro id="190" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 4" />
+  <macro id="191" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 5" />
+  <macro id="192" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 6" />
+  <macro id="193" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 7" />
+  <macro id="194" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 8" />
+  <macro id="195" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 9" />
+  <macro id="196" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 10" />
+  <macro id="197" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 11" />
+  <macro id="198" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 12" />
+  <macro id="199" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 13" />
+  <macro id="200" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 14" />
+  <macro id="201" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 15" />
+  <macro id="202" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 16" />
+  <macro id="203" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 17" />
+  <macro id="204" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 18" />
+  <macro id="205" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 19" />
+  <macro id="206" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 20" />
+  <macro id="207" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 21" />
+  <macro id="208" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 22" />
+  <macro id="209" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 23" />
+  <macro id="210" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 24" />
+  <macro id="211" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 25" />
+  <macro id="212" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 26" />
+  <macro id="213" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 27" />
+  <macro id="214" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 28" />
+  <macro id="215" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 29" />
+  <macro id="216" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 30" />
+  <macro id="217" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 31" />
+  <macro id="218" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 32" />
+  <macro id="219" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 33" />
+  <macro id="220" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 34" />
+  <macro id="221" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 35" />
+  <macro id="222" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 36" />
+  <macro id="223" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 37" />
+  <macro id="224" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 38" />
+  <macro id="225" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 39" />
+  <macro id="226" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 40" />
+  <macro id="227" versions="7.39 7.60 7.61 7.611 7.612" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="7.39 7.60 7.61 7.611 7.612" description="Macro Priority High" />
+  <macro id="229" versions="7.39 7.60 7.61 7.611 7.612" description="Macro Priority Low" />
+  <macro id="230" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Receiver Port 1" />
+  <macro id="237" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Receiver Port 2" />
+  <macro id="238" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Receiver Port 3" />
+  <macro id="239" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Receiver Port 1" />
+  <macro id="240" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Receiver Port 2" />
+  <macro id="241" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Receiver Port 3" />
+  <macro id="242" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="7.39 7.60 7.61 7.611 7.612" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="7.39 7.60 7.61 7.611 7.612" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="7.39 7.60 7.61 7.611 7.612" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="7.39 7.60 7.61 7.611 7.612" description="Force Audio To Entered Port" />
+  <macro id="252" versions="7.39 7.60 7.61 7.611 7.612" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="7.39 7.60 7.61 7.611 7.612" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="7.39 7.60 7.61 7.611 7.612" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="7.39 7.60 7.61 7.611 7.612" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="7.39 7.60 7.61 7.611 7.612" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="7.39 7.60 7.61 7.611 7.612" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 1" />
+  <macro id="260" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 2" />
+  <macro id="261" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 3" />
+  <macro id="262" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 4" />
+  <macro id="263" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 5" />
+  <macro id="264" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 6" />
+  <macro id="265" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 7" />
+  <macro id="266" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 8" />
+  <macro id="267" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 9" />
+  <macro id="268" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 10" />
+  <macro id="269" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 11" />
+  <macro id="270" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 12" />
+  <macro id="271" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 13" />
+  <macro id="272" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 14" />
+  <macro id="273" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 15" />
+  <macro id="274" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 16" />
+  <macro id="275" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 17" />
+  <macro id="276" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 18" />
+  <macro id="277" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 19" />
+  <macro id="278" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 20" />
+  <macro id="279" versions="7.39 7.60 7.61 7.611 7.612" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="7.39 7.60 7.61 7.611 7.612" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="7.39 7.60 7.61 7.611 7.612" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="7.39 7.60 7.61 7.611 7.612" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="7.39 7.60 7.61 7.611 7.612" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="7.39 7.60 7.61 7.611 7.612" description="Say year as part of date" />
+  <macro id="308" versions="7.39 7.60 7.61 7.611 7.612" description="Don't say year as part of date" />
+  <macro id="309" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 1" />
+  <macro id="322" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 2" />
+  <macro id="323" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 3" />
+  <macro id="324" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 4" />
+  <macro id="325" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 5" />
+  <macro id="326" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 6" />
+  <macro id="327" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 7" />
+  <macro id="328" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 8" />
+  <macro id="329" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 9" />
+  <macro id="330" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 10" />
+  <macro id="331" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Zero Hang Time Select" />
+  <macro id="336" versions="7.39 7.60 7.61 7.611 7.612" description="Dial 911" />
+  <macro id="337" versions="7.39 7.60 7.61 7.611 7.612" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Autopatch" />
+  <macro id="339" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="7.39 7.60 7.61 7.611 7.612" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="7.39 7.60 7.61 7.611 7.612" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="7.39 7.60 7.61 7.611 7.612" description="Start General Timer 1" />
+  <macro id="348" versions="7.39 7.60 7.61 7.611 7.612" description="Start General Timer 2" />
+  <macro id="349" versions="7.39 7.60 7.61 7.611 7.612" description="Start General Timer 3" />
+  <macro id="350" versions="7.39 7.60 7.61 7.611 7.612" description="Stop General Timer 1" />
+  <macro id="351" versions="7.39 7.60 7.61 7.611 7.612" description="Stop General Timer 2" />
+  <macro id="352" versions="7.39 7.60 7.61 7.611 7.612" description="Stop General Timer 3" />
+  <macro id="353" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Power Select 1" />
+  <macro id="354" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Power Select 2" />
+  <macro id="355" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Power Select 3" />
+  <macro id="356" versions="7.39 7.60 7.61 7.611 7.612" description="Guest Macros Enabled" />
+  <macro id="357" versions="7.39 7.60 7.61 7.611 7.612" description="Guest Macros Disabled" />
+  <macro id="358" versions="7.39 7.60 7.61 7.611 7.612" description="Receiver 1 Macros On" />
+  <macro id="359" versions="7.39 7.60 7.61 7.611 7.612" description="Receiver 2 Macros On" />
+  <macro id="360" versions="7.39 7.60 7.61 7.611 7.612" description="Receiver 3 Macros On" />
+  <macro id="361" versions="7.39 7.60 7.61 7.611 7.612" description="Receiver 1 Macros Off" />
+  <macro id="362" versions="7.39 7.60 7.61 7.611 7.612" description="Receiver 2 Macros Off" />
+  <macro id="363" versions="7.39 7.60 7.61 7.611 7.612" description="Receiver 3 Macros Off" />
+  <macro id="364" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 1 Output ON" />
+  <macro id="365" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 2 Output ON" />
+  <macro id="366" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 3 Output ON" />
+  <macro id="367" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 4 Output ON" />
+  <macro id="368" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 5 Output ON" />
+  <macro id="369" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 6 Output ON" />
+  <macro id="370" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 7 Output ON" />
+  <macro id="371" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 8 Output ON" />
+  <macro id="372" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 9 Output ON" />
+  <macro id="373" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 10 Output ON" />
+  <macro id="374" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 11 Output ON" />
+  <macro id="375" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 12 Output ON" />
+  <macro id="376" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 13 Output ON" />
+  <macro id="377" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 14 Output ON" />
+  <macro id="378" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 15 Output ON" />
+  <macro id="379" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 16 Output ON" />
+  <macro id="380" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 17 Output ON" />
+  <macro id="381" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 18 Output ON" />
+  <macro id="382" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 19 Output ON" />
+  <macro id="383" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 20 Output ON" />
+  <macro id="384" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 21 Output ON" />
+  <macro id="385" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 22 Output ON" />
+  <macro id="386" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 23 Output ON" />
+  <macro id="387" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 24 Output ON" />
+  <macro id="388" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 25 Output ON" />
+  <macro id="389" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 26 Output ON" />
+  <macro id="390" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 27 Output ON" />
+  <macro id="391" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 28 Output ON" />
+  <macro id="392" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 29 Output ON" />
+  <macro id="393" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 30 Output ON" />
+  <macro id="394" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 31 Output ON" />
+  <macro id="395" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 32 Output ON" />
+  <macro id="396" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 1 Output Pulse" />
+  <macro id="397" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 2 Output Pulse" />
+  <macro id="398" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 3 Output Pulse" />
+  <macro id="399" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 4 Output Pulse" />
+  <macro id="400" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 5 Output Pulse" />
+  <macro id="401" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 6 Output Pulse" />
+  <macro id="402" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 7 Output Pulse" />
+  <macro id="403" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 8 Output Pulse" />
+  <macro id="404" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 9 Output Pulse" />
+  <macro id="405" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 10 Output Pulse" />
+  <macro id="406" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 11 Output Pulse" />
+  <macro id="407" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 12 Output Pulse" />
+  <macro id="408" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 13 Output Pulse" />
+  <macro id="409" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 14 Output Pulse" />
+  <macro id="410" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 15 Output Pulse" />
+  <macro id="411" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 16 Output Pulse" />
+  <macro id="412" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 17 Output Pulse" />
+  <macro id="413" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 18 Output Pulse" />
+  <macro id="414" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 19 Output Pulse" />
+  <macro id="415" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 20 Output Pulse" />
+  <macro id="416" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 21 Output Pulse" />
+  <macro id="417" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 22 Output Pulse" />
+  <macro id="418" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 23 Output Pulse" />
+  <macro id="419" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 24 Output Pulse" />
+  <macro id="420" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 25 Output Pulse" />
+  <macro id="421" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 26 Output Pulse" />
+  <macro id="422" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 27 Output Pulse" />
+  <macro id="423" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 28 Output Pulse" />
+  <macro id="424" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 29 Output Pulse" />
+  <macro id="425" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 30 Output Pulse" />
+  <macro id="426" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 31 Output Pulse" />
+  <macro id="427" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 32 Output Pulse" />
+  <macro id="428" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 1 Output OFF" />
+  <macro id="429" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 2 Output OFF" />
+  <macro id="430" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 3 Output OFF" />
+  <macro id="431" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 4 Output OFF" />
+  <macro id="432" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 5 Output OFF" />
+  <macro id="433" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 6 Output OFF" />
+  <macro id="434" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 7 Output OFF" />
+  <macro id="435" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 8 Output OFF" />
+  <macro id="436" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 9 Output OFF" />
+  <macro id="437" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 10 Output OFF" />
+  <macro id="438" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 11 Output OFF" />
+  <macro id="439" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 12 Output OFF" />
+  <macro id="440" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 13 Output OFF" />
+  <macro id="441" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 14 Output OFF" />
+  <macro id="442" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 15 Output OFF" />
+  <macro id="443" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 16 Output OFF" />
+  <macro id="444" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 17 Output OFF" />
+  <macro id="445" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 18 Output OFF" />
+  <macro id="446" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 19 Output OFF" />
+  <macro id="447" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 20 Output OFF" />
+  <macro id="448" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 21 Output OFF" />
+  <macro id="449" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 22 Output OFF" />
+  <macro id="450" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 23 Output OFF" />
+  <macro id="451" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 24 Output OFF" />
+  <macro id="452" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 25 Output OFF" />
+  <macro id="453" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 26 Output OFF" />
+  <macro id="454" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 27 Output OFF" />
+  <macro id="455" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 28 Output OFF" />
+  <macro id="456" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 29 Output OFF" />
+  <macro id="457" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 30 Output OFF" />
+  <macro id="458" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 31 Output OFF" />
+  <macro id="459" versions="7.39 7.60 7.61 7.611 7.612" description="Extended Logic 32 Output OFF" />
+  <macro id="460" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 41" />
+  <macro id="461" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 42" />
+  <macro id="462" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 43" />
+  <macro id="463" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 44" />
+  <macro id="464" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 45" />
+  <macro id="465" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 46" />
+  <macro id="466" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 47" />
+  <macro id="467" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 48" />
+  <macro id="468" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 49" />
+  <macro id="469" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 50" />
+  <macro id="470" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 51" />
+  <macro id="471" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 52" />
+  <macro id="472" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 53" />
+  <macro id="473" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 54" />
+  <macro id="474" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 55" />
+  <macro id="475" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 56" />
+  <macro id="476" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 57" />
+  <macro id="477" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 58" />
+  <macro id="478" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 59" />
+  <macro id="479" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 60" />
+  <macro id="480" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 61" />
+  <macro id="481" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 62" />
+  <macro id="482" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 63" />
+  <macro id="483" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 64" />
+  <macro id="484" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 65" />
+  <macro id="485" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 66" />
+  <macro id="486" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 67" />
+  <macro id="487" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 68" />
+  <macro id="488" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 69" />
+  <macro id="489" versions="7.39 7.60 7.61 7.611 7.612" description="Play Message Macro 70" />
+  <macro id="490" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 11" />
+  <macro id="491" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 12" />
+  <macro id="492" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 13" />
+  <macro id="493" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 14" />
+  <macro id="494" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 15" />
+  <macro id="495" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 16" />
+  <macro id="496" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 17" />
+  <macro id="497" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 18" />
+  <macro id="498" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 19" />
+  <macro id="499" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 20" />
+  <macro id="500" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 21" />
+  <macro id="501" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 22" />
+  <macro id="502" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 23" />
+  <macro id="503" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 24" />
+  <macro id="504" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 25" />
+  <macro id="505" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 26" />
+  <macro id="506" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 27" />
+  <macro id="507" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 28" />
+  <macro id="508" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 29" />
+  <macro id="509" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 30" />
+  <macro id="511" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 31" />
+  <macro id="512" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 32" />
+  <macro id="513" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 33" />
+  <macro id="514" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 34" />
+  <macro id="515" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 35" />
+  <macro id="516" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 36" />
+  <macro id="517" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 37" />
+  <macro id="518" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 38" />
+  <macro id="519" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 39" />
+  <macro id="520" versions="7.39 7.60 7.61 7.611 7.612" description="Remote Base Memory 40" />
+  <macro id="521" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 21" />
+  <macro id="522" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 22" />
+  <macro id="523" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 23" />
+  <macro id="524" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 24" />
+  <macro id="525" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 25" />
+  <macro id="526" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 26" />
+  <macro id="527" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 27" />
+  <macro id="528" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 28" />
+  <macro id="529" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 29" />
+  <macro id="530" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 30" />
+  <macro id="531" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 31" />
+  <macro id="532" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 32" />
+  <macro id="533" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 33" />
+  <macro id="534" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 34" />
+  <macro id="535" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 35" />
+  <macro id="536" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 36" />
+  <macro id="537" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 37" />
+  <macro id="538" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 38" />
+  <macro id="539" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 39" />
+  <macro id="540" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 40" />
+  <macro id="541" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 41" />
+  <macro id="542" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 42" />
+  <macro id="543" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 43" />
+  <macro id="544" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 44" />
+  <macro id="545" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 45" />
+  <macro id="546" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 46" />
+  <macro id="547" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 47" />
+  <macro id="548" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 48" />
+  <macro id="549" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 49" />
+  <macro id="550" versions="7.39 7.60 7.61 7.611 7.612" description="Send DTMF Memory 50" />
+  <macro id="551" versions="7.39 7.60 7.61 7.611 7.612" description="Get RTC Time and Date" />
+  <macro id="552" versions="7.39 7.60 7.61 7.611 7.612" description="CTCSS During ID ON" />
+  <macro id="553" versions="7.39 7.60 7.61 7.611 7.612" description="CTCSS During ID OFF" />
+  <macro id="554" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Time Transmitter Active since Last Reset" />
+  <macro id="555" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Time Transmitter Active since Last Reset" />
+  <macro id="556" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Time Transmitter Active since Last Reset" />
+  <macro id="557" versions="7.39 7.60 7.61 7.611 7.612" description="Reset Port 1 Transmitter Activity Timer" />
+  <macro id="558" versions="7.39 7.60 7.61 7.611 7.612" description="Reset Port 2 Transmitter Activity Timer" />
+  <macro id="559" versions="7.39 7.60 7.61 7.611 7.612" description="Reset Port 3 Transmitter Activity Timer" />
+  <macro id="560" versions="7.39 7.60 7.61 7.611 7.612" description="Give RSSI Report" />
+  <macro id="561" versions="7.39 7.60 7.61 7.611 7.612" description="Restart Controller" />
+  <macro id="562" versions="7.39 7.60 7.61 7.611 7.612" description="Readback Number of Keyups Port 1" />
+  <macro id="563" versions="7.39 7.60 7.61 7.611 7.612" description="Readback Number of Keyups Port 2" />
+  <macro id="564" versions="7.39 7.60 7.61 7.611 7.612" description="Readback Number of Keyups Port 3" />
+  <macro id="565" versions="7.39 7.60 7.61 7.611 7.612" description="Reset Keyup Counter Port 1" />
+  <macro id="566" versions="7.39 7.60 7.61 7.611 7.612" description="Reset Keyup Counter Port 2" />
+  <macro id="567" versions="7.39 7.60 7.61 7.611 7.612" description="Reset Keyup Counter Port 3" />
+  <macro id="570" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="571" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="572" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="573" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="574" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="575" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="576" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="577" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="578" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 1 Stored High" />
+  <macro id="579" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 2 Stored High" />
+  <macro id="580" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 3 Stored High" />
+  <macro id="581" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 4 Stored High" />
+  <macro id="582" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 5 Stored High" />
+  <macro id="583" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 6 Stored High" />
+  <macro id="584" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 7 Stored High" />
+  <macro id="585" versions="7.39 7.60 7.61 7.611 7.612" description="Readback A/D Channel 8 Stored High" />
+  <macro id="586" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="592" versions="7.39 7.60 7.61 7.611 7.612" description="Current wind speed and direction" />
+  <macro id="593" versions="7.39 7.60 7.61 7.611 7.612" description="Current Outdoor temperature" />
+  <macro id="594" versions="7.39 7.60 7.61 7.611 7.612" description="Indoor humidity" />
+  <macro id="595" versions="7.39 7.60 7.61 7.611 7.612" description="Outdoor humidity" />
+  <macro id="596" versions="7.39 7.60 7.61 7.611 7.612" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="597" versions="7.39 7.60 7.61 7.611 7.612" description="Outdoor Temp High (since Midnight)" />
+  <macro id="598" versions="7.39 7.60 7.61 7.611 7.612" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="605" versions="7.39 7.60 7.61 7.611 7.612" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="606" versions="7.39 7.60 7.61 7.611 7.612" description="Start General Timer 4" />
+  <macro id="607" versions="7.39 7.60 7.61 7.611 7.612" description="Start General Timer 5" />
+  <macro id="608" versions="7.39 7.60 7.61 7.611 7.612" description="Start General Timer 6" />
+  <macro id="609" versions="7.39 7.60 7.61 7.611 7.612" description="Stop General Timer 4" />
+  <macro id="610" versions="7.39 7.60 7.61 7.611 7.612" description="Stop General Timer 5" />
+  <macro id="611" versions="7.39 7.60 7.61 7.611 7.612" description="Stop General Timer 6" />
+  <macro id="612" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Port 1 Inactivity Timer" />
+  <macro id="613" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Port 2 Inactivity Timer" />
+  <macro id="614" versions="7.39 7.60 7.61 7.611 7.612" description="Disable Port 3 Inactivity Timer" />
+  <macro id="615" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="7.39 7.60 7.61 7.611 7.612" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="618" versions="7.39 7.60 7.61 7.611 7.612" description="1 Second Execution Delay" />
+  <macro id="619" versions="7.39 7.60 7.61 7.611 7.612" description="2 Second Execution Delay" />
+  <macro id="620" versions="7.39 7.60 7.61 7.611 7.612" description="4 Second Execution Delay" />
+  <macro id="621" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Hangtimer 1 Select" />
+  <macro id="622" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Hangtimer 2 Select" />
+  <macro id="623" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Hangtimer 3 Select" />
+  <macro id="624" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Hangtimer 1 Select" />
+  <macro id="625" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Hangtimer 2 Select" />
+  <macro id="626" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Hangtimer 3 Select" />
+  <macro id="627" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Hangtimer 1 Select" />
+  <macro id="628" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Hangtimer 2 Select" />
+  <macro id="629" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Hangtimer 3 Select" />
+  <macro id="630" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 1" />
+  <macro id="631" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 2" />
+  <macro id="632" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 3" />
+  <macro id="633" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 4" />
+  <macro id="634" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 5" />
+  <macro id="635" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 6" />
+  <macro id="636" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 7" />
+  <macro id="637" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 8" />
+  <macro id="638" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 9" />
+  <macro id="639" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Next Courtesy Tone 10" />
+  <macro id="640" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 1" />
+  <macro id="641" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 2" />
+  <macro id="642" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 3" />
+  <macro id="643" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 4" />
+  <macro id="644" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 5" />
+  <macro id="645" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 6" />
+  <macro id="646" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 7" />
+  <macro id="647" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 8" />
+  <macro id="648" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 9" />
+  <macro id="649" versions="7.39 7.60 7.61 7.611 7.612" description="Port 1 Following Courtesy Tone 10" />
+  <macro id="650" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="651" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone1" />
+  <macro id="652" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone2" />
+  <macro id="653" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="654" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="655" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="656" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="657" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="658" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone" />
+  <macro id="659" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Next Courtesy Tone 10" />
+  <macro id="660" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 1" />
+  <macro id="661" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 2" />
+  <macro id="662" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 3" />
+  <macro id="663" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 4" />
+  <macro id="664" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 5" />
+  <macro id="665" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 6" />
+  <macro id="666" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 7" />
+  <macro id="667" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 8" />
+  <macro id="668" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 9" />
+  <macro id="669" versions="7.39 7.60 7.61 7.611 7.612" description="Port 2 Following Courtesy Tone 10" />
+  <macro id="670" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 1" />
+  <macro id="671" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 2" />
+  <macro id="672" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 3" />
+  <macro id="673" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 4" />
+  <macro id="674" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 5" />
+  <macro id="675" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 6" />
+  <macro id="676" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 7" />
+  <macro id="677" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 8" />
+  <macro id="678" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 9" />
+  <macro id="679" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Next Courtesy Tone 10" />
+  <macro id="681" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="682" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="683" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 4" />
+  <macro id="684" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 5" />
+  <macro id="685" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 6" />
+  <macro id="686" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 7" />
+  <macro id="687" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 8" />
+  <macro id="688" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 9" />
+  <macro id="689" versions="7.39 7.60 7.61 7.611 7.612" description="Port 3 Following Courtesy Tone 10" />
+  <macro id="692" versions="7.39 7.60 7.61 7.611 7.612" description="Play Port 1 Pending ID" />
+  <macro id="693" versions="7.39 7.60 7.61 7.611 7.612" description="Play Port 2 Pending ID" />
+  <macro id="694" versions="7.39 7.60 7.61 7.611 7.612" description="Play Port 3 Pending ID" />
+  <macro id="810" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 1" />
+  <macro id="811" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 2" />
+  <macro id="812" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 3" />
+  <macro id="813" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 4" />
+  <macro id="814" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 5" />
+  <macro id="815" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 6" />
+  <macro id="816" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 7" />
+  <macro id="817" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 8" />
+  <macro id="818" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 9" />
+  <macro id="819" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 10" />
+  <macro id="820" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 11" />
+  <macro id="821" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 12" />
+  <macro id="822" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 13" />
+  <macro id="823" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 14" />
+  <macro id="824" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 15" />
+  <macro id="825" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 16" />
+  <macro id="826" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 17" />
+  <macro id="827" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 18" />
+  <macro id="828" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 19" />
+  <macro id="829" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 20" />
+  <macro id="830" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 21" />
+  <macro id="831" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 22" />
+  <macro id="832" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 23" />
+  <macro id="833" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 24" />
+  <macro id="834" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 25" />
+  <macro id="835" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 26" />
+  <macro id="836" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 27" />
+  <macro id="837" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 28" />
+  <macro id="838" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 29" />
+  <macro id="839" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 30" />
+  <macro id="840" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 31" />
+  <macro id="841" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 32" />
+  <macro id="842" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 33" />
+  <macro id="843" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 34" />
+  <macro id="844" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 35" />
+  <macro id="845" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 36" />
+  <macro id="846" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 37" />
+  <macro id="847" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 38" />
+  <macro id="848" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 39" />
+  <macro id="849" versions="7.39 7.60 7.61 7.611 7.612" description="Suspend Scheduler Setpoint 40" />
+  <macro id="850" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 1" />
+  <macro id="851" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 2" />
+  <macro id="852" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 3" />
+  <macro id="853" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 4" />
+  <macro id="854" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 5" />
+  <macro id="355" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 6" />
+  <macro id="856" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 7" />
+  <macro id="857" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 8" />
+  <macro id="858" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 9" />
+  <macro id="859" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 10" />
+  <macro id="860" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 11" />
+  <macro id="861" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 12" />
+  <macro id="862" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 13" />
+  <macro id="863" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 14" />
+  <macro id="864" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 15" />
+  <macro id="865" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 16" />
+  <macro id="866" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 17" />
+  <macro id="867" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 18" />
+  <macro id="868" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 19" />
+  <macro id="869" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 20" />
+  <macro id="870" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 21" />
+  <macro id="871" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 22" />
+  <macro id="872" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 23" />
+  <macro id="873" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 24" />
+  <macro id="874" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 25" />
+  <macro id="875" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 26" />
+  <macro id="876" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 27" />
+  <macro id="877" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 28" />
+  <macro id="878" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 29" />
+  <macro id="879" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 30" />
+  <macro id="880" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 31" />
+  <macro id="881" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 32" />
+  <macro id="882" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 33" />
+  <macro id="883" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 34" />
+  <macro id="884" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 35" />
+  <macro id="885" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 36" />
+  <macro id="886" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 37" />
+  <macro id="887" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 38" />
+  <macro id="888" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 39" />
+  <macro id="889" versions="7.39 7.60 7.61 7.611 7.612" description="Resume Scheduler Setpoint 40" />
+  <macro id="901" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 1" />
+  <macro id="902" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 2" />
+  <macro id="903" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 3" />
+  <macro id="904" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 4" />
+  <macro id="905" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 5" />
+  <macro id="906" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 6" />
+  <macro id="907" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 7" />
+  <macro id="908" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 8" />
+  <macro id="909" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 9" />
+  <macro id="910" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 10" />
+  <macro id="911" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 11" />
+  <macro id="912" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 12" />
+  <macro id="913" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 13" />
+  <macro id="914" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 14" />
+  <macro id="915" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 15" />
+  <macro id="916" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 16" />
+  <macro id="917" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 17" />
+  <macro id="918" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 18" />
+  <macro id="919" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 19" />
+  <macro id="920" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 20" />
+  <macro id="921" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 21" />
+  <macro id="922" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 22" />
+  <macro id="923" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 23" />
+  <macro id="924" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 24" />
+  <macro id="925" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 25" />
+  <macro id="926" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 26" />
+  <macro id="927" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 27" />
+  <macro id="928" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 28" />
+  <macro id="929" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 29" />
+  <macro id="930" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 30" />
+  <macro id="931" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 31" />
+  <macro id="932" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 32" />
+  <macro id="933" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 33" />
+  <macro id="934" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 34" />
+  <macro id="935" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 35" />
+  <macro id="936" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 36" />
+  <macro id="937" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 37" />
+  <macro id="938" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 38" />
+  <macro id="939" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 39" />
+  <macro id="940" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 40" />
+  <macro id="941" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 41" />
+  <macro id="942" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 42" />
+  <macro id="943" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 43" />
+  <macro id="944" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 44" />
+  <macro id="945" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 45" />
+  <macro id="946" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 46" />
+  <macro id="947" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 47" />
+  <macro id="948" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 48" />
+  <macro id="949" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 49" />
+  <macro id="950" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 50" />
+  <macro id="951" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 51" />
+  <macro id="952" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 52" />
+  <macro id="953" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 53" />
+  <macro id="954" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 54" />
+  <macro id="955" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 55" />
+  <macro id="956" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 56" />
+  <macro id="957" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 57" />
+  <macro id="958" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 58" />
+  <macro id="959" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 59" />
+  <macro id="960" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 60" />
+  <macro id="961" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 61" />
+  <macro id="962" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 62" />
+  <macro id="963" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 63" />
+  <macro id="964" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 64" />
+  <macro id="965" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 65" />
+  <macro id="966" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 66" />
+  <macro id="967" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 67" />
+  <macro id="968" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 68" />
+  <macro id="969" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 69" />
+  <macro id="970" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 70" />
+  <macro id="971" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 71" />
+  <macro id="972" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 72" />
+  <macro id="973" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 73" />
+  <macro id="974" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 74" />
+  <macro id="975" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 75" />
+  <macro id="976" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 76" />
+  <macro id="977" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 77" />
+  <macro id="978" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 78" />
+  <macro id="979" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 79" />
+  <macro id="980" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 80" />
+  <macro id="981" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 81" />
+  <macro id="982" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 82" />
+  <macro id="983" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 83" />
+  <macro id="984" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 84" />
+  <macro id="985" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 85" />
+  <macro id="986" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 86" />
+  <macro id="987" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 87" />
+  <macro id="988" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 88" />
+  <macro id="989" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 89" />
+  <macro id="990" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 90" />
+  <macro id="991" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 91" />
+  <macro id="992" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 92" />
+  <macro id="993" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 93" />
+  <macro id="994" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 94" />
+  <macro id="995" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 95" />
+  <macro id="996" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 96" />
+  <macro id="997" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 97" />
+  <macro id="998" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 98" />
+  <macro id="999" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 99" />
+  <macro id="1000" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 100" />
+  <macro id="1001" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 101" />
+  <macro id="1002" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 102" />
+  <macro id="1003" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 103" />
+  <macro id="1004" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 104" />
+  <macro id="1005" versions="7.39 7.60 7.61 7.611 7.612" description="Call Macro 105" />
 </macros>

--- a/XML/Ver9_macro_def.xml
+++ b/XML/Ver9_macro_def.xml
@@ -1,0 +1,867 @@
+<macros version="4.000">
+  <macro id="1" versions="7.63 7.635 7.636 7.64" description="Port 1 CTCSS Access" />
+  <macro id="2" versions="7.63 7.635 7.636 7.64" description="Port 2 CTCSS Access" />
+  <macro id="3" versions="7.63 7.635 7.636 7.64" description="Port 3 CTCSS Access" />
+  <macro id="4" versions="7.63 7.635 7.636 7.64" description="Port 1 Carrier Access" />
+  <macro id="5" versions="7.63 7.635 7.636 7.64" description="Port 2 Carrier Access" />
+  <macro id="6" versions="7.63 7.635 7.636 7.64" description="Port 3 Carrier Access" />
+  <macro id="7" versions="7.63 7.635 7.636 7.64" description="Port 1 DTMF Covertone ON" />
+  <macro id="8" versions="7.63 7.635 7.636 7.64" description="Port 2 DTMF Covertone ON" />
+  <macro id="9" versions="7.63 7.635 7.636 7.64" description="Port 3 DTMF Covertone ON" />
+  <macro id="10" versions="7.63 7.635 7.636 7.64" description="Port 1 DTMF Covertone OFF" />
+  <macro id="11" versions="7.63 7.635 7.636 7.64" description="Port 2 DTMF Covertone OFF" />
+  <macro id="12" versions="7.63 7.635 7.636 7.64" description="Port 3 DTMF Covertone OFF" />
+  <macro id="13" versions="7.63 7.635 7.636 7.64" description="Port 1 Enable" />
+  <macro id="14" versions="7.63 7.635 7.636 7.64" description="Port 2 Enable" />
+  <macro id="15" versions="7.63 7.635 7.636 7.64" description="Port 3 Enable" />
+  <macro id="16" versions="7.63 7.635 7.636 7.64" description="Port 1 Disable" />
+  <macro id="17" versions="7.63 7.635 7.636 7.64" description="Port 2 Disable" />
+  <macro id="18" versions="7.63 7.635 7.636 7.64" description="Port 3 Disable" />
+  <macro id="19" versions="7.63 7.635 7.636 7.64" description="Monitor Port 1 from Port 2" />
+  <macro id="20" versions="7.63 7.635 7.636 7.64" description="Monitor Port 1 from Port 3" />
+  <macro id="21" versions="7.63 7.635 7.636 7.64" description="Disconnect Port 1 from Port 2" />
+  <macro id="22" versions="7.63 7.635 7.636 7.64" description="Disconnect Port 1 from Port 3" />
+  <macro id="23" versions="7.63 7.635 7.636 7.64" description="Monitor Port 2 from Port 1" />
+  <macro id="24" versions="7.63 7.635 7.636 7.64" description="Monitor Port 2 from Port 3" />
+  <macro id="25" versions="7.63 7.635 7.636 7.64" description="Disconnect Port 2 from Port 1" />
+  <macro id="26" versions="7.63 7.635 7.636 7.64" description="Disconnect Port 2 from Port 3" />
+  <macro id="27" versions="7.63 7.635 7.636 7.64" description="Monitor Port 3 from Port 1" />
+  <macro id="28" versions="7.63 7.635 7.636 7.64" description="Monitor Port 3 from Port 2" />
+  <macro id="29" versions="7.63 7.635 7.636 7.64" description="Disconnect Port 3 from Port 1" />
+  <macro id="30" versions="7.63 7.635 7.636 7.64" description="Disconnect Port 3 from Port 2" />
+  <macro id="31" versions="7.63 7.635 7.636 7.64" description="Port 1 Monitor Mute" />
+  <macro id="32" versions="7.63 7.635 7.636 7.64" description="Port 2 Monitor Mute" />
+  <macro id="33" versions="7.63 7.635 7.636 7.64" description="Port 3 Monitor Mute" />
+  <macro id="34" versions="7.63 7.635 7.636 7.64" description="Port 1 Monitor Mix" />
+  <macro id="35" versions="7.63 7.635 7.636 7.64" description="Port 2 Monitor Mix" />
+  <macro id="36" versions="7.63 7.635 7.636 7.64" description="Port 3 Monitor Mix" />
+  <macro id="37" versions="7.63 7.635 7.636 7.64" description="Port 1 Repeat ON" />
+  <macro id="38" versions="7.63 7.635 7.636 7.64" description="Port 2 Repeat ON" />
+  <macro id="39" versions="7.63 7.635 7.636 7.64" description="Port 3 Repeat ON" />
+  <macro id="40" versions="7.63 7.635 7.636 7.64" description="Port 1 Repeat OFF" />
+  <macro id="41" versions="7.63 7.635 7.636 7.64" description="Port 2 Repeat OFF" />
+  <macro id="42" versions="7.63 7.635 7.636 7.64" description="Port 3 Repeat OFF" />
+  <macro id="43" versions="7.63 7.635 7.636 7.64" description="Port 1 Speech OverrideON" />
+  <macro id="44" versions="7.63 7.635 7.636 7.64" description="Port 2 Speech OverrideON" />
+  <macro id="45" versions="7.63 7.635 7.636 7.64" description="Port 3 Speech OverrideON" />
+  <macro id="46" versions="7.63 7.635 7.636 7.64" description="Port 1 Speech Override OFF" />
+  <macro id="47" versions="7.63 7.635 7.636 7.64" description="Port 2 Speech Override OFF" />
+  <macro id="48" versions="7.63 7.635 7.636 7.64" description="Port 3 Speech Override OFF" />
+  <macro id="49" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 1" />
+  <macro id="50" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 2" />
+  <macro id="51" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 3" />
+  <macro id="52" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 4" />
+  <macro id="53" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 5" />
+  <macro id="54" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 6" />
+  <macro id="55" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 7" />
+  <macro id="56" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 8" />
+  <macro id="57" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 9" />
+  <macro id="58" versions="7.63 7.635 7.636 7.64" description="Port 1 Courtesy Tone 10" />
+  <macro id="59" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 1" />
+  <macro id="60" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 2" />
+  <macro id="61" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 3" />
+  <macro id="62" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 4" />
+  <macro id="63" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 5" />
+  <macro id="64" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 6" />
+  <macro id="65" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 7" />
+  <macro id="66" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 8" />
+  <macro id="67" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 9" />
+  <macro id="68" versions="7.63 7.635 7.636 7.64" description="Port 2 Courtesy Tone 10" />
+  <macro id="69" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 1" />
+  <macro id="70" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 2" />
+  <macro id="71" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 3" />
+  <macro id="72" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 4" />
+  <macro id="73" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 5" />
+  <macro id="74" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 6" />
+  <macro id="75" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 7" />
+  <macro id="76" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 8" />
+  <macro id="77" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 9" />
+  <macro id="78" versions="7.63 7.635 7.636 7.64" description="Port 3 Courtesy Tone 10" />
+  <macro id="79" versions="7.63 7.635 7.636 7.64" description="Port 1 DTMF Muting ON" />
+  <macro id="80" versions="7.63 7.635 7.636 7.64" description="Port 2 DTMF Muting ON" />
+  <macro id="81" versions="7.63 7.635 7.636 7.64" description="Port 3 DTMF Muting ON" />
+  <macro id="82" versions="7.63 7.635 7.636 7.64" description="Port 1 DTMF Muting OFF" />
+  <macro id="83" versions="7.63 7.635 7.636 7.64" description="Port 2 DTMF Muting OFF" />
+  <macro id="84" versions="7.63 7.635 7.636 7.64" description="Port 3 DTMF Muting OFF" />
+  <macro id="85" versions="7.63 7.635 7.636 7.64" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="86" versions="7.63 7.635 7.636 7.64" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="87" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 1" />
+  <macro id="88" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 2" />
+  <macro id="89" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 3" />
+  <macro id="90" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 4" />
+  <macro id="91" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 5" />
+  <macro id="92" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 6" />
+  <macro id="93" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 7" />
+  <macro id="94" versions="7.63 7.635 7.636 7.64" description="Read ADC Channel 8" />
+  <macro id="95" versions="7.63 7.635 7.636 7.64" description="UF1 ON" />
+  <macro id="96" versions="7.63 7.635 7.636 7.64" description="UF2 ON" />
+  <macro id="97" versions="7.63 7.635 7.636 7.64" description="UF3 ON" />
+  <macro id="98" versions="7.63 7.635 7.636 7.64" description="UF4 ON" />
+  <macro id="99" versions="7.63 7.635 7.636 7.64" description="UF5 ON" />
+  <macro id="100" versions="7.63 7.635 7.636 7.64" description="UF6 ON" />
+  <macro id="101" versions="7.63 7.635 7.636 7.64" description="UF7 ON" />
+  <macro id="102" versions="7.63 7.635 7.636 7.64" description="UF1 OFF" />
+  <macro id="103" versions="7.63 7.635 7.636 7.64" description="UF2 OFF" />
+  <macro id="104" versions="7.63 7.635 7.636 7.64" description="UF3 OFF" />
+  <macro id="105" versions="7.63 7.635 7.636 7.64" description="UF4 OFF" />
+  <macro id="106" versions="7.63 7.635 7.636 7.64" description="UF5 OFF" />
+  <macro id="107" versions="7.63 7.635 7.636 7.64" description="UF6 OFF" />
+  <macro id="108" versions="7.63 7.635 7.636 7.64" description="UF7 OFF" />
+  <macro id="109" versions="7.63 7.635 7.636 7.64" description="UF1 Pulse" />
+  <macro id="110" versions="7.63 7.635 7.636 7.64" description="UF2 Pulse" />
+  <macro id="111" versions="7.63 7.635 7.636 7.64" description="UF3 Pulse" />
+  <macro id="112" versions="7.63 7.635 7.636 7.64" description="UF4 Pulse" />
+  <macro id="113" versions="7.63 7.635 7.636 7.64" description="UF5 Pulse" />
+  <macro id="114" versions="7.63 7.635 7.636 7.64" description="UF6 Pulse" />
+  <macro id="115" versions="7.63 7.635 7.636 7.64" description="UF7 Pulse" />
+  <macro id="116" versions="7.63 7.635 7.636 7.64" description="Say Time" />
+  <macro id="117" versions="7.63 7.635 7.636 7.64" description="Say Date" />
+  <macro id="118" versions="7.63 7.635 7.636 7.64" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="7.63 7.635 7.636 7.64" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="7.63 7.635 7.636 7.64" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="7.63 7.635 7.636 7.64" description="Link All Ports" />
+  <macro id="122" versions="7.63 7.635 7.636 7.64" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="7.63 7.635 7.636 7.64" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="7.63 7.635 7.636 7.64" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="7.63 7.635 7.636 7.64" description="UnLink All Ports" />
+  <macro id="126" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 1" />
+  <macro id="127" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 2" />
+  <macro id="128" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 3" />
+  <macro id="129" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 4" />
+  <macro id="130" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 5" />
+  <macro id="131" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 6" />
+  <macro id="132" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 7" />
+  <macro id="133" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 8" />
+  <macro id="134" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 9" />
+  <macro id="135" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 10" />
+  <macro id="136" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 11" />
+  <macro id="137" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 12" />
+  <macro id="138" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 13" />
+  <macro id="139" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 14" />
+  <macro id="140" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 15" />
+  <macro id="141" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 16" />
+  <macro id="142" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 17" />
+  <macro id="143" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 18" />
+  <macro id="144" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 19" />
+  <macro id="145" versions="7.63 7.635 7.636 7.64" description="Play DVR Track 20" />
+  <macro id="146" versions="7.63 7.635 7.636 7.64" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="7.63 7.635 7.636 7.64" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="7.63 7.635 7.636 7.64" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="7.63 7.635 7.636 7.64" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="7.63 7.635 7.636 7.64" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="7.63 7.635 7.636 7.64" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="7.63 7.635 7.636 7.64" description="Alarm 1 ON" />
+  <macro id="153" versions="7.63 7.635 7.636 7.64" description="Alarm 2 ON" />
+  <macro id="154" versions="7.63 7.635 7.636 7.64" description="Alarm 3 ON" />
+  <macro id="155" versions="7.63 7.635 7.636 7.64" description="Alarm 4 ON" />
+  <macro id="156" versions="7.63 7.635 7.636 7.64" description="Alarm 5 ON" />
+  <macro id="157" versions="7.63 7.635 7.636 7.64" description="Alarm 1 OFF" />
+  <macro id="158" versions="7.63 7.635 7.636 7.64" description="Alarm 2 OFF" />
+  <macro id="159" versions="7.63 7.635 7.636 7.64" description="Alarm 3 OFF" />
+  <macro id="160" versions="7.63 7.635 7.636 7.64" description="Alarm 4 OFF" />
+  <macro id="161" versions="7.63 7.635 7.636 7.64" description="Alarm 5 OFF" />
+  <macro id="162" versions="7.63 7.635 7.636 7.64" description="Speech Out Port 1" />
+  <macro id="163" versions="7.63 7.635 7.636 7.64" description="Speech Out Port 2" />
+  <macro id="164" versions="7.63 7.635 7.636 7.64" description="Speech Out Port 3" />
+  <macro id="165" versions="7.63 7.635 7.636 7.64" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="7.63 7.635 7.636 7.64" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="7.63 7.635 7.636 7.64" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="7.63 7.635 7.636 7.64" description="Speech Out All Ports" />
+  <macro id="169" versions="7.63 7.635 7.636 7.64" description="DTMF Enable Port 1" />
+  <macro id="170" versions="7.63 7.635 7.636 7.64" description="DTMF Enable Port 2" />
+  <macro id="171" versions="7.63 7.635 7.636 7.64" description="DTMF Enable Port 3" />
+  <macro id="172" versions="7.63 7.635 7.636 7.64" description="DTMF Disable Port 1" />
+  <macro id="173" versions="7.63 7.635 7.636 7.64" description="DTMF Disable Port 2" />
+  <macro id="174" versions="7.63 7.635 7.636 7.64" description="DTMF Disable Port 3" />
+  <macro id="175" versions="7.63 7.635 7.636 7.64" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="7.63 7.635 7.636 7.64" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="7.63 7.635 7.636 7.64" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="7.63 7.635 7.636 7.64" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="7.63 7.635 7.636 7.64" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="7.63 7.635 7.636 7.64" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="7.63 7.635 7.636 7.64" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="7.63 7.635 7.636 7.64" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="7.63 7.635 7.636 7.64" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="7.63 7.635 7.636 7.64" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="7.63 7.635 7.636 7.64" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="7.63 7.635 7.636 7.64" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 1" />
+  <macro id="188" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 2" />
+  <macro id="189" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 3" />
+  <macro id="190" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 4" />
+  <macro id="191" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 5" />
+  <macro id="192" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 6" />
+  <macro id="193" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 7" />
+  <macro id="194" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 8" />
+  <macro id="195" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 9" />
+  <macro id="196" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 10" />
+  <macro id="197" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 11" />
+  <macro id="198" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 12" />
+  <macro id="199" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 13" />
+  <macro id="200" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 14" />
+  <macro id="201" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 15" />
+  <macro id="202" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 16" />
+  <macro id="203" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 17" />
+  <macro id="204" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 18" />
+  <macro id="205" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 19" />
+  <macro id="206" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 20" />
+  <macro id="207" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 21" />
+  <macro id="208" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 22" />
+  <macro id="209" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 23" />
+  <macro id="210" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 24" />
+  <macro id="211" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 25" />
+  <macro id="212" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 26" />
+  <macro id="213" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 27" />
+  <macro id="214" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 28" />
+  <macro id="215" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 29" />
+  <macro id="216" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 30" />
+  <macro id="217" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 31" />
+  <macro id="218" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 32" />
+  <macro id="219" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 33" />
+  <macro id="220" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 34" />
+  <macro id="221" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 35" />
+  <macro id="222" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 36" />
+  <macro id="223" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 37" />
+  <macro id="224" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 38" />
+  <macro id="225" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 39" />
+  <macro id="226" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 40" />
+  <macro id="227" versions="7.63 7.635 7.636 7.64" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="7.63 7.635 7.636 7.64" description="Macro Priority High" />
+  <macro id="229" versions="7.63 7.635 7.636 7.64" description="Macro Priority Low" />
+  <macro id="230" versions="7.63 7.635 7.636 7.64" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="7.63 7.635 7.636 7.64" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="7.63 7.635 7.636 7.64" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="7.63 7.635 7.636 7.64" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="7.63 7.635 7.636 7.64" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="7.63 7.635 7.636 7.64" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="7.63 7.635 7.636 7.64" description="Enable Receiver Port 1" />
+  <macro id="237" versions="7.63 7.635 7.636 7.64" description="Enable Receiver Port 2" />
+  <macro id="238" versions="7.63 7.635 7.636 7.64" description="Enable Receiver Port 3" />
+  <macro id="239" versions="7.63 7.635 7.636 7.64" description="Disable Receiver Port 1" />
+  <macro id="240" versions="7.63 7.635 7.636 7.64" description="Disable Receiver Port 2" />
+  <macro id="241" versions="7.63 7.635 7.636 7.64" description="Disable Receiver Port 3" />
+  <macro id="242" versions="7.63 7.635 7.636 7.64" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="7.63 7.635 7.636 7.64" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="7.63 7.635 7.636 7.64" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="7.63 7.635 7.636 7.64" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="7.63 7.635 7.636 7.64" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="7.63 7.635 7.636 7.64" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="7.63 7.635 7.636 7.64" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="7.63 7.635 7.636 7.64" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="7.63 7.635 7.636 7.64" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="7.63 7.635 7.636 7.64" description="Force Audio To Entered Port" />
+  <macro id="252" versions="7.63 7.635 7.636 7.64" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="7.63 7.635 7.636 7.64" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="7.63 7.635 7.636 7.64" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="7.63 7.635 7.636 7.64" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="7.63 7.635 7.636 7.64" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="7.63 7.635 7.636 7.64" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 1" />
+  <macro id="260" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 2" />
+  <macro id="261" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 3" />
+  <macro id="262" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 4" />
+  <macro id="263" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 5" />
+  <macro id="264" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 6" />
+  <macro id="265" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 7" />
+  <macro id="266" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 8" />
+  <macro id="267" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 9" />
+  <macro id="268" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 10" />
+  <macro id="269" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 11" />
+  <macro id="270" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 12" />
+  <macro id="271" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 13" />
+  <macro id="272" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 14" />
+  <macro id="273" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 15" />
+  <macro id="274" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 16" />
+  <macro id="275" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 17" />
+  <macro id="276" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 18" />
+  <macro id="277" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 19" />
+  <macro id="278" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 20" />
+  <macro id="279" versions="7.63 7.635 7.636 7.64" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="7.63 7.635 7.636 7.64" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="7.63 7.635 7.636 7.64" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="7.63 7.635 7.636 7.64" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="7.63 7.635 7.636 7.64" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="7.63 7.635 7.636 7.64" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="7.63 7.635 7.636 7.64" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="7.63 7.635 7.636 7.64" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="7.63 7.635 7.636 7.64" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="7.63 7.635 7.636 7.64" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="7.63 7.635 7.636 7.64" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="7.63 7.635 7.636 7.64" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="7.63 7.635 7.636 7.64" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="7.63 7.635 7.636 7.64" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="7.63 7.635 7.636 7.64" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="7.63 7.635 7.636 7.64" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="7.63 7.635 7.636 7.64" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="7.63 7.635 7.636 7.64" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="7.63 7.635 7.636 7.64" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="7.63 7.635 7.636 7.64" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="7.63 7.635 7.636 7.64" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="7.63 7.635 7.636 7.64" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="7.63 7.635 7.636 7.64" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="7.63 7.635 7.636 7.64" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="7.63 7.635 7.636 7.64" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="7.63 7.635 7.636 7.64" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="7.63 7.635 7.636 7.64" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="7.63 7.635 7.636 7.64" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="7.63 7.635 7.636 7.64" description="Say year as part of date" />
+  <macro id="308" versions="7.63 7.635 7.636 7.64" description="Don't say year as part of date" />
+  <macro id="309" versions="7.63 7.635 7.636 7.64" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="7.63 7.635 7.636 7.64" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="7.63 7.635 7.636 7.64" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="7.63 7.635 7.636 7.64" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="7.63 7.635 7.636 7.64" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="7.63 7.635 7.636 7.64" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="7.63 7.635 7.636 7.64" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="7.63 7.635 7.636 7.64" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="7.63 7.635 7.636 7.64" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="7.63 7.635 7.636 7.64" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="7.63 7.635 7.636 7.64" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="7.63 7.635 7.636 7.64" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 1" />
+  <macro id="322" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 2" />
+  <macro id="323" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 3" />
+  <macro id="324" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 4" />
+  <macro id="325" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 5" />
+  <macro id="326" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 6" />
+  <macro id="327" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 7" />
+  <macro id="328" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 8" />
+  <macro id="329" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 9" />
+  <macro id="330" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 10" />
+  <macro id="331" versions="7.63 7.635 7.636 7.64" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="7.63 7.635 7.636 7.64" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="7.63 7.635 7.636 7.64" description="Port 3 Zero Hang Time Select" />
+  <macro id="336" versions="7.63 7.635 7.636 7.64" description="Dial 911" />
+  <macro id="337" versions="7.63 7.635 7.636 7.64" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="7.63 7.635 7.636 7.64" description="Disable Autopatch" />
+  <macro id="339" versions="7.63 7.635 7.636 7.64" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="7.63 7.635 7.636 7.64" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="7.63 7.635 7.636 7.64" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="7.63 7.635 7.636 7.64" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="7.63 7.635 7.636 7.64" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="7.63 7.635 7.636 7.64" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="7.63 7.635 7.636 7.64" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="7.63 7.635 7.636 7.64" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="7.63 7.635 7.636 7.64" description="Start General Timer 1" />
+  <macro id="348" versions="7.63 7.635 7.636 7.64" description="Start General Timer 2" />
+  <macro id="349" versions="7.63 7.635 7.636 7.64" description="Start General Timer 3" />
+  <macro id="350" versions="7.63 7.635 7.636 7.64" description="Stop General Timer 1" />
+  <macro id="351" versions="7.63 7.635 7.636 7.64" description="Stop General Timer 2" />
+  <macro id="352" versions="7.63 7.635 7.636 7.64" description="Stop General Timer 3" />
+  <macro id="353" versions="7.63 7.635 7.636 7.64" description="Remote Base Power Select 1" />
+  <macro id="354" versions="7.63 7.635 7.636 7.64" description="Remote Base Power Select 2" />
+  <macro id="355" versions="7.63 7.635 7.636 7.64" description="Remote Base Power Select 3" />
+  <macro id="356" versions="7.63 7.635 7.636 7.64" description="Guest Macros Enabled" />
+  <macro id="357" versions="7.63 7.635 7.636 7.64" description="Guest Macros Disabled" />
+  <macro id="358" versions="7.63 7.635 7.636 7.64" description="Receiver 1 Macros On" />
+  <macro id="359" versions="7.63 7.635 7.636 7.64" description="Receiver 2 Macros On" />
+  <macro id="360" versions="7.63 7.635 7.636 7.64" description="Receiver 3 Macros On" />
+  <macro id="361" versions="7.63 7.635 7.636 7.64" description="Receiver 1 Macros Off" />
+  <macro id="362" versions="7.63 7.635 7.636 7.64" description="Receiver 2 Macros Off" />
+  <macro id="363" versions="7.63 7.635 7.636 7.64" description="Receiver 3 Macros Off" />
+  <macro id="364" versions="7.63 7.635 7.636 7.64" description="Extended Logic 1 Output ON" />
+  <macro id="365" versions="7.63 7.635 7.636 7.64" description="Extended Logic 2 Output ON" />
+  <macro id="366" versions="7.63 7.635 7.636 7.64" description="Extended Logic 3 Output ON" />
+  <macro id="367" versions="7.63 7.635 7.636 7.64" description="Extended Logic 4 Output ON" />
+  <macro id="368" versions="7.63 7.635 7.636 7.64" description="Extended Logic 5 Output ON" />
+  <macro id="369" versions="7.63 7.635 7.636 7.64" description="Extended Logic 6 Output ON" />
+  <macro id="370" versions="7.63 7.635 7.636 7.64" description="Extended Logic 7 Output ON" />
+  <macro id="371" versions="7.63 7.635 7.636 7.64" description="Extended Logic 8 Output ON" />
+  <macro id="372" versions="7.63 7.635 7.636 7.64" description="Extended Logic 9 Output ON" />
+  <macro id="373" versions="7.63 7.635 7.636 7.64" description="Extended Logic 10 Output ON" />
+  <macro id="374" versions="7.63 7.635 7.636 7.64" description="Extended Logic 11 Output ON" />
+  <macro id="375" versions="7.63 7.635 7.636 7.64" description="Extended Logic 12 Output ON" />
+  <macro id="376" versions="7.63 7.635 7.636 7.64" description="Extended Logic 13 Output ON" />
+  <macro id="377" versions="7.63 7.635 7.636 7.64" description="Extended Logic 14 Output ON" />
+  <macro id="378" versions="7.63 7.635 7.636 7.64" description="Extended Logic 15 Output ON" />
+  <macro id="379" versions="7.63 7.635 7.636 7.64" description="Extended Logic 16 Output ON" />
+  <macro id="380" versions="7.63 7.635 7.636 7.64" description="Extended Logic 17 Output ON" />
+  <macro id="381" versions="7.63 7.635 7.636 7.64" description="Extended Logic 18 Output ON" />
+  <macro id="382" versions="7.63 7.635 7.636 7.64" description="Extended Logic 19 Output ON" />
+  <macro id="383" versions="7.63 7.635 7.636 7.64" description="Extended Logic 20 Output ON" />
+  <macro id="384" versions="7.63 7.635 7.636 7.64" description="Extended Logic 21 Output ON" />
+  <macro id="385" versions="7.63 7.635 7.636 7.64" description="Extended Logic 22 Output ON" />
+  <macro id="386" versions="7.63 7.635 7.636 7.64" description="Extended Logic 23 Output ON" />
+  <macro id="387" versions="7.63 7.635 7.636 7.64" description="Extended Logic 24 Output ON" />
+  <macro id="388" versions="7.63 7.635 7.636 7.64" description="Extended Logic 25 Output ON" />
+  <macro id="389" versions="7.63 7.635 7.636 7.64" description="Extended Logic 26 Output ON" />
+  <macro id="390" versions="7.63 7.635 7.636 7.64" description="Extended Logic 27 Output ON" />
+  <macro id="391" versions="7.63 7.635 7.636 7.64" description="Extended Logic 28 Output ON" />
+  <macro id="392" versions="7.63 7.635 7.636 7.64" description="Extended Logic 29 Output ON" />
+  <macro id="393" versions="7.63 7.635 7.636 7.64" description="Extended Logic 30 Output ON" />
+  <macro id="394" versions="7.63 7.635 7.636 7.64" description="Extended Logic 31 Output ON" />
+  <macro id="395" versions="7.63 7.635 7.636 7.64" description="Extended Logic 32 Output ON" />
+  <macro id="396" versions="7.63 7.635 7.636 7.64" description="Extended Logic 1 Output Pulse" />
+  <macro id="397" versions="7.63 7.635 7.636 7.64" description="Extended Logic 2 Output Pulse" />
+  <macro id="398" versions="7.63 7.635 7.636 7.64" description="Extended Logic 3 Output Pulse" />
+  <macro id="399" versions="7.63 7.635 7.636 7.64" description="Extended Logic 4 Output Pulse" />
+  <macro id="400" versions="7.63 7.635 7.636 7.64" description="Extended Logic 5 Output Pulse" />
+  <macro id="401" versions="7.63 7.635 7.636 7.64" description="Extended Logic 6 Output Pulse" />
+  <macro id="402" versions="7.63 7.635 7.636 7.64" description="Extended Logic 7 Output Pulse" />
+  <macro id="403" versions="7.63 7.635 7.636 7.64" description="Extended Logic 8 Output Pulse" />
+  <macro id="404" versions="7.63 7.635 7.636 7.64" description="Extended Logic 9 Output Pulse" />
+  <macro id="405" versions="7.63 7.635 7.636 7.64" description="Extended Logic 10 Output Pulse" />
+  <macro id="406" versions="7.63 7.635 7.636 7.64" description="Extended Logic 11 Output Pulse" />
+  <macro id="407" versions="7.63 7.635 7.636 7.64" description="Extended Logic 12 Output Pulse" />
+  <macro id="408" versions="7.63 7.635 7.636 7.64" description="Extended Logic 13 Output Pulse" />
+  <macro id="409" versions="7.63 7.635 7.636 7.64" description="Extended Logic 14 Output Pulse" />
+  <macro id="410" versions="7.63 7.635 7.636 7.64" description="Extended Logic 15 Output Pulse" />
+  <macro id="411" versions="7.63 7.635 7.636 7.64" description="Extended Logic 16 Output Pulse" />
+  <macro id="412" versions="7.63 7.635 7.636 7.64" description="Extended Logic 17 Output Pulse" />
+  <macro id="413" versions="7.63 7.635 7.636 7.64" description="Extended Logic 18 Output Pulse" />
+  <macro id="414" versions="7.63 7.635 7.636 7.64" description="Extended Logic 19 Output Pulse" />
+  <macro id="415" versions="7.63 7.635 7.636 7.64" description="Extended Logic 20 Output Pulse" />
+  <macro id="416" versions="7.63 7.635 7.636 7.64" description="Extended Logic 21 Output Pulse" />
+  <macro id="417" versions="7.63 7.635 7.636 7.64" description="Extended Logic 22 Output Pulse" />
+  <macro id="418" versions="7.63 7.635 7.636 7.64" description="Extended Logic 23 Output Pulse" />
+  <macro id="419" versions="7.63 7.635 7.636 7.64" description="Extended Logic 24 Output Pulse" />
+  <macro id="420" versions="7.63 7.635 7.636 7.64" description="Extended Logic 25 Output Pulse" />
+  <macro id="421" versions="7.63 7.635 7.636 7.64" description="Extended Logic 26 Output Pulse" />
+  <macro id="422" versions="7.63 7.635 7.636 7.64" description="Extended Logic 27 Output Pulse" />
+  <macro id="423" versions="7.63 7.635 7.636 7.64" description="Extended Logic 28 Output Pulse" />
+  <macro id="424" versions="7.63 7.635 7.636 7.64" description="Extended Logic 29 Output Pulse" />
+  <macro id="425" versions="7.63 7.635 7.636 7.64" description="Extended Logic 30 Output Pulse" />
+  <macro id="426" versions="7.63 7.635 7.636 7.64" description="Extended Logic 31 Output Pulse" />
+  <macro id="427" versions="7.63 7.635 7.636 7.64" description="Extended Logic 32 Output Pulse" />
+  <macro id="428" versions="7.63 7.635 7.636 7.64" description="Extended Logic 1 Output OFF" />
+  <macro id="429" versions="7.63 7.635 7.636 7.64" description="Extended Logic 2 Output OFF" />
+  <macro id="430" versions="7.63 7.635 7.636 7.64" description="Extended Logic 3 Output OFF" />
+  <macro id="431" versions="7.63 7.635 7.636 7.64" description="Extended Logic 4 Output OFF" />
+  <macro id="432" versions="7.63 7.635 7.636 7.64" description="Extended Logic 5 Output OFF" />
+  <macro id="433" versions="7.63 7.635 7.636 7.64" description="Extended Logic 6 Output OFF" />
+  <macro id="434" versions="7.63 7.635 7.636 7.64" description="Extended Logic 7 Output OFF" />
+  <macro id="435" versions="7.63 7.635 7.636 7.64" description="Extended Logic 8 Output OFF" />
+  <macro id="436" versions="7.63 7.635 7.636 7.64" description="Extended Logic 9 Output OFF" />
+  <macro id="437" versions="7.63 7.635 7.636 7.64" description="Extended Logic 10 Output OFF" />
+  <macro id="438" versions="7.63 7.635 7.636 7.64" description="Extended Logic 11 Output OFF" />
+  <macro id="439" versions="7.63 7.635 7.636 7.64" description="Extended Logic 12 Output OFF" />
+  <macro id="440" versions="7.63 7.635 7.636 7.64" description="Extended Logic 13 Output OFF" />
+  <macro id="441" versions="7.63 7.635 7.636 7.64" description="Extended Logic 14 Output OFF" />
+  <macro id="442" versions="7.63 7.635 7.636 7.64" description="Extended Logic 15 Output OFF" />
+  <macro id="443" versions="7.63 7.635 7.636 7.64" description="Extended Logic 16 Output OFF" />
+  <macro id="444" versions="7.63 7.635 7.636 7.64" description="Extended Logic 17 Output OFF" />
+  <macro id="445" versions="7.63 7.635 7.636 7.64" description="Extended Logic 18 Output OFF" />
+  <macro id="446" versions="7.63 7.635 7.636 7.64" description="Extended Logic 19 Output OFF" />
+  <macro id="447" versions="7.63 7.635 7.636 7.64" description="Extended Logic 20 Output OFF" />
+  <macro id="448" versions="7.63 7.635 7.636 7.64" description="Extended Logic 21 Output OFF" />
+  <macro id="449" versions="7.63 7.635 7.636 7.64" description="Extended Logic 22 Output OFF" />
+  <macro id="450" versions="7.63 7.635 7.636 7.64" description="Extended Logic 23 Output OFF" />
+  <macro id="451" versions="7.63 7.635 7.636 7.64" description="Extended Logic 24 Output OFF" />
+  <macro id="452" versions="7.63 7.635 7.636 7.64" description="Extended Logic 25 Output OFF" />
+  <macro id="453" versions="7.63 7.635 7.636 7.64" description="Extended Logic 26 Output OFF" />
+  <macro id="454" versions="7.63 7.635 7.636 7.64" description="Extended Logic 27 Output OFF" />
+  <macro id="455" versions="7.63 7.635 7.636 7.64" description="Extended Logic 28 Output OFF" />
+  <macro id="456" versions="7.63 7.635 7.636 7.64" description="Extended Logic 29 Output OFF" />
+  <macro id="457" versions="7.63 7.635 7.636 7.64" description="Extended Logic 30 Output OFF" />
+  <macro id="458" versions="7.63 7.635 7.636 7.64" description="Extended Logic 31 Output OFF" />
+  <macro id="459" versions="7.63 7.635 7.636 7.64" description="Extended Logic 32 Output OFF" />
+  <macro id="460" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 41" />
+  <macro id="461" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 42" />
+  <macro id="462" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 43" />
+  <macro id="463" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 44" />
+  <macro id="464" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 45" />
+  <macro id="465" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 46" />
+  <macro id="466" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 47" />
+  <macro id="467" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 48" />
+  <macro id="468" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 49" />
+  <macro id="469" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 50" />
+  <macro id="470" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 51" />
+  <macro id="471" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 52" />
+  <macro id="472" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 53" />
+  <macro id="473" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 54" />
+  <macro id="474" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 55" />
+  <macro id="475" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 56" />
+  <macro id="476" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 57" />
+  <macro id="477" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 58" />
+  <macro id="478" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 59" />
+  <macro id="479" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 60" />
+  <macro id="480" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 61" />
+  <macro id="481" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 62" />
+  <macro id="482" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 63" />
+  <macro id="483" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 64" />
+  <macro id="484" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 65" />
+  <macro id="485" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 66" />
+  <macro id="486" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 67" />
+  <macro id="487" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 68" />
+  <macro id="488" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 69" />
+  <macro id="489" versions="7.63 7.635 7.636 7.64" description="Play Message Macro 70" />
+  <macro id="490" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 11" />
+  <macro id="491" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 12" />
+  <macro id="492" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 13" />
+  <macro id="493" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 14" />
+  <macro id="494" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 15" />
+  <macro id="495" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 16" />
+  <macro id="496" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 17" />
+  <macro id="497" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 18" />
+  <macro id="498" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 19" />
+  <macro id="499" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 20" />
+  <macro id="500" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 21" />
+  <macro id="501" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 22" />
+  <macro id="502" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 23" />
+  <macro id="503" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 24" />
+  <macro id="504" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 25" />
+  <macro id="505" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 26" />
+  <macro id="506" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 27" />
+  <macro id="507" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 28" />
+  <macro id="508" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 29" />
+  <macro id="509" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 30" />
+  <macro id="511" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 31" />
+  <macro id="512" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 32" />
+  <macro id="513" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 33" />
+  <macro id="514" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 34" />
+  <macro id="515" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 35" />
+  <macro id="516" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 36" />
+  <macro id="517" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 37" />
+  <macro id="518" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 38" />
+  <macro id="519" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 39" />
+  <macro id="520" versions="7.63 7.635 7.636 7.64" description="Remote Base Memory 40" />
+  <macro id="521" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 21" />
+  <macro id="522" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 22" />
+  <macro id="523" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 23" />
+  <macro id="524" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 24" />
+  <macro id="525" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 25" />
+  <macro id="526" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 26" />
+  <macro id="527" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 27" />
+  <macro id="528" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 28" />
+  <macro id="529" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 29" />
+  <macro id="530" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 30" />
+  <macro id="531" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 31" />
+  <macro id="532" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 32" />
+  <macro id="533" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 33" />
+  <macro id="534" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 34" />
+  <macro id="535" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 35" />
+  <macro id="536" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 36" />
+  <macro id="537" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 37" />
+  <macro id="538" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 38" />
+  <macro id="539" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 39" />
+  <macro id="540" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 40" />
+  <macro id="541" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 41" />
+  <macro id="542" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 42" />
+  <macro id="543" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 43" />
+  <macro id="544" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 44" />
+  <macro id="545" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 45" />
+  <macro id="546" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 46" />
+  <macro id="547" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 47" />
+  <macro id="548" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 48" />
+  <macro id="549" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 49" />
+  <macro id="550" versions="7.63 7.635 7.636 7.64" description="Send DTMF Memory 50" />
+  <macro id="551" versions="7.63 7.635 7.636 7.64" description="Get RTC Time and Date" />
+  <macro id="552" versions="7.63 7.635 7.636 7.64" description="CTCSS During ID ON" />
+  <macro id="553" versions="7.63 7.635 7.636 7.64" description="CTCSS During ID OFF" />
+  <macro id="554" versions="7.63 7.635 7.636 7.64" description="Port 1 Time Transmitter Active since Last Reset" />
+  <macro id="555" versions="7.63 7.635 7.636 7.64" description="Port 2 Time Transmitter Active since Last Reset" />
+  <macro id="556" versions="7.63 7.635 7.636 7.64" description="Port 3 Time Transmitter Active since Last Reset" />
+  <macro id="557" versions="7.63 7.635 7.636 7.64" description="Reset Port 1 Transmitter Activity Timer" />
+  <macro id="558" versions="7.63 7.635 7.636 7.64" description="Reset Port 2 Transmitter Activity Timer" />
+  <macro id="559" versions="7.63 7.635 7.636 7.64" description="Reset Port 3 Transmitter Activity Timer" />
+  <macro id="560" versions="7.63 7.635 7.636 7.64" description="Give RSSI Report" />
+  <macro id="561" versions="7.63 7.635 7.636 7.64" description="Restart Controller" />
+  <macro id="562" versions="7.63 7.635 7.636 7.64" description="Readback Number of Keyups Port 1" />
+  <macro id="563" versions="7.63 7.635 7.636 7.64" description="Readback Number of Keyups Port 2" />
+  <macro id="564" versions="7.63 7.635 7.636 7.64" description="Readback Number of Keyups Port 3" />
+  <macro id="565" versions="7.63 7.635 7.636 7.64" description="Reset Keyup Counter Port 1" />
+  <macro id="566" versions="7.63 7.635 7.636 7.64" description="Reset Keyup Counter Port 2" />
+  <macro id="567" versions="7.63 7.635 7.636 7.64" description="Reset Keyup Counter Port 3" />
+  <macro id="570" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="571" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="572" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="573" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="574" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="575" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="576" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="577" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="578" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 1 Stored High" />
+  <macro id="579" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 2 Stored High" />
+  <macro id="580" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 3 Stored High" />
+  <macro id="581" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 4 Stored High" />
+  <macro id="582" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 5 Stored High" />
+  <macro id="583" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 6 Stored High" />
+  <macro id="584" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 7 Stored High" />
+  <macro id="585" versions="7.63 7.635 7.636 7.64" description="Readback A/D Channel 8 Stored High" />
+  <macro id="586" versions="7.63 7.635 7.636 7.64" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="7.63 7.635 7.636 7.64" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="7.63 7.635 7.636 7.64" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="7.63 7.635 7.636 7.64" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="7.63 7.635 7.636 7.64" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="7.63 7.635 7.636 7.64" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="592" versions="7.63 7.635 7.636 7.64" description="Current wind speed and direction" />
+  <macro id="593" versions="7.63 7.635 7.636 7.64" description="Current Outdoor temperature" />
+  <macro id="594" versions="7.63 7.635 7.636 7.64" description="Indoor humidity" />
+  <macro id="595" versions="7.63 7.635 7.636 7.64" description="Outdoor humidity" />
+  <macro id="596" versions="7.63 7.635 7.636 7.64" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="597" versions="7.63 7.635 7.636 7.64" description="Outdoor Temp High (since Midnight)" />
+  <macro id="598" versions="7.63 7.635 7.636 7.64" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="605" versions="7.63 7.635 7.636 7.64" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="606" versions="7.63 7.635 7.636 7.64" description="Start General Timer 4" />
+  <macro id="607" versions="7.63 7.635 7.636 7.64" description="Start General Timer 5" />
+  <macro id="608" versions="7.63 7.635 7.636 7.64" description="Start General Timer 6" />
+  <macro id="609" versions="7.63 7.635 7.636 7.64" description="Stop General Timer 4" />
+  <macro id="610" versions="7.63 7.635 7.636 7.64" description="Stop General Timer 5" />
+  <macro id="611" versions="7.63 7.635 7.636 7.64" description="Stop General Timer 6" />
+  <macro id="612" versions="7.63 7.635 7.636 7.64" description="Disable Port 1 Inactivity Timer" />
+  <macro id="613" versions="7.63 7.635 7.636 7.64" description="Disable Port 2 Inactivity Timer" />
+  <macro id="614" versions="7.63 7.635 7.636 7.64" description="Disable Port 3 Inactivity Timer" />
+  <macro id="615" versions="7.63 7.635 7.636 7.64" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="7.63 7.635 7.636 7.64" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="7.63 7.635 7.636 7.64" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="618" versions="7.63 7.635 7.636 7.64" description="1 Second Execution Delay" />
+  <macro id="619" versions="7.63 7.635 7.636 7.64" description="2 Second Execution Delay" />
+  <macro id="620" versions="7.63 7.635 7.636 7.64" description="4 Second Execution Delay" />
+  <macro id="621" versions="7.63 7.635 7.636 7.64" description="Port 1 Hangtimer 1 Select" />
+  <macro id="622" versions="7.63 7.635 7.636 7.64" description="Port 1 Hangtimer 2 Select" />
+  <macro id="623" versions="7.63 7.635 7.636 7.64" description="Port 1 Hangtimer 3 Select" />
+  <macro id="624" versions="7.63 7.635 7.636 7.64" description="Port 2 Hangtimer 1 Select" />
+  <macro id="625" versions="7.63 7.635 7.636 7.64" description="Port 2 Hangtimer 2 Select" />
+  <macro id="626" versions="7.63 7.635 7.636 7.64" description="Port 2 Hangtimer 3 Select" />
+  <macro id="627" versions="7.63 7.635 7.636 7.64" description="Port 3 Hangtimer 1 Select" />
+  <macro id="628" versions="7.63 7.635 7.636 7.64" description="Port 3 Hangtimer 2 Select" />
+  <macro id="629" versions="7.63 7.635 7.636 7.64" description="Port 3 Hangtimer 3 Select" />
+  <macro id="630" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 1" />
+  <macro id="631" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 2" />
+  <macro id="632" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 3" />
+  <macro id="633" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 4" />
+  <macro id="634" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 5" />
+  <macro id="635" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 6" />
+  <macro id="636" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 7" />
+  <macro id="637" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 8" />
+  <macro id="638" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 9" />
+  <macro id="639" versions="7.63 7.635 7.636 7.64" description="Port 1 Next Courtesy Tone 10" />
+  <macro id="640" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 1" />
+  <macro id="641" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 2" />
+  <macro id="642" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 3" />
+  <macro id="643" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 4" />
+  <macro id="644" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 5" />
+  <macro id="645" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 6" />
+  <macro id="646" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 7" />
+  <macro id="647" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 8" />
+  <macro id="648" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 9" />
+  <macro id="649" versions="7.63 7.635 7.636 7.64" description="Port 1 Following Courtesy Tone 10" />
+  <macro id="650" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="651" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone1" />
+  <macro id="652" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone2" />
+  <macro id="653" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="654" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="655" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="656" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="657" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="658" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone" />
+  <macro id="659" versions="7.63 7.635 7.636 7.64" description="Port 2 Next Courtesy Tone 10" />
+  <macro id="660" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 1" />
+  <macro id="661" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 2" />
+  <macro id="662" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 3" />
+  <macro id="663" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 4" />
+  <macro id="664" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 5" />
+  <macro id="665" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 6" />
+  <macro id="666" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 7" />
+  <macro id="667" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 8" />
+  <macro id="668" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 9" />
+  <macro id="669" versions="7.63 7.635 7.636 7.64" description="Port 2 Following Courtesy Tone 10" />
+  <macro id="670" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 1" />
+  <macro id="671" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 2" />
+  <macro id="672" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 3" />
+  <macro id="673" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 4" />
+  <macro id="674" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 5" />
+  <macro id="675" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 6" />
+  <macro id="676" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 7" />
+  <macro id="677" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 8" />
+  <macro id="678" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 9" />
+  <macro id="679" versions="7.63 7.635 7.636 7.64" description="Port 3 Next Courtesy Tone 10" />
+  <macro id="680" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 1" />
+  <macro id="681" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="682" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 2" />
+  <macro id="683" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 4" />
+  <macro id="684" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 5" />
+  <macro id="685" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 6" />
+  <macro id="686" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 7" />
+  <macro id="687" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 8" />
+  <macro id="688" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 9" />
+  <macro id="689" versions="7.63 7.635 7.636 7.64" description="Port 3 Following Courtesy Tone 10" />
+  <macro id="692" versions="7.63 7.635 7.636 7.64" description="Play Port 1 Pending ID" />
+  <macro id="693" versions="7.63 7.635 7.636 7.64" description="Play Port 2 Pending ID" />
+  <macro id="694" versions="7.63 7.635 7.636 7.64" description="Play Port 3 Pending ID" />
+  <macro id="810" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 1" />
+  <macro id="811" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 2" />
+  <macro id="812" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 3" />
+  <macro id="813" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 4" />
+  <macro id="814" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 5" />
+  <macro id="815" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 6" />
+  <macro id="816" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 7" />
+  <macro id="817" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 8" />
+  <macro id="818" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 9" />
+  <macro id="819" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 10" />
+  <macro id="820" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 11" />
+  <macro id="821" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 12" />
+  <macro id="822" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 13" />
+  <macro id="823" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 14" />
+  <macro id="824" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 15" />
+  <macro id="825" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 16" />
+  <macro id="826" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 17" />
+  <macro id="827" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 18" />
+  <macro id="828" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 19" />
+  <macro id="829" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 20" />
+  <macro id="830" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 21" />
+  <macro id="831" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 22" />
+  <macro id="832" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 23" />
+  <macro id="833" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 24" />
+  <macro id="834" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 25" />
+  <macro id="835" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 26" />
+  <macro id="836" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 27" />
+  <macro id="837" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 28" />
+  <macro id="838" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 29" />
+  <macro id="839" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 30" />
+  <macro id="840" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 31" />
+  <macro id="841" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 32" />
+  <macro id="842" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 33" />
+  <macro id="843" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 34" />
+  <macro id="844" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 35" />
+  <macro id="845" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 36" />
+  <macro id="846" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 37" />
+  <macro id="847" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 38" />
+  <macro id="848" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 39" />
+  <macro id="849" versions="7.63 7.635 7.636 7.64" description="Suspend Scheduler Setpoint 40" />
+  <macro id="850" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 1" />
+  <macro id="851" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 2" />
+  <macro id="852" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 3" />
+  <macro id="853" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 4" />
+  <macro id="854" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 5" />
+  <macro id="355" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 6" />
+  <macro id="856" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 7" />
+  <macro id="857" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 8" />
+  <macro id="858" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 9" />
+  <macro id="859" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 10" />
+  <macro id="860" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 11" />
+  <macro id="861" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 12" />
+  <macro id="862" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 13" />
+  <macro id="863" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 14" />
+  <macro id="864" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 15" />
+  <macro id="865" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 16" />
+  <macro id="866" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 17" />
+  <macro id="867" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 18" />
+  <macro id="868" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 19" />
+  <macro id="869" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 20" />
+  <macro id="870" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 21" />
+  <macro id="871" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 22" />
+  <macro id="872" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 23" />
+  <macro id="873" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 24" />
+  <macro id="874" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 25" />
+  <macro id="875" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 26" />
+  <macro id="876" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 27" />
+  <macro id="877" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 28" />
+  <macro id="878" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 29" />
+  <macro id="879" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 30" />
+  <macro id="880" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 31" />
+  <macro id="881" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 32" />
+  <macro id="882" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 33" />
+  <macro id="883" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 34" />
+  <macro id="884" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 35" />
+  <macro id="885" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 36" />
+  <macro id="886" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 37" />
+  <macro id="887" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 38" />
+  <macro id="888" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 39" />
+  <macro id="889" versions="7.63 7.635 7.636 7.64" description="Resume Scheduler Setpoint 40" />
+  <macro id="901" versions="7.63 7.635 7.636 7.64" description="Call Macro 1" />
+  <macro id="902" versions="7.63 7.635 7.636 7.64" description="Call Macro 2" />
+  <macro id="903" versions="7.63 7.635 7.636 7.64" description="Call Macro 3" />
+  <macro id="904" versions="7.63 7.635 7.636 7.64" description="Call Macro 4" />
+  <macro id="905" versions="7.63 7.635 7.636 7.64" description="Call Macro 5" />
+  <macro id="906" versions="7.63 7.635 7.636 7.64" description="Call Macro 6" />
+  <macro id="907" versions="7.63 7.635 7.636 7.64" description="Call Macro 7" />
+  <macro id="908" versions="7.63 7.635 7.636 7.64" description="Call Macro 8" />
+  <macro id="909" versions="7.63 7.635 7.636 7.64" description="Call Macro 9" />
+  <macro id="910" versions="7.63 7.635 7.636 7.64" description="Call Macro 10" />
+  <macro id="911" versions="7.63 7.635 7.636 7.64" description="Call Macro 11" />
+  <macro id="912" versions="7.63 7.635 7.636 7.64" description="Call Macro 12" />
+  <macro id="913" versions="7.63 7.635 7.636 7.64" description="Call Macro 13" />
+  <macro id="914" versions="7.63 7.635 7.636 7.64" description="Call Macro 14" />
+  <macro id="915" versions="7.63 7.635 7.636 7.64" description="Call Macro 15" />
+  <macro id="916" versions="7.63 7.635 7.636 7.64" description="Call Macro 16" />
+  <macro id="917" versions="7.63 7.635 7.636 7.64" description="Call Macro 17" />
+  <macro id="918" versions="7.63 7.635 7.636 7.64" description="Call Macro 18" />
+  <macro id="919" versions="7.63 7.635 7.636 7.64" description="Call Macro 19" />
+  <macro id="920" versions="7.63 7.635 7.636 7.64" description="Call Macro 20" />
+  <macro id="921" versions="7.63 7.635 7.636 7.64" description="Call Macro 21" />
+  <macro id="922" versions="7.63 7.635 7.636 7.64" description="Call Macro 22" />
+  <macro id="923" versions="7.63 7.635 7.636 7.64" description="Call Macro 23" />
+  <macro id="924" versions="7.63 7.635 7.636 7.64" description="Call Macro 24" />
+  <macro id="925" versions="7.63 7.635 7.636 7.64" description="Call Macro 25" />
+  <macro id="926" versions="7.63 7.635 7.636 7.64" description="Call Macro 26" />
+  <macro id="927" versions="7.63 7.635 7.636 7.64" description="Call Macro 27" />
+  <macro id="928" versions="7.63 7.635 7.636 7.64" description="Call Macro 28" />
+  <macro id="929" versions="7.63 7.635 7.636 7.64" description="Call Macro 29" />
+  <macro id="930" versions="7.63 7.635 7.636 7.64" description="Call Macro 30" />
+  <macro id="931" versions="7.63 7.635 7.636 7.64" description="Call Macro 31" />
+  <macro id="932" versions="7.63 7.635 7.636 7.64" description="Call Macro 32" />
+  <macro id="933" versions="7.63 7.635 7.636 7.64" description="Call Macro 33" />
+  <macro id="934" versions="7.63 7.635 7.636 7.64" description="Call Macro 34" />
+  <macro id="935" versions="7.63 7.635 7.636 7.64" description="Call Macro 35" />
+  <macro id="936" versions="7.63 7.635 7.636 7.64" description="Call Macro 36" />
+  <macro id="937" versions="7.63 7.635 7.636 7.64" description="Call Macro 37" />
+  <macro id="938" versions="7.63 7.635 7.636 7.64" description="Call Macro 38" />
+  <macro id="939" versions="7.63 7.635 7.636 7.64" description="Call Macro 39" />
+  <macro id="940" versions="7.63 7.635 7.636 7.64" description="Call Macro 40" />
+  <macro id="941" versions="7.63 7.635 7.636 7.64" description="Call Macro 41" />
+  <macro id="942" versions="7.63 7.635 7.636 7.64" description="Call Macro 42" />
+  <macro id="943" versions="7.63 7.635 7.636 7.64" description="Call Macro 43" />
+  <macro id="944" versions="7.63 7.635 7.636 7.64" description="Call Macro 44" />
+  <macro id="945" versions="7.63 7.635 7.636 7.64" description="Call Macro 45" />
+  <macro id="946" versions="7.63 7.635 7.636 7.64" description="Call Macro 46" />
+  <macro id="947" versions="7.63 7.635 7.636 7.64" description="Call Macro 47" />
+  <macro id="948" versions="7.63 7.635 7.636 7.64" description="Call Macro 48" />
+  <macro id="949" versions="7.63 7.635 7.636 7.64" description="Call Macro 49" />
+  <macro id="950" versions="7.63 7.635 7.636 7.64" description="Call Macro 50" />
+  <macro id="951" versions="7.63 7.635 7.636 7.64" description="Call Macro 51" />
+  <macro id="952" versions="7.63 7.635 7.636 7.64" description="Call Macro 52" />
+  <macro id="953" versions="7.63 7.635 7.636 7.64" description="Call Macro 53" />
+  <macro id="954" versions="7.63 7.635 7.636 7.64" description="Call Macro 54" />
+  <macro id="955" versions="7.63 7.635 7.636 7.64" description="Call Macro 55" />
+  <macro id="956" versions="7.63 7.635 7.636 7.64" description="Call Macro 56" />
+  <macro id="957" versions="7.63 7.635 7.636 7.64" description="Call Macro 57" />
+  <macro id="958" versions="7.63 7.635 7.636 7.64" description="Call Macro 58" />
+  <macro id="959" versions="7.63 7.635 7.636 7.64" description="Call Macro 59" />
+  <macro id="960" versions="7.63 7.635 7.636 7.64" description="Call Macro 60" />
+  <macro id="961" versions="7.63 7.635 7.636 7.64" description="Call Macro 61" />
+  <macro id="962" versions="7.63 7.635 7.636 7.64" description="Call Macro 62" />
+  <macro id="963" versions="7.63 7.635 7.636 7.64" description="Call Macro 63" />
+  <macro id="964" versions="7.63 7.635 7.636 7.64" description="Call Macro 64" />
+  <macro id="965" versions="7.63 7.635 7.636 7.64" description="Call Macro 65" />
+  <macro id="966" versions="7.63 7.635 7.636 7.64" description="Call Macro 66" />
+  <macro id="967" versions="7.63 7.635 7.636 7.64" description="Call Macro 67" />
+  <macro id="968" versions="7.63 7.635 7.636 7.64" description="Call Macro 68" />
+  <macro id="969" versions="7.63 7.635 7.636 7.64" description="Call Macro 69" />
+  <macro id="970" versions="7.63 7.635 7.636 7.64" description="Call Macro 70" />
+  <macro id="971" versions="7.63 7.635 7.636 7.64" description="Call Macro 71" />
+  <macro id="972" versions="7.63 7.635 7.636 7.64" description="Call Macro 72" />
+  <macro id="973" versions="7.63 7.635 7.636 7.64" description="Call Macro 73" />
+  <macro id="974" versions="7.63 7.635 7.636 7.64" description="Call Macro 74" />
+  <macro id="975" versions="7.63 7.635 7.636 7.64" description="Call Macro 75" />
+  <macro id="976" versions="7.63 7.635 7.636 7.64" description="Call Macro 76" />
+  <macro id="977" versions="7.63 7.635 7.636 7.64" description="Call Macro 77" />
+  <macro id="978" versions="7.63 7.635 7.636 7.64" description="Call Macro 78" />
+  <macro id="979" versions="7.63 7.635 7.636 7.64" description="Call Macro 79" />
+  <macro id="980" versions="7.63 7.635 7.636 7.64" description="Call Macro 80" />
+  <macro id="981" versions="7.63 7.635 7.636 7.64" description="Call Macro 81" />
+  <macro id="982" versions="7.63 7.635 7.636 7.64" description="Call Macro 82" />
+  <macro id="983" versions="7.63 7.635 7.636 7.64" description="Call Macro 83" />
+  <macro id="984" versions="7.63 7.635 7.636 7.64" description="Call Macro 84" />
+  <macro id="985" versions="7.63 7.635 7.636 7.64" description="Call Macro 85" />
+  <macro id="986" versions="7.63 7.635 7.636 7.64" description="Call Macro 86" />
+  <macro id="987" versions="7.63 7.635 7.636 7.64" description="Call Macro 87" />
+  <macro id="988" versions="7.63 7.635 7.636 7.64" description="Call Macro 88" />
+  <macro id="989" versions="7.63 7.635 7.636 7.64" description="Call Macro 89" />
+  <macro id="990" versions="7.63 7.635 7.636 7.64" description="Call Macro 90" />
+  <macro id="991" versions="7.63 7.635 7.636 7.64" description="Call Macro 91" />
+  <macro id="992" versions="7.63 7.635 7.636 7.64" description="Call Macro 92" />
+  <macro id="993" versions="7.63 7.635 7.636 7.64" description="Call Macro 93" />
+  <macro id="994" versions="7.63 7.635 7.636 7.64" description="Call Macro 94" />
+  <macro id="995" versions="7.63 7.635 7.636 7.64" description="Call Macro 95" />
+  <macro id="996" versions="7.63 7.635 7.636 7.64" description="Call Macro 96" />
+  <macro id="997" versions="7.63 7.635 7.636 7.64" description="Call Macro 97" />
+  <macro id="998" versions="7.63 7.635 7.636 7.64" description="Call Macro 98" />
+  <macro id="999" versions="7.63 7.635 7.636 7.64" description="Call Macro 99" />
+  <macro id="1000" versions="7.63 7.635 7.636 7.64" description="Call Macro 100" />
+  <macro id="1001" versions="7.63 7.635 7.636 7.64" description="Call Macro 101" />
+  <macro id="1002" versions="7.63 7.635 7.636 7.64" description="Call Macro 102" />
+  <macro id="1003" versions="7.63 7.635 7.636 7.64" description="Call Macro 103" />
+  <macro id="1004" versions="7.63 7.635 7.636 7.64" description="Call Macro 104" />
+  <macro id="1005" versions="7.63 7.635 7.636 7.64" description="Call Macro 105" />
+</macros>

--- a/macro_def.xml
+++ b/macro_def.xml
@@ -1,0 +1,1221 @@
+<macros version="1.003">
+  <macro id="001" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 CTCSS Access" />
+  <macro id="002" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 CTCSS Access" />
+  <macro id="003" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 CTCSS Access" />
+  <macro id="004" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Carrier Access" />
+  <macro id="005" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Carrier Access" />
+  <macro id="006" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Carrier Access" />
+  <macro id="007" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Covertone ON" />
+  <macro id="008" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Covertone ON" />
+  <macro id="009" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Covertone ON" />
+  <macro id="010" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Covertone OFF" />
+  <macro id="011" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Covertone OFF" />
+  <macro id="012" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Covertone OFF" />
+  <macro id="013" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Enable" />
+  <macro id="014" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Enable" />
+  <macro id="015" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Enable" />
+  <macro id="016" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Disable" />
+  <macro id="017" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Disable" />
+  <macro id="018" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Disable" />
+  <macro id="019" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 1 from Port 2" />
+  <macro id="020" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 1 from Port 3" />
+  <macro id="021" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 1 from Port 2" />
+  <macro id="022" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 1 from Port 3" />
+  <macro id="023" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 2 from Port 1" />
+  <macro id="024" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 2 from Port 3" />
+  <macro id="025" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 2 from Port 1" />
+  <macro id="026" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 2 from Port 3" />
+  <macro id="027" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 3 from Port 1" />
+  <macro id="028" versions="5.281 5.285 5.360 6.000 6.040" description="Monitor Port 3 from Port 2" />
+  <macro id="029" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 3 from Port 1" />
+  <macro id="030" versions="5.281 5.285 5.360 6.000 6.040" description="Disconnect Port 3 from Port 2" />
+  <macro id="031" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Monitor Mute" />
+  <macro id="032" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Monitor Mute" />
+  <macro id="033" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Monitor Mute" />
+  <macro id="034" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Monitor Mix" />
+  <macro id="035" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Monitor Mix" />
+  <macro id="036" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Monitor Mix" />
+  <macro id="037" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Repeat ON" />
+  <macro id="038" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Repeat ON" />
+  <macro id="039" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Repeat ON" />
+  <macro id="040" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Repeat OFF" />
+  <macro id="041" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Repeat OFF" />
+  <macro id="042" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Repeat OFF" />
+  <macro id="043" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech OverrideON" />
+  <macro id="044" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech OverrideON" />
+  <macro id="045" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech OverrideON" />
+  <macro id="046" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech Override OFF" />
+  <macro id="047" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech Override OFF" />
+  <macro id="048" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech Override OFF" />
+  <macro id="049" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 1" />
+  <macro id="050" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 2" />
+  <macro id="051" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 3" />
+  <macro id="052" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 4" />
+  <macro id="053" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 5" />
+  <macro id="054" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 6" />
+  <macro id="055" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 7" />
+  <macro id="056" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 8" />
+  <macro id="057" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 9" />
+  <macro id="058" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Courtesy Tone 10" />
+  <macro id="059" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 1" />
+  <macro id="060" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 2" />
+  <macro id="061" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 3" />
+  <macro id="062" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 4" />
+  <macro id="063" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 5" />
+  <macro id="064" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 6" />
+  <macro id="065" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 7" />
+  <macro id="066" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 8" />
+  <macro id="067" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 9" />
+  <macro id="068" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Courtesy Tone 10" />
+  <macro id="069" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 1" />
+  <macro id="070" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 2" />
+  <macro id="071" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 3" />
+  <macro id="072" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 4" />
+  <macro id="073" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 5" />
+  <macro id="074" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 6" />
+  <macro id="075" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 7" />
+  <macro id="076" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 8" />
+  <macro id="077" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 9" />
+  <macro id="078" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Courtesy Tone 10" />
+  <macro id="079" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Muting ON" />
+  <macro id="080" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Muting ON" />
+  <macro id="081" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Muting ON" />
+  <macro id="082" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 DTMF Muting OFF" />
+  <macro id="083" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 DTMF Muting OFF" />
+  <macro id="084" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 DTMF Muting OFF" />
+  <macro id="085" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode ON (for the duration of this Macro)" />
+  <macro id="086" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode OFF (for the duration of this Macro)" />
+  <macro id="087" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 1" />
+  <macro id="088" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 2" />
+  <macro id="089" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 3" />
+  <macro id="090" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 4" />
+  <macro id="091" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 5" />
+  <macro id="092" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 6" />
+  <macro id="093" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 7" />
+  <macro id="094" versions="5.281 5.285 5.360 6.000 6.040" description="Read ADC Channel 8" />
+  <macro id="095" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 ON" />
+  <macro id="096" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 ON" />
+  <macro id="097" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 ON" />
+  <macro id="098" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 ON" />
+  <macro id="099" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 ON" />
+  <macro id="100" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 ON" />
+  <macro id="101" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 ON" />
+  <macro id="102" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 OFF" />
+  <macro id="103" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 OFF" />
+  <macro id="104" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 OFF" />
+  <macro id="105" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 OFF" />
+  <macro id="106" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 OFF" />
+  <macro id="107" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 OFF" />
+  <macro id="108" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 OFF" />
+  <macro id="109" versions="5.281 5.285 5.360 6.000 6.040" description="UF1 Pulse" />
+  <macro id="110" versions="5.281 5.285 5.360 6.000 6.040" description="UF2 Pulse" />
+  <macro id="111" versions="5.281 5.285 5.360 6.000 6.040" description="UF3 Pulse" />
+  <macro id="112" versions="5.281 5.285 5.360 6.000 6.040" description="UF4 Pulse" />
+  <macro id="113" versions="5.281 5.285 5.360 6.000 6.040" description="UF5 Pulse" />
+  <macro id="114" versions="5.281 5.285 5.360 6.000 6.040" description="UF6 Pulse" />
+  <macro id="115" versions="5.281 5.285 5.360 6.000 6.040" description="UF7 Pulse" />
+  <macro id="116" versions="5.281 5.285 5.360 6.000 6.040" description="Say Time" />
+  <macro id="117" versions="5.281 5.285 5.360 6.000 6.040" description="Say Date" />
+  <macro id="118" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 1 to Port 2" />
+  <macro id="119" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 1 to Port 3" />
+  <macro id="120" versions="5.281 5.285 5.360 6.000 6.040" description="Link Port 2 to Port 3" />
+  <macro id="121" versions="5.281 5.285 5.360 6.000 6.040" description="Link All Ports" />
+  <macro id="122" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 1 from Port 2" />
+  <macro id="123" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 1 from Port 3" />
+  <macro id="124" versions="5.281 5.285 5.360 6.000 6.040" description="Unlink Port 2 from Port 3" />
+  <macro id="125" versions="5.281 5.285 5.360 6.000 6.040" description="UnLink All Ports" />
+  <macro id="126" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 1" />
+  <macro id="127" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 2" />
+  <macro id="128" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 3" />
+  <macro id="129" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 4" />
+  <macro id="130" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 5" />
+  <macro id="131" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 6" />
+  <macro id="132" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 7" />
+  <macro id="133" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 8" />
+  <macro id="134" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 9" />
+  <macro id="135" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 10" />
+  <macro id="136" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 11" />
+  <macro id="137" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 12" />
+  <macro id="138" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 13" />
+  <macro id="139" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 14" />
+  <macro id="140" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 15" />
+  <macro id="141" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 16" />
+  <macro id="142" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 17" />
+  <macro id="143" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 18" />
+  <macro id="144" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 19" />
+  <macro id="145" versions="5.281 5.285 5.360 6.000 6.040" description="Play DVR Track 20" />
+  <macro id="146" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 1 ON" />
+  <macro id="147" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 2 ON" />
+  <macro id="148" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 3 ON" />
+  <macro id="149" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 1 OFF" />
+  <macro id="150" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 2 OFF" />
+  <macro id="151" versions="5.281 5.285 5.360 6.000 6.040" description="Auxiliary Audio 3 OFF" />
+  <macro id="152" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 1 ON" />
+  <macro id="153" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 2 ON" />
+  <macro id="154" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 3 ON" />
+  <macro id="155" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 4 ON" />
+  <macro id="156" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 5 ON" />
+  <macro id="157" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 1 OFF" />
+  <macro id="158" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 2 OFF" />
+  <macro id="159" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 3 OFF" />
+  <macro id="160" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 4 OFF" />
+  <macro id="161" versions="5.281 5.285 5.360 6.000 6.040" description="Alarm 5 OFF" />
+  <macro id="162" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 1" />
+  <macro id="163" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 2" />
+  <macro id="164" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Port 3" />
+  <macro id="165" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 1 and 2" />
+  <macro id="166" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 1 and 3" />
+  <macro id="167" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out Ports 2 and 3" />
+  <macro id="168" versions="5.281 5.285 5.360 6.000 6.040" description="Speech Out All Ports" />
+  <macro id="169" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 1" />
+  <macro id="170" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 2" />
+  <macro id="171" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Enable Port 3" />
+  <macro id="172" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 1" />
+  <macro id="173" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 2" />
+  <macro id="174" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Disable Port 3" />
+  <macro id="175" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 1" />
+  <macro id="176" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 2" />
+  <macro id="177" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Require CTCSS Port 3" />
+  <macro id="178" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 1" />
+  <macro id="179" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 2" />
+  <macro id="180" versions="5.281 5.285 5.360 6.000 6.040" description="DTMF Not Require CTCSS Port 3" />
+  <macro id="181" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 1" />
+  <macro id="182" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 2" />
+  <macro id="183" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next Voice ID In Rotation On Port 3" />
+  <macro id="184" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 1" />
+  <macro id="185" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 2" />
+  <macro id="186" versions="5.281 5.285 5.360 6.000 6.040" description="Force Next CW ID In Rotation On Port 3" />
+  <macro id="187" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 1" />
+  <macro id="188" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 2" />
+  <macro id="189" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 3" />
+  <macro id="190" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 4" />
+  <macro id="191" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 5" />
+  <macro id="192" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 6" />
+  <macro id="193" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 7" />
+  <macro id="194" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 8" />
+  <macro id="195" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 9" />
+  <macro id="196" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 10" />
+  <macro id="197" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 11" />
+  <macro id="198" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 12" />
+  <macro id="199" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 13" />
+  <macro id="200" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 14" />
+  <macro id="201" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 15" />
+  <macro id="202" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 16" />
+  <macro id="203" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 17" />
+  <macro id="204" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 18" />
+  <macro id="205" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 19" />
+  <macro id="206" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 20" />
+  <macro id="207" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 21" />
+  <macro id="208" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 22" />
+  <macro id="209" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 23" />
+  <macro id="210" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 24" />
+  <macro id="211" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 25" />
+  <macro id="212" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 26" />
+  <macro id="213" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 27" />
+  <macro id="214" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 28" />
+  <macro id="215" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 29" />
+  <macro id="216" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 30" />
+  <macro id="217" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 31" />
+  <macro id="218" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 32" />
+  <macro id="219" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 33" />
+  <macro id="220" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 34" />
+  <macro id="221" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 35" />
+  <macro id="222" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 36" />
+  <macro id="223" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 37" />
+  <macro id="224" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 38" />
+  <macro id="225" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 39" />
+  <macro id="226" versions="5.281 5.285 5.360 6.000 6.040" description="Play Message Macro 40" />
+  <macro id="227" versions="5.281 5.285 5.360 6.000 6.040" description="Good Morning/Afternoon/Evening Runtime Variable" />
+  <macro id="228" versions="5.281 5.285 5.360 6.000 6.040" description="Macro Priority High" />
+  <macro id="229" versions="5.281 5.285 5.360 6.000 6.040" description="Macro Priority Low" />
+  <macro id="230" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 1" />
+  <macro id="231" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 2" />
+  <macro id="232" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Kerchunk Filter Port 3" />
+  <macro id="233" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 1" />
+  <macro id="234" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 2" />
+  <macro id="235" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Kerchunk Filter Port 3" />
+  <macro id="236" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 1" />
+  <macro id="237" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 2" />
+  <macro id="238" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Receiver Port 3" />
+  <macro id="239" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 1" />
+  <macro id="240" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 2" />
+  <macro id="241" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Receiver Port 3" />
+  <macro id="242" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech ID Override ON" />
+  <macro id="243" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech ID Override ON" />
+  <macro id="244" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech ID Override ON" />
+  <macro id="245" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Speech ID Override OFF" />
+  <macro id="246" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Speech ID Override OFF" />
+  <macro id="247" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Speech ID Override OFF" />
+  <macro id="248" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 1" />
+  <macro id="249" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 2" />
+  <macro id="250" versions="5.281 5.285 5.360 6.000 6.040" description="All Courtesy Tones OFF Port 3" />
+  <macro id="251" versions="5.281 5.285 5.360 6.000 6.040" description="Force Audio To Entered Port" />
+  <macro id="252" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 1" />
+  <macro id="253" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 2" />
+  <macro id="254" versions="5.281 5.285 5.360 6.000 6.040" description="Stop ID/Disable Timeout Timer Port 3" />
+  <macro id="256" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 1" />
+  <macro id="257" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 2" />
+  <macro id="258" versions="5.281 5.285 5.360 6.000 6.040" description="Resume ID/Enable Timeout Timer Port 3" />
+  <macro id="259" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 1" />
+  <macro id="260" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 2" />
+  <macro id="261" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 3" />
+  <macro id="262" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 4" />
+  <macro id="263" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 5" />
+  <macro id="264" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 6" />
+  <macro id="265" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 7" />
+  <macro id="266" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 8" />
+  <macro id="267" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 9" />
+  <macro id="268" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 10" />
+  <macro id="269" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 11" />
+  <macro id="270" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 12" />
+  <macro id="271" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 13" />
+  <macro id="272" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 14" />
+  <macro id="273" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 15" />
+  <macro id="274" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 16" />
+  <macro id="275" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 17" />
+  <macro id="276" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 18" />
+  <macro id="277" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 19" />
+  <macro id="278" versions="5.281 5.285 5.360 6.000 6.040" description="Send DTMF Memory 20" />
+  <macro id="279" versions="5.281 5.285 5.360 6.000 6.040" description="Clear All Meter Hi/Low Trippoints" />
+  <macro id="280" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 1 Hi/Low Trippoint" />
+  <macro id="281" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 2 Hi/Low Trippoint" />
+  <macro id="282" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 3 Hi/Low Trippoint" />
+  <macro id="283" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 4 Hi/Low Trippoint" />
+  <macro id="284" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 5 Hi/Low Trippoint" />
+  <macro id="285" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 6 Hi/Low Trippoint" />
+  <macro id="286" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 7 Hi/Low Trippoint" />
+  <macro id="287" versions="5.281 5.285 5.360 6.000 6.040" description="Clear Meter 8 Hi/Low Trippoint" />
+  <macro id="288" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 1 Alarm" />
+  <macro id="289" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 2 Alarm" />
+  <macro id="290" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 3 Alarm" />
+  <macro id="291" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 4 Alarm" />
+  <macro id="292" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 5 Alarm" />
+  <macro id="293" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 6 Alarm" />
+  <macro id="294" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 7 Alarm" />
+  <macro id="295" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Meter 8 Alarm" />
+  <macro id="296" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 1 Alarm" />
+  <macro id="297" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 2 Alarm" />
+  <macro id="298" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 3 Alarm" />
+  <macro id="299" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 4 Alarm" />
+  <macro id="300" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 5 Alarm" />
+  <macro id="301" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 6 Alarm" />
+  <macro id="302" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 7 Alarm" />
+  <macro id="303" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Meter 8 Alarm" />
+  <macro id="304" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode Force OFF" />
+  <macro id="305" versions="5.281 5.285 5.360 6.000 6.040" description="CTCSS Encode to Programmed Value" />
+  <macro id="306" versions="5.281 5.285 5.360 6.000 6.040" description="Bump Clock By Correction Factor" />
+  <macro id="307" versions="5.281 5.285 5.360 6.000 6.040" description="Say year as part of date" />
+  <macro id="308" versions="5.281 5.285 5.360 6.000 6.040" description="Don't say year as part of date" />
+  <macro id="309" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message OFF" />
+  <macro id="310" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message OFF" />
+  <macro id="311" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message OFF" />
+  <macro id="312" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 1" />
+  <macro id="313" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 1" />
+  <macro id="314" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 1" />
+  <macro id="315" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 2" />
+  <macro id="316" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 2" />
+  <macro id="317" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 2" />
+  <macro id="318" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Tail Message 3" />
+  <macro id="319" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Tail Message 3" />
+  <macro id="320" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Tail Message 3" />
+  <macro id="321" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 1" />
+  <macro id="322" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 2" />
+  <macro id="323" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 3" />
+  <macro id="324" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 4" />
+  <macro id="325" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 5" />
+  <macro id="326" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 6" />
+  <macro id="327" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 7" />
+  <macro id="328" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 8" />
+  <macro id="329" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 9" />
+  <macro id="330" versions="5.281 5.285 5.360 6.000 6.040" description="Remote Base Memory 10" />
+  <macro id="331" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Zero Hang Time Select" />
+  <macro id="332" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Zero Hang Time Select" />
+  <macro id="333" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Zero Hang Time Select" />
+  <macro id="334" versions="5.281 5.285 5.360 6.000 6.040" description="Port 1 Hang Time Revert to Programmed Value" />
+  <macro id="335" versions="5.281 5.285 5.360 6.000 6.040" description="Port 2 Hang Time Revert to Programmed Value" />
+  <macro id="336" versions="5.281 5.285 5.360 6.000 6.040" description="Port 3 Hang Time Revert to Programmed Value" />
+  <macro id="337" versions="5.281 5.285 5.360 6.000 6.040" description="Allow Autopatch from programmed Ports" />
+  <macro id="338" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Autopatch" />
+  <macro id="339" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 1" />
+  <macro id="340" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 2" />
+  <macro id="341" versions="5.281 5.285 5.360 6.000 6.040" description="Enable Speech ID's Port 3" />
+  <macro id="342" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 1" />
+  <macro id="343" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 2" />
+  <macro id="344" versions="5.281 5.285 5.360 6.000 6.040" description="Disable Speech ID's Port 3" />
+  <macro id="345" versions="5.281 5.285 5.360 6.000 6.040" description="User DVR Record test, erase after auto playback" />
+  <macro id="346" versions="5.281 5.285 5.360 6.000 6.040" description="User DVR Record test, don't erase after auto playback" />
+  <macro id="347" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 1" />
+  <macro id="348" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 2" />
+  <macro id="349" versions="5.281 5.285 5.360 6.000 6.040" description="Start General Timer 3" />
+  <macro id="350" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 1" />
+  <macro id="351" versions="5.281" description="Suspend Scheduler Setpoint 1" />
+  <macro id="351" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 2" />
+  <macro id="352" versions="5.281" description="Suspend Scheduler Setpoint 2" />
+  <macro id="352" versions="5.285 5.360 6.000 6.040" description="Stop General Timer 3" />
+  <macro id="353" versions="5.281" description="Suspend Scheduler Setpoint 3" />
+  <macro id="353" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 1" />
+  <macro id="354" versions="5.281" description="Suspend Scheduler Setpoint 4" />
+  <macro id="354" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 2" />
+  <macro id="355" versions="5.281" description="Suspend Scheduler Setpoint 5" />
+  <macro id="355" versions="5.285 5.360 6.000 6.040" description="Remote Base Power Select 3" />
+  <macro id="356" versions="5.281" description="Suspend Scheduler Setpoint 6" />
+  <macro id="356" versions="5.285 5.360 6.000 6.040" description="Guest Macros Enabled" />
+  <macro id="357" versions="5.281" description="Suspend Scheduler Setpoint 7" />
+  <macro id="357" versions="5.285 5.360 6.000 6.040" description="Guest Macros Disabled" />
+  <macro id="358" versions="5.281" description="Suspend Scheduler Setpoint 8" />
+  <macro id="358" versions="5.285" description="Reveiver Is Active Port 1" />
+  <macro id="358" versions="5.360 6.000 6.040" description="Reveiver 1 Macros On" />
+  <macro id="359" versions="5.281" description="Suspend Scheduler Setpoint 9" />
+  <macro id="359" versions="5.285" description="Reveiver Is Active Port 2" />
+  <macro id="359" versions="5.360 6.000 6.040" description="Reveiver 2 Macros On" />
+  <macro id="360" versions="5.281" description="Suspend Scheduler Setpoint 10" />
+  <macro id="360" versions="5.285" description="Reveiver Is Active Port 3" />
+  <macro id="360" versions="5.360 6.000 6.040" description="Reveiver 3 Macros On" />
+  <macro id="361" versions="5.281" description="Suspend Scheduler Setpoint 11" />
+  <macro id="361" versions="5.285" description="Reveiver Is Inactive Port 1" />
+  <macro id="361" versions="5.360 6.000 6.040" description="Reveiver 3 Macros Off" />
+  <macro id="362" versions="5.281" description="Suspend Scheduler Setpoint 12" />
+  <macro id="362" versions="5.285" description="Reveiver Is Inactive Port 2" />
+  <macro id="362" versions="5.360 6.000 6.040" description="Reveiver 3 Macros Off" />
+  <macro id="363" versions="5.281" description="Suspend Scheduler Setpoint 13" />
+  <macro id="363" versions="5.285" description="Reveiver Is Inactive Port 3" />
+  <macro id="363" versions="5.360 6.000 6.040" description="Reveiver 3 Macros Off" />
+  <macro id="364" versions="5.281" description="Suspend Scheduler Setpoint 14" />
+  <macro id="364" versions="5.285" description="Play Message Macro 41" />
+  <macro id="364" versions="5.360 6.000 6.040" description="Extended Logic 1 Output ON" />
+  <macro id="365" versions="5.281" description="Suspend Scheduler Setpoint 15" />
+  <macro id="365" versions="5.285" description="Play Message Macro 42" />
+  <macro id="365" versions="5.360 6.000 6.040" description="Extended Logic 2 Output ON" />
+  <macro id="366" versions="5.281" description="Suspend Scheduler Setpoint 16" />
+  <macro id="366" versions="5.285" description="Play Message Macro 43" />
+  <macro id="366" versions="5.360 6.000 6.040" description="Extended Logic 3 Output ON" />
+  <macro id="367" versions="5.281" description="Suspend Scheduler Setpoint 17" />
+  <macro id="367" versions="5.285" description="Play Message Macro 44" />
+  <macro id="367" versions="5.360 6.000 6.040" description="Extended Logic 4 Output ON" />
+  <macro id="368" versions="5.281" description="Suspend Scheduler Setpoint 18" />
+  <macro id="368" versions="5.285" description="Play Message Macro 45" />
+  <macro id="368" versions="5.360 6.000 6.040" description="Extended Logic 5 Output ON" />
+  <macro id="369" versions="5.281" description="Suspend Scheduler Setpoint 19" />
+  <macro id="369" versions="5.285" description="Play Message Macro 46" />
+  <macro id="369" versions="5.360 6.000 6.040" description="Extended Logic 6 Output ON" />
+  <macro id="370" versions="5.281" description="Suspend Scheduler Setpoint 20" />
+  <macro id="370" versions="5.285" description="Play Message Macro 47" />
+  <macro id="370" versions="5.360 6.000 6.040" description="Extended Logic 7 Output ON" />
+  <macro id="371" versions="5.281" description="Resume Scheduler Setpoint 1" />
+  <macro id="371" versions="5.285" description="Play Message Macro 48" />
+  <macro id="371" versions="5.360 6.000 6.040" description="Extended Logic 8 Output ON" />
+  <macro id="372" versions="5.281" description="Resume Scheduler Setpoint 2" />
+  <macro id="372" versions="5.285" description="Play Message Macro 49" />
+  <macro id="372" versions="5.360 6.000 6.040" description="Extended Logic 9 Output ON" />
+  <macro id="373" versions="5.281" description="Resume Scheduler Setpoint 3" />
+  <macro id="373" versions="5.285" description="Play Message Macro 50" />
+  <macro id="373" versions="5.360 6.000 6.040" description="Extended Logic 10 Output ON" />
+  <macro id="374" versions="5.281" description="Resume Scheduler Setpoint 4" />
+  <macro id="374" versions="5.285" description="Play Message Macro 51" />
+  <macro id="374" versions="5.360 6.000 6.040" description="Extended Logic 11 Output ON" />
+  <macro id="375" versions="5.281" description="Resume Scheduler Setpoint 5" />
+  <macro id="375" versions="5.285" description="Play Message Macro 52" />
+  <macro id="375" versions="5.360 6.000 6.040" description="Extended Logic 12 Output ON" />
+  <macro id="376" versions="5.281" description="Resume Scheduler Setpoint 6" />
+  <macro id="376" versions="5.285" description="Play Message Macro 53" />
+  <macro id="376" versions="5.360 6.000 6.040" description="Extended Logic 13 Output ON" />
+  <macro id="377" versions="5.281" description="Resume Scheduler Setpoint 7" />
+  <macro id="377" versions="5.285" description="Play Message Macro 54" />
+  <macro id="377" versions="5.360 6.000 6.040" description="Extended Logic 14 Output ON" />
+  <macro id="378" versions="5.281" description="Resume Scheduler Setpoint 8" />
+  <macro id="378" versions="5.285" description="Play Message Macro 55" />
+  <macro id="378" versions="5.360 6.000 6.040" description="Extended Logic 15 Output ON" />
+  <macro id="379" versions="5.281" description="Resume Scheduler Setpoint 9" />
+  <macro id="379" versions="5.285" description="Play Message Macro 56" />
+  <macro id="379" versions="5.360 6.000 6.040" description="Extended Logic 16 Output ON" />
+  <macro id="380" versions="5.281" description="Resume Scheduler Setpoint 10" />
+  <macro id="380" versions="5.285" description="Play Message Macro 57" />
+  <macro id="380" versions="5.360 6.000 6.040" description="Extended Logic 17 Output ON" />
+  <macro id="381" versions="5.281" description="Resume Scheduler Setpoint 11" />
+  <macro id="381" versions="5.285" description="Play Message Macro 58" />
+  <macro id="381" versions="5.360 6.000 6.040" description="Extended Logic 18 Output ON" />
+  <macro id="382" versions="5.281" description="Resume Scheduler Setpoint 12" />
+  <macro id="382" versions="5.285" description="Play Message Macro 59" />
+  <macro id="382" versions="5.360 6.000 6.040" description="Extended Logic 19 Output ON" />
+  <macro id="383" versions="5.281" description="Resume Scheduler Setpoint 13" />
+  <macro id="383" versions="5.285" description="Play Message Macro 60" />
+  <macro id="383" versions="5.360 6.000 6.040" description="Extended Logic 20 Output ON" />
+  <macro id="384" versions="5.281" description="Resume Scheduler Setpoint 14" />
+  <macro id="384" versions="5.285" description="Play Message Macro 61" />
+  <macro id="384" versions="5.360 6.000 6.040" description="Extended Logic 21 Output ON" />
+  <macro id="385" versions="5.281" description="Resume Scheduler Setpoint 15" />
+  <macro id="385" versions="5.285" description="Play Message Macro 62" />
+  <macro id="385" versions="5.360 6.000 6.040" description="Extended Logic 22 Output ON" />
+  <macro id="386" versions="5.281" description="Resume Scheduler Setpoint 16" />
+  <macro id="386" versions="5.285" description="Play Message Macro 63" />
+  <macro id="386" versions="5.360 6.000 6.040" description="Extended Logic 23 Output ON" />
+  <macro id="387" versions="5.281" description="Resume Scheduler Setpoint 17" />
+  <macro id="387" versions="5.285" description="Play Message Macro 64" />
+  <macro id="387" versions="5.360 6.000 6.040" description="Extended Logic 24 Output ON" />
+  <macro id="388" versions="5.281" description="Resume Scheduler Setpoint 18" />
+  <macro id="388" versions="5.285" description="Play Message Macro 65" />
+  <macro id="388" versions="5.360 6.000 6.040" description="Extended Logic 25 Output ON" />
+  <macro id="389" versions="5.281" description="Resume Scheduler Setpoint 19" />
+  <macro id="389" versions="5.285" description="Play Message Macro 66" />
+  <macro id="389" versions="5.360 6.000 6.040" description="Extended Logic 26 Output ON" />
+  <macro id="390" versions="5.281" description="Resume Scheduler Setpoint 20" />
+  <macro id="390" versions="5.285" description="Play Message Macro 67" />
+  <macro id="390" versions="5.360 6.000 6.040" description="Extended Logic 27 Output ON" />
+  <macro id="391" versions="5.281" description="Stop General Timer 1" />
+  <macro id="391" versions="5.285" description="Play Message Macro 68" />
+  <macro id="391" versions="5.360 6.000 6.040" description="Extended Logic 28 Output ON" />
+  <macro id="392" versions="5.281" description="Stop General Timer 2" />
+  <macro id="392" versions="5.285" description="Play Message Macro 69" />
+  <macro id="392" versions="5.360 6.000 6.040" description="Extended Logic 29 Output ON" />
+  <macro id="393" versions="5.281" description="Stop General Timer 3" />
+  <macro id="393" versions="5.285" description="Play Message Macro 70" />
+  <macro id="393" versions="5.360 6.000 6.040" description="Extended Logic 30 Output ON" />
+  <macro id="394" versions="5.285" description="Remote Base Memory 11" />
+  <macro id="394" versions="5.360 6.000 6.040" description="Extended Logic 31 Output ON" />
+  <macro id="395" versions="5.285" description="Remote Base Memory 12" />
+  <macro id="395" versions="5.360 6.000 6.040" description="Extended Logic 32 Output ON" />
+  <macro id="396" versions="5.285" description="Remote Base Memory 13" />
+  <macro id="396" versions="5.360 6.000 6.040" description="Extended Logic 1 Output Pulse" />
+  <macro id="397" versions="5.281" description="Macro Subset Disable" />
+  <macro id="397" versions="5.285" description="Remote Base Memory 14" />
+  <macro id="397" versions="5.360 6.000 6.040" description="Extended Logic 2 Output Pulse" />
+  <macro id="398" versions="5.281" description="Macro Subset Enable" />
+  <macro id="398" versions="5.285" description="Remote Base Memory 15" />
+  <macro id="398" versions="5.360 6.000 6.040" description="Extended Logic 3 Output Pulse" />
+  <macro id="399" versions="5.285" description="Remote Base Memory 16" />
+  <macro id="399" versions="5.360 6.000 6.040" description="Extended Logic 4 Output Pulse" />
+  <macro id="400" versions="5.285" description="Remote Base Memory 17" />
+  <macro id="400" versions="5.360 6.000 6.040" description="Extended Logic 5 Output Pulse" />
+  <macro id="401" versions="5.281" description="Macro 1" />
+  <macro id="401" versions="5.285" description="Remote Base Memory 18" />
+  <macro id="401" versions="5.360 6.000 6.040" description="Extended Logic 6 Output Pulse" />
+  <macro id="402" versions="5.281" description="Macro 2" />
+  <macro id="402" versions="5.285" description="Remote Base Memory 19" />
+  <macro id="402" versions="5.360 6.000 6.040" description="Extended Logic 7 Output Pulse" />
+  <macro id="403" versions="5.281" description="Macro 3" />
+  <macro id="403" versions="5.285" description="Remote Base Memory 20" />
+  <macro id="403" versions="5.360 6.000 6.040" description="Extended Logic 8 Output Pulse" />
+  <macro id="404" versions="5.281" description="Macro 4" />
+  <macro id="404" versions="5.285" description="Remote Base Memory 21" />
+  <macro id="404" versions="5.360 6.000 6.040" description="Extended Logic 9 Output Pulse" />
+  <macro id="405" versions="5.281" description="Macro 5" />
+  <macro id="405" versions="5.285" description="Remote Base Memory 22" />
+  <macro id="405" versions="5.360 6.000 6.040" description="Extended Logic 10 Output Pulse" />
+  <macro id="406" versions="5.281" description="Macro 6" />
+  <macro id="406" versions="5.285" description="Remote Base Memory 23" />
+  <macro id="406" versions="5.360 6.000 6.040" description="Extended Logic 11 Output Pulse" />
+  <macro id="407" versions="5.281" description="Macro 7" />
+  <macro id="407" versions="5.285" description="Remote Base Memory 24" />
+  <macro id="407" versions="5.360 6.000 6.040" description="Extended Logic 12 Output Pulse" />
+  <macro id="408" versions="5.281" description="Macro 8" />
+  <macro id="408" versions="5.285" description="Remote Base Memory 25" />
+  <macro id="408" versions="5.360 6.000 6.040" description="Extended Logic 13 Output Pulse" />
+  <macro id="409" versions="5.281" description="Macro 9" />
+  <macro id="409" versions="5.285" description="Remote Base Memory 26" />
+  <macro id="409" versions="5.360 6.000 6.040" description="Extended Logic 14 Output Pulse" />
+  <macro id="410" versions="5.281" description="Macro 10" />
+  <macro id="410" versions="5.285" description="Remote Base Memory 27" />
+  <macro id="410" versions="5.360 6.000 6.040" description="Extended Logic 15 Output Pulse" />
+  <macro id="411" versions="5.281" description="Macro 11" />
+  <macro id="411" versions="5.285" description="Remote Base Memory 28" />
+  <macro id="411" versions="5.360 6.000 6.040" description="Extended Logic 16 Output Pulse" />
+  <macro id="412" versions="5.281" description="Macro 12" />
+  <macro id="412" versions="5.285" description="Remote Base Memory 29" />
+  <macro id="412" versions="5.360 6.000 6.040" description="Extended Logic 17 Output Pulse" />
+  <macro id="413" versions="5.281" description="Macro 13" />
+  <macro id="413" versions="5.285" description="Remote Base Memory 30" />
+  <macro id="413" versions="5.360 6.000 6.040" description="Extended Logic 18 Output Pulse" />
+  <macro id="414" versions="5.281" description="Macro 14" />
+  <macro id="414" versions="5.285" description="Remote Base Memory 31" />
+  <macro id="414" versions="5.360 6.000 6.040" description="Extended Logic 19 Output Pulse" />
+  <macro id="415" versions="5.281" description="Macro 15" />
+  <macro id="415" versions="5.285" description="Remote Base Memory 32" />
+  <macro id="415" versions="5.360 6.000 6.040" description="Extended Logic 20 Output Pulse" />
+  <macro id="416" versions="5.281" description="Macro 16" />
+  <macro id="416" versions="5.285" description="Remote Base Memory 33" />
+  <macro id="416" versions="5.360 6.000 6.040" description="Extended Logic 21 Output Pulse" />
+  <macro id="417" versions="5.281" description="Macro 17" />
+  <macro id="417" versions="5.285" description="Remote Base Memory 34" />
+  <macro id="417" versions="5.360 6.000 6.040" description="Extended Logic 22 Output Pulse" />
+  <macro id="418" versions="5.281" description="Macro 18" />
+  <macro id="418" versions="5.285" description="Remote Base Memory 35" />
+  <macro id="418" versions="5.360 6.000 6.040" description="Extended Logic 23 Output Pulse" />
+  <macro id="419" versions="5.281" description="Macro 19" />
+  <macro id="419" versions="5.285" description="Remote Base Memory 36" />
+  <macro id="419" versions="5.360 6.000 6.040" description="Extended Logic 24 Output Pulse" />
+  <macro id="420" versions="5.281" description="Macro 20" />
+  <macro id="420" versions="5.285" description="Remote Base Memory 37" />
+  <macro id="420" versions="5.360 6.000 6.040" description="Extended Logic 25 Output Pulse" />
+  <macro id="421" versions="5.281" description="Macro 21" />
+  <macro id="421" versions="5.285" description="Remote Base Memory 38" />
+  <macro id="421" versions="5.360 6.000 6.040" description="Extended Logic 26 Output Pulse" />
+  <macro id="422" versions="5.281" description="Macro 22" />
+  <macro id="422" versions="5.285" description="Remote Base Memory 39" />
+  <macro id="422" versions="5.360 6.000 6.040" description="Extended Logic 27 Output Pulse" />
+  <macro id="423" versions="5.281" description="Macro 23" />
+  <macro id="423" versions="5.285" description="Remote Base Memory 40" />
+  <macro id="423" versions="5.360 6.000 6.040" description="Extended Logic 28 Output Pulse" />
+  <macro id="424" versions="5.281" description="Macro 24" />
+  <macro id="424" versions="5.285" description="Send DTMF Memory 21" />
+  <macro id="424" versions="5.360 6.000 6.040" description="Extended Logic 29 Output Pulse" />
+  <macro id="425" versions="5.281" description="Macro 25" />
+  <macro id="425" versions="5.285" description="Send DTMF Memory 22" />
+  <macro id="425" versions="5.360 6.000 6.040" description="Extended Logic 30 Output Pulse" />
+  <macro id="426" versions="5.281" description="Macro 26" />
+  <macro id="426" versions="5.285" description="Send DTMF Memory 23" />
+  <macro id="426" versions="5.360 6.000 6.040" description="Extended Logic 31 Output Pulse" />
+  <macro id="427" versions="5.281" description="Macro 27" />
+  <macro id="427" versions="5.285" description="Send DTMF Memory 24" />
+  <macro id="427" versions="5.360 6.000 6.040" description="Extended Logic 32 Output Pulse" />
+  <macro id="428" versions="5.281" description="Macro 28" />
+  <macro id="428" versions="5.285" description="Send DTMF Memory 25" />
+  <macro id="428" versions="5.360 6.000 6.040" description="Extended Logic 1 Output OFF" />
+  <macro id="429" versions="5.281" description="Macro 29" />
+  <macro id="429" versions="5.285" description="Send DTMF Memory 26" />
+  <macro id="429" versions="5.360 6.000 6.040" description="Extended Logic 2 Output OFF" />
+  <macro id="430" versions="5.281" description="Macro 30" />
+  <macro id="430" versions="5.285" description="Send DTMF Memory 27" />
+  <macro id="430" versions="5.360 6.000 6.040" description="Extended Logic 3 Output OFF" />
+  <macro id="431" versions="5.281" description="Macro 31" />
+  <macro id="431" versions="5.285" description="Send DTMF Memory 28" />
+  <macro id="431" versions="5.360 6.000 6.040" description="Extended Logic 4 Output OFF" />
+  <macro id="432" versions="5.281" description="Macro 32" />
+  <macro id="432" versions="5.285" description="Send DTMF Memory 29" />
+  <macro id="432" versions="5.360 6.000 6.040" description="Extended Logic 5 Output OFF" />
+  <macro id="433" versions="5.281" description="Macro 33" />
+  <macro id="433" versions="5.285" description="Send DTMF Memory 30" />
+  <macro id="433" versions="5.360 6.000 6.040" description="Extended Logic 6 Output OFF" />
+  <macro id="434" versions="5.281" description="Macro 34" />
+  <macro id="434" versions="5.285" description="Send DTMF Memory 31" />
+  <macro id="434" versions="5.360 6.000 6.040" description="Extended Logic 7 Output OFF" />
+  <macro id="435" versions="5.281" description="Macro 35" />
+  <macro id="435" versions="5.285" description="Send DTMF Memory 32" />
+  <macro id="435" versions="5.360 6.000 6.040" description="Extended Logic 8 Output OFF" />
+  <macro id="436" versions="5.281" description="Macro 36" />
+  <macro id="436" versions="5.285" description="Send DTMF Memory 33" />
+  <macro id="436" versions="5.360 6.000 6.040" description="Extended Logic 9 Output OFF" />
+  <macro id="437" versions="5.281" description="Macro 37" />
+  <macro id="437" versions="5.285" description="Send DTMF Memory 34" />
+  <macro id="437" versions="5.360 6.000 6.040" description="Extended Logic 10 Output OFF" />
+  <macro id="438" versions="5.281" description="Macro 38" />
+  <macro id="438" versions="5.285" description="Send DTMF Memory 35" />
+  <macro id="438" versions="5.360 6.000 6.040" description="Extended Logic 11 Output OFF" />
+  <macro id="439" versions="5.281" description="Macro 39" />
+  <macro id="439" versions="5.285" description="Send DTMF Memory 36" />
+  <macro id="439" versions="5.360 6.000 6.040" description="Extended Logic 12 Output OFF" />
+  <macro id="440" versions="5.281" description="Macro 40" />
+  <macro id="440" versions="5.285" description="Send DTMF Memory 37" />
+  <macro id="440" versions="5.360 6.000 6.040" description="Extended Logic 13 Output OFF" />
+  <macro id="441" versions="5.281" description="Macro 41" />
+  <macro id="441" versions="5.285" description="Send DTMF Memory 38" />
+  <macro id="441" versions="5.360 6.000 6.040" description="Extended Logic 14 Output OFF" />
+  <macro id="442" versions="5.281" description="Macro 42" />
+  <macro id="442" versions="5.285" description="Send DTMF Memory 39" />
+  <macro id="442" versions="5.360 6.000 6.040" description="Extended Logic 15 Output OFF" />
+  <macro id="443" versions="5.281" description="Macro 43" />
+  <macro id="443" versions="5.285" description="Send DTMF Memory 40" />
+  <macro id="443" versions="5.360 6.000 6.040" description="Extended Logic 16 Output OFF" />
+  <macro id="444" versions="5.281" description="Macro 44" />
+  <macro id="444" versions="5.285" description="Send DTMF Memory 41" />
+  <macro id="444" versions="5.360 6.000 6.040" description="Extended Logic 17 Output OFF" />
+  <macro id="445" versions="5.281" description="Macro 45" />
+  <macro id="445" versions="5.285" description="Send DTMF Memory 42" />
+  <macro id="445" versions="5.360 6.000 6.040" description="Extended Logic 18 Output OFF" />
+  <macro id="446" versions="5.281" description="Macro 46" />
+  <macro id="446" versions="5.285" description="Send DTMF Memory 43" />
+  <macro id="446" versions="5.360 6.000 6.040" description="Extended Logic 19 Output OFF" />
+  <macro id="447" versions="5.281" description="Macro 47" />
+  <macro id="447" versions="5.285" description="Send DTMF Memory 44" />
+  <macro id="447" versions="5.360 6.000 6.040" description="Extended Logic 20 Output OFF" />
+  <macro id="448" versions="5.281" description="Macro 48" />
+  <macro id="448" versions="5.285" description="Send DTMF Memory 45" />
+  <macro id="448" versions="5.360 6.000 6.040" description="Extended Logic 21 Output OFF" />
+  <macro id="449" versions="5.281" description="Macro 49" />
+  <macro id="449" versions="5.285" description="Send DTMF Memory 46" />
+  <macro id="449" versions="5.360 6.000 6.040" description="Extended Logic 22 Output OFF" />
+  <macro id="450" versions="5.281" description="Macro 50" />
+  <macro id="450" versions="5.285" description="Send DTMF Memory 47" />
+  <macro id="450" versions="5.360 6.000 6.040" description="Extended Logic 23 Output OFF" />
+  <macro id="451" versions="5.281" description="Macro 51" />
+  <macro id="451" versions="5.285" description="Send DTMF Memory 48" />
+  <macro id="451" versions="5.360 6.000 6.040" description="Extended Logic 24 Output OFF" />
+  <macro id="452" versions="5.281" description="Macro 52" />
+  <macro id="452" versions="5.285" description="Send DTMF Memory 49" />
+  <macro id="452" versions="5.360 6.000 6.040" description="Extended Logic 25 Output OFF" />
+  <macro id="453" versions="5.281" description="Macro 53" />
+  <macro id="453" versions="5.285" description="Send DTMF Memory 50" />
+  <macro id="453" versions="5.360 6.000 6.040" description="Extended Logic 26 Output OFF" />
+  <macro id="454" versions="5.281" description="Macro 54" />
+  <macro id="454" versions="5.285" description="Load RTC Time/Date" />
+  <macro id="454" versions="5.360 6.000 6.040" description="Extended Logic 27 Output OFF" />
+  <macro id="455" versions="5.281" description="Macro 55" />
+  <macro id="455" versions="5.360 6.000 6.040" description="Extended Logic 28 Output OFF" />
+  <macro id="456" versions="5.281" description="Macro 56" />
+  <macro id="456" versions="5.360 6.000 6.040" description="Extended Logic 29 Output OFF" />
+  <macro id="457" versions="5.281" description="Macro 57" />
+  <macro id="457" versions="5.360 6.000 6.040" description="Extended Logic 30 Output OFF" />
+  <macro id="458" versions="5.281" description="Macro 58" />
+  <macro id="458" versions="5.360 6.000 6.040" description="Extended Logic 31 Output OFF" />
+  <macro id="459" versions="5.281" description="Macro 59" />
+  <macro id="459" versions="5.360 6.000 6.040" description="Extended Logic 32 Output OFF" />
+  <macro id="460" versions="5.281" description="Macro 60" />
+  <macro id="460" versions="5.285" description="Suspend Scheduler Setpoint 1" />
+  <macro id="460" versions="5.360 6.000 6.040" description="Play Message Macro 41" />
+  <macro id="461" versions="5.281" description="Macro 61" />
+  <macro id="461" versions="5.285" description="Suspend Scheduler Setpoint 2" />
+  <macro id="461" versions="5.360 6.000 6.040" description="Play Message Macro 42" />
+  <macro id="462" versions="5.281" description="Macro 62" />
+  <macro id="462" versions="5.285" description="Suspend Scheduler Setpoint 3" />
+  <macro id="462" versions="5.360 6.000 6.040" description="Play Message Macro 43" />
+  <macro id="463" versions="5.281" description="Macro 63" />
+  <macro id="463" versions="5.285" description="Suspend Scheduler Setpoint 4" />
+  <macro id="463" versions="5.360 6.000 6.040" description="Play Message Macro 44" />
+  <macro id="464" versions="5.281" description="Macro 64" />
+  <macro id="464" versions="5.285" description="Suspend Scheduler Setpoint 5" />
+  <macro id="464" versions="5.360 6.000 6.040" description="Play Message Macro 45" />
+  <macro id="465" versions="5.281" description="Macro 65" />
+  <macro id="465" versions="5.285" description="Suspend Scheduler Setpoint 6" />
+  <macro id="465" versions="5.360 6.000 6.040" description="Play Message Macro 46" />
+  <macro id="466" versions="5.281" description="Macro 66" />
+  <macro id="466" versions="5.285" description="Suspend Scheduler Setpoint 7" />
+  <macro id="466" versions="5.360 6.000 6.040" description="Play Message Macro 47" />
+  <macro id="467" versions="5.281" description="Macro 67" />
+  <macro id="467" versions="5.285" description="Suspend Scheduler Setpoint 8" />
+  <macro id="467" versions="5.360 6.000 6.040" description="Play Message Macro 48" />
+  <macro id="468" versions="5.281" description="Macro 68" />
+  <macro id="468" versions="5.285" description="Suspend Scheduler Setpoint 9" />
+  <macro id="468" versions="5.360 6.000 6.040" description="Play Message Macro 49" />
+  <macro id="469" versions="5.281" description="Macro 69" />
+  <macro id="469" versions="5.285" description="Suspend Scheduler Setpoint 10" />
+  <macro id="469" versions="5.360 6.000 6.040" description="Play Message Macro 50" />
+  <macro id="470" versions="5.281" description="Macro 70" />
+  <macro id="470" versions="5.285" description="Suspend Scheduler Setpoint 11" />
+  <macro id="470" versions="5.360 6.000 6.040" description="Play Message Macro 51" />
+  <macro id="471" versions="5.281" description="Macro 71" />
+  <macro id="471" versions="5.285" description="Suspend Scheduler Setpoint 12" />
+  <macro id="471" versions="5.360 6.000 6.040" description="Play Message Macro 52" />
+  <macro id="472" versions="5.281" description="Macro 72" />
+  <macro id="472" versions="5.285" description="Suspend Scheduler Setpoint 13" />
+  <macro id="472" versions="5.360 6.000 6.040" description="Play Message Macro 53" />
+  <macro id="473" versions="5.281" description="Macro 73" />
+  <macro id="473" versions="5.285" description="Suspend Scheduler Setpoint 14" />
+  <macro id="473" versions="5.360 6.000 6.040" description="Play Message Macro 54" />
+  <macro id="474" versions="5.281" description="Macro 74" />
+  <macro id="474" versions="5.285" description="Suspend Scheduler Setpoint 15" />
+  <macro id="474" versions="5.360 6.000 6.040" description="Play Message Macro 55" />
+  <macro id="475" versions="5.281" description="Macro 75" />
+  <macro id="475" versions="5.285" description="Suspend Scheduler Setpoint 16" />
+  <macro id="475" versions="5.360 6.000 6.040" description="Play Message Macro 56" />
+  <macro id="476" versions="5.281" description="Macro 76" />
+  <macro id="476" versions="5.285" description="Suspend Scheduler Setpoint 17" />
+  <macro id="476" versions="5.360 6.000 6.040" description="Play Message Macro 57" />
+  <macro id="477" versions="5.281" description="Macro 77" />
+  <macro id="477" versions="5.285" description="Suspend Scheduler Setpoint 18" />
+  <macro id="477" versions="5.360 6.000 6.040" description="Play Message Macro 58" />
+  <macro id="478" versions="5.281" description="Macro 78" />
+  <macro id="478" versions="5.285" description="Suspend Scheduler Setpoint 19" />
+  <macro id="478" versions="5.360 6.000 6.040" description="Play Message Macro 59" />
+  <macro id="479" versions="5.281" description="Macro 79" />
+  <macro id="479" versions="5.285" description="Suspend Scheduler Setpoint 20" />
+  <macro id="479" versions="5.360 6.000 6.040" description="Play Message Macro 60" />
+  <macro id="480" versions="5.281" description="Macro 80" />
+  <macro id="480" versions="5.285" description="Resume Scheduler Setpoint 1" />
+  <macro id="480" versions="5.360 6.000 6.040" description="Play Message Macro 61" />
+  <macro id="481" versions="5.281" description="Macro 81" />
+  <macro id="481" versions="5.285" description="Resume Scheduler Setpoint 2" />
+  <macro id="481" versions="5.360 6.000 6.040" description="Play Message Macro 62" />
+  <macro id="482" versions="5.281" description="Macro 82" />
+  <macro id="482" versions="5.285" description="Resume Scheduler Setpoint 3" />
+  <macro id="482" versions="5.360 6.000 6.040" description="Play Message Macro 63" />
+  <macro id="483" versions="5.281" description="Macro 83" />
+  <macro id="483" versions="5.285" description="Resume Scheduler Setpoint 4" />
+  <macro id="483" versions="5.360 6.000 6.040" description="Play Message Macro 64" />
+  <macro id="484" versions="5.281" description="Macro 84" />
+  <macro id="484" versions="5.285" description="Resume Scheduler Setpoint 5" />
+  <macro id="484" versions="5.360 6.000 6.040" description="Play Message Macro 65" />
+  <macro id="485" versions="5.281" description="Macro 85" />
+  <macro id="485" versions="5.285" description="Resume Scheduler Setpoint 6" />
+  <macro id="485" versions="5.360 6.000 6.040" description="Play Message Macro 66" />
+  <macro id="486" versions="5.281" description="Macro 86" />
+  <macro id="486" versions="5.285" description="Resume Scheduler Setpoint 7" />
+  <macro id="486" versions="5.360 6.000 6.040" description="Play Message Macro 67" />
+  <macro id="487" versions="5.281" description="Macro 87" />
+  <macro id="487" versions="5.285" description="Resume Scheduler Setpoint 8" />
+  <macro id="487" versions="5.360 6.000 6.040" description="Play Message Macro 68" />
+  <macro id="488" versions="5.281" description="Macro 88" />
+  <macro id="488" versions="5.285" description="Resume Scheduler Setpoint 9" />
+  <macro id="488" versions="5.360 6.000 6.040" description="Play Message Macro 69" />
+  <macro id="489" versions="5.281" description="Macro 89" />
+  <macro id="489" versions="5.285" description="Resume Scheduler Setpoint 10" />
+  <macro id="489" versions="5.360 6.000 6.040" description="Play Message Macro 70" />
+  <macro id="490" versions="5.281" description="Macro 90" />
+  <macro id="490" versions="5.285" description="Resume Scheduler Setpoint 11" />
+  <macro id="490" versions="5.360 6.000 6.040" description="Remote Base Memory 11" />
+  <macro id="491" versions="5.285" description="Resume Scheduler Setpoint 12" />
+  <macro id="491" versions="5.360 6.000 6.040" description="Remote Base Memory 12" />
+  <macro id="492" versions="5.285" description="Resume Scheduler Setpoint 13" />
+  <macro id="492" versions="5.360 6.000 6.040" description="Remote Base Memory 13" />
+  <macro id="493" versions="5.285" description="Resume Scheduler Setpoint 14" />
+  <macro id="493" versions="5.360 6.000 6.040" description="Remote Base Memory 14" />
+  <macro id="494" versions="5.285" description="Resume Scheduler Setpoint 15" />
+  <macro id="494" versions="5.360 6.000 6.040" description="Remote Base Memory 15" />
+  <macro id="495" versions="5.285" description="Resume Scheduler Setpoint 16" />
+  <macro id="495" versions="5.360 6.000 6.040" description="Remote Base Memory 16" />
+  <macro id="496" versions="5.285" description="Resume Scheduler Setpoint 17" />
+  <macro id="496" versions="5.360 6.000 6.040" description="Remote Base Memory 17" />
+  <macro id="497" versions="5.285" description="Resume Scheduler Setpoint 18" />
+  <macro id="497" versions="5.360 6.000 6.040" description="Remote Base Memory 18" />
+  <macro id="498" versions="5.285" description="Resume Scheduler Setpoint 19" />
+  <macro id="498" versions="5.360 6.000 6.040" description="Remote Base Memory 19" />
+  <macro id="499" versions="5.285" description="Resume Scheduler Setpoint 20" />
+  <macro id="499" versions="5.360 6.000 6.040" description="Remote Base Memory 20" />
+  <macro id="500" versions="5.360 6.000 6.040" description="Remote Base Memory 21" />
+  <macro id="501" versions="5.285" description="Call Macro 1" />
+  <macro id="501" versions="5.360 6.000 6.040" description="Remote Base Memory 22" />
+  <macro id="502" versions="5.285" description="Call Macro 2" />
+  <macro id="502" versions="5.360 6.000 6.040" description="Remote Base Memory 23" />
+  <macro id="503" versions="5.285" description="Call Macro 3" />
+  <macro id="503" versions="5.360 6.000 6.040" description="Remote Base Memory 24" />
+  <macro id="504" versions="5.285" description="Call Macro 4" />
+  <macro id="504" versions="5.360 6.000 6.040" description="Remote Base Memory 25" />
+  <macro id="505" versions="5.285" description="Call Macro 5" />
+  <macro id="505" versions="5.360 6.000 6.040" description="Remote Base Memory 26" />
+  <macro id="506" versions="5.285" description="Call Macro 6" />
+  <macro id="506" versions="5.360 6.000 6.040" description="Remote Base Memory 27" />
+  <macro id="507" versions="5.285" description="Call Macro 7" />
+  <macro id="507" versions="5.360 6.000 6.040" description="Remote Base Memory 28" />
+  <macro id="508" versions="5.285" description="Call Macro 8" />
+  <macro id="508" versions="5.360 6.000 6.040" description="Remote Base Memory 29" />
+  <macro id="509" versions="5.285" description="Call Macro 9" />
+  <macro id="509" versions="5.360 6.000 6.040" description="Remote Base Memory 30" />
+  <macro id="510" versions="5.285" description="Call Macro 10" />
+  <macro id="511" versions="5.285" description="Call Macro 11" />
+  <macro id="511" versions="5.360 6.000 6.040" description="Remote Base Memory 31" />
+  <macro id="512" versions="5.285" description="Call Macro 12" />
+  <macro id="512" versions="5.360 6.000 6.040" description="Remote Base Memory 32" />
+  <macro id="513" versions="5.285" description="Call Macro 13" />
+  <macro id="513" versions="5.360 6.000 6.040" description="Remote Base Memory 33" />
+  <macro id="514" versions="5.285" description="Call Macro 14" />
+  <macro id="514" versions="5.360 6.000 6.040" description="Remote Base Memory 34" />
+  <macro id="515" versions="5.285" description="Call Macro 15" />
+  <macro id="515" versions="5.360 6.000 6.040" description="Remote Base Memory 35" />
+  <macro id="516" versions="5.285" description="Call Macro 16" />
+  <macro id="516" versions="5.360 6.000 6.040" description="Remote Base Memory 36" />
+  <macro id="517" versions="5.285" description="Call Macro 17" />
+  <macro id="517" versions="5.360 6.000 6.040" description="Remote Base Memory 37" />
+  <macro id="518" versions="5.285" description="Call Macro 18" />
+  <macro id="518" versions="5.360 6.000 6.040" description="Remote Base Memory 38" />
+  <macro id="519" versions="5.285" description="Call Macro 19" />
+  <macro id="519" versions="5.360 6.000 6.040" description="Remote Base Memory 39" />
+  <macro id="520" versions="5.285" description="Call Macro 20" />
+  <macro id="520" versions="5.360 6.000 6.040" description="Remote Base Memory 40" />
+  <macro id="521" versions="5.285" description="Call Macro 21" />
+  <macro id="521" versions="5.360 6.000 6.040" description="Send DTMF Memory 21" />
+  <macro id="522" versions="5.285" description="Call Macro 22" />
+  <macro id="522" versions="5.360 6.000 6.040" description="Send DTMF Memory 22" />
+  <macro id="523" versions="5.285" description="Call Macro 23" />
+  <macro id="523" versions="5.360 6.000 6.040" description="Send DTMF Memory 23" />
+  <macro id="524" versions="5.285" description="Call Macro 24" />
+  <macro id="524" versions="5.360 6.000 6.040" description="Send DTMF Memory 24" />
+  <macro id="525" versions="5.285" description="Call Macro 25" />
+  <macro id="525" versions="5.360 6.000 6.040" description="Send DTMF Memory 25" />
+  <macro id="526" versions="5.285" description="Call Macro 26" />
+  <macro id="526" versions="5.360 6.000 6.040" description="Send DTMF Memory 26" />
+  <macro id="527" versions="5.285" description="Call Macro 27" />
+  <macro id="527" versions="5.360 6.000 6.040" description="Send DTMF Memory 27" />
+  <macro id="528" versions="5.285" description="Call Macro 28" />
+  <macro id="528" versions="5.360 6.000 6.040" description="Send DTMF Memory 28" />
+  <macro id="529" versions="5.285" description="Call Macro 29" />
+  <macro id="529" versions="5.360 6.000 6.040" description="Send DTMF Memory 29" />
+  <macro id="530" versions="5.285" description="Call Macro 30" />
+  <macro id="530" versions="5.360 6.000 6.040" description="Send DTMF Memory 30" />
+  <macro id="531" versions="5.285" description="Call Macro 31" />
+  <macro id="531" versions="5.360 6.000 6.040" description="Send DTMF Memory 31" />
+  <macro id="532" versions="5.285" description="Call Macro 32" />
+  <macro id="532" versions="5.360 6.000 6.040" description="Send DTMF Memory 32" />
+  <macro id="533" versions="5.285" description="Call Macro 33" />
+  <macro id="533" versions="5.360 6.000 6.040" description="Send DTMF Memory 33" />
+  <macro id="534" versions="5.285" description="Call Macro 34" />
+  <macro id="534" versions="5.360 6.000 6.040" description="Send DTMF Memory 34" />
+  <macro id="535" versions="5.285" description="Call Macro 35" />
+  <macro id="535" versions="5.360 6.000 6.040" description="Send DTMF Memory 35" />
+  <macro id="536" versions="5.285" description="Call Macro 36" />
+  <macro id="536" versions="5.360 6.000 6.040" description="Send DTMF Memory 36" />
+  <macro id="537" versions="5.285" description="Call Macro 37" />
+  <macro id="537" versions="5.360 6.000 6.040" description="Send DTMF Memory 37" />
+  <macro id="538" versions="5.285" description="Call Macro 38" />
+  <macro id="538" versions="5.360 6.000 6.040" description="Send DTMF Memory 38" />
+  <macro id="539" versions="5.285" description="Call Macro 39" />
+  <macro id="539" versions="5.360 6.000 6.040" description="Send DTMF Memory 39" />
+  <macro id="540" versions="5.285" description="Call Macro 40" />
+  <macro id="540" versions="5.360 6.000 6.040" description="Send DTMF Memory 40" />
+  <macro id="541" versions="5.285" description="Call Macro 41" />
+  <macro id="541" versions="5.360 6.000 6.040" description="Send DTMF Memory 41" />
+  <macro id="542" versions="5.285" description="Call Macro 42" />
+  <macro id="542" versions="5.360 6.000 6.040" description="Send DTMF Memory 42" />
+  <macro id="543" versions="5.285" description="Call Macro 43" />
+  <macro id="543" versions="5.360 6.000 6.040" description="Send DTMF Memory 43" />
+  <macro id="544" versions="5.285" description="Call Macro 44" />
+  <macro id="544" versions="5.360 6.000 6.040" description="Send DTMF Memory 44" />
+  <macro id="545" versions="5.285" description="Call Macro 45" />
+  <macro id="545" versions="5.360 6.000 6.040" description="Send DTMF Memory 45" />
+  <macro id="546" versions="5.285" description="Call Macro 46" />
+  <macro id="546" versions="5.360 6.000 6.040" description="Send DTMF Memory 46" />
+  <macro id="547" versions="5.285" description="Call Macro 47" />
+  <macro id="547" versions="5.360 6.000 6.040" description="Send DTMF Memory 47" />
+  <macro id="548" versions="5.285" description="Call Macro 48" />
+  <macro id="548" versions="5.360 6.000 6.040" description="Send DTMF Memory 48" />
+  <macro id="549" versions="5.285" description="Call Macro 49" />
+  <macro id="549" versions="5.360 6.000 6.040" description="Send DTMF Memory 49" />
+  <macro id="550" versions="5.285" description="Call Macro 50" />
+  <macro id="550" versions="5.360 6.000 6.040" description="Send DTMF Memory 50" />
+  <macro id="551" versions="5.285" description="Call Macro 51" />
+  <macro id="551" versions="5.360 6.000 6.040" description="Get RTC Time and Date" />
+  <macro id="552" versions="5.285" description="Call Macro 52" />
+  <macro id="552" versions="6.000 6.040" description="CTCSS During ID ON" />
+  <macro id="553" versions="5.285" description="Call Macro 53" />
+  <macro id="553" versions="6.000 6.040" description="CTCSS During ID OFF" />
+  <macro id="554" versions="5.285" description="Call Macro 54" />
+  <macro id="555" versions="5.285" description="Call Macro 55" />
+  <macro id="556" versions="5.285" description="Call Macro 56" />
+  <macro id="557" versions="5.285" description="Call Macro 57" />
+  <macro id="558" versions="5.285" description="Call Macro 58" />
+  <macro id="559" versions="5.285" description="Call Macro 59" />
+  <macro id="560" versions="5.285" description="Call Macro 60" />
+  <macro id="560" versions="5.360" description="Suspend Scheduler Setpoint 1" />
+  <macro id="561" versions="5.285" description="Call Macro 61" />
+  <macro id="561" versions="5.360" description="Suspend Scheduler Setpoint 2" />
+  <macro id="561" versions="6.000 6.040" description="Restart Controller" />
+  <macro id="562" versions="5.285" description="Call Macro 62" />
+  <macro id="562" versions="5.360" description="Suspend Scheduler Setpoint 3" />
+  <macro id="563" versions="5.285" description="Call Macro 63" />
+  <macro id="563" versions="5.360" description="Suspend Scheduler Setpoint 4" />
+  <macro id="564" versions="5.285" description="Call Macro 64" />
+  <macro id="564" versions="5.360" description="Suspend Scheduler Setpoint 5" />
+  <macro id="565" versions="5.285" description="Call Macro 65" />
+  <macro id="565" versions="5.360" description="Suspend Scheduler Setpoint 6" />
+  <macro id="566" versions="5.285" description="Call Macro 66" />
+  <macro id="566" versions="5.360" description="Suspend Scheduler Setpoint 7" />
+  <macro id="567" versions="5.285" description="Call Macro 67" />
+  <macro id="567" versions="5.360" description="Suspend Scheduler Setpoint 8" />
+  <macro id="568" versions="5.285" description="Call Macro 68" />
+  <macro id="568" versions="5.360" description="Suspend Scheduler Setpoint 9" />
+  <macro id="569" versions="5.285" description="Call Macro 69" />
+  <macro id="569" versions="5.360" description="Suspend Scheduler Setpoint 10" />
+  <macro id="570" versions="5.285" description="Call Macro 70" />
+  <macro id="570" versions="5.360" description="Suspend Scheduler Setpoint 11" />
+  <macro id="570" versions="6.000 6.040" description="Readback A/D Channel 1 Stored Low" />
+  <macro id="571" versions="5.285" description="Call Macro 71" />
+  <macro id="571" versions="5.360" description="Suspend Scheduler Setpoint 12" />
+  <macro id="571" versions="6.000 6.040" description="Readback A/D Channel 2 Stored Low" />
+  <macro id="572" versions="5.285" description="Call Macro 72" />
+  <macro id="572" versions="5.360" description="Suspend Scheduler Setpoint 13" />
+  <macro id="572" versions="6.000 6.040" description="Readback A/D Channel 3 Stored Low" />
+  <macro id="573" versions="5.285" description="Call Macro 73" />
+  <macro id="573" versions="5.360" description="Suspend Scheduler Setpoint 14" />
+  <macro id="573" versions="6.000 6.040" description="Readback A/D Channel 4 Stored Low" />
+  <macro id="574" versions="5.285" description="Call Macro 74" />
+  <macro id="574" versions="5.360" description="Suspend Scheduler Setpoint 15" />
+  <macro id="574" versions="6.000 6.040" description="Readback A/D Channel 5 Stored Low" />
+  <macro id="575" versions="5.285" description="Call Macro 75" />
+  <macro id="575" versions="5.360" description="Suspend Scheduler Setpoint 16" />
+  <macro id="575" versions="6.000 6.040" description="Readback A/D Channel 6 Stored Low" />
+  <macro id="576" versions="5.285" description="Call Macro 76" />
+  <macro id="576" versions="5.360" description="Suspend Scheduler Setpoint 17" />
+  <macro id="576" versions="6.000 6.040" description="Readback A/D Channel 7 Stored Low" />
+  <macro id="577" versions="5.285" description="Call Macro 77" />
+  <macro id="577" versions="5.360" description="Suspend Scheduler Setpoint 18" />
+  <macro id="577" versions="6.000 6.040" description="Readback A/D Channel 8 Stored Low" />
+  <macro id="578" versions="5.285" description="Call Macro 78" />
+  <macro id="578" versions="5.360" description="Suspend Scheduler Setpoint 19" />
+  <macro id="578" versions="6.000 6.040" description="Readback A/D Channel 1 Stored High" />
+  <macro id="579" versions="5.285" description="Call Macro 79" />
+  <macro id="579" versions="5.360" description="Suspend Scheduler Setpoint 20" />
+  <macro id="579" versions="6.000 6.040" description="Readback A/D Channel 2 Stored High" />
+  <macro id="580" versions="5.285" description="Call Macro 80" />
+  <macro id="580" versions="5.360" description="Resume Scheduler Setpoint 1" />
+  <macro id="580" versions="6.000 6.040" description="Readback A/D Channel 3 Stored High" />
+  <macro id="581" versions="5.285" description="Call Macro 81" />
+  <macro id="581" versions="5.360" description="Resume Scheduler Setpoint 2" />
+  <macro id="581" versions="6.000 6.040" description="Readback A/D Channel 4 Stored High" />
+  <macro id="582" versions="5.285" description="Call Macro 82" />
+  <macro id="582" versions="5.360" description="Resume Scheduler Setpoint 3" />
+  <macro id="582" versions="6.000 6.040" description="Readback A/D Channel 5 Stored High" />
+  <macro id="583" versions="5.285" description="Call Macro 83" />
+  <macro id="583" versions="5.360" description="Resume Scheduler Setpoint 4" />
+  <macro id="583" versions="6.000 6.040" description="Readback A/D Channel 6 Stored High" />
+  <macro id="584" versions="5.285" description="Call Macro 84" />
+  <macro id="584" versions="5.360" description="Resume Scheduler Setpoint 5" />
+  <macro id="584" versions="6.000 6.040" description="Readback A/D Channel 7 Stored High" />
+  <macro id="585" versions="5.285" description="Call Macro 85" />
+  <macro id="585" versions="5.360" description="Resume Scheduler Setpoint 6" />
+  <macro id="585" versions="6.000 6.040" description="Readback A/D Channel 8 Stored High" />
+  <macro id="586" versions="5.285" description="Call Macro 86" />
+  <macro id="586" versions="5.360" description="Resume Scheduler Setpoint 7" />
+  <macro id="586" versions="6.000 6.040" description="Disable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="587" versions="5.285" description="Call Macro 87" />
+  <macro id="587" versions="5.360" description="Resume Scheduler Setpoint 8" />
+  <macro id="587" versions="6.000 6.040" description="Disable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="588" versions="5.285" description="Call Macro 88" />
+  <macro id="588" versions="5.360" description="Resume Scheduler Setpoint 9" />
+  <macro id="588" versions="6.000 6.040" description="Disable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="589" versions="5.285" description="Call Macro 89" />
+  <macro id="589" versions="5.360" description="Resume Scheduler Setpoint 10" />
+  <macro id="589" versions="6.000 6.040" description="Enable Port 1 Timeout Timer ONLY for 60 min." />
+  <macro id="590" versions="5.285" description="Call Macro 90" />
+  <macro id="590" versions="5.360" description="Resume Scheduler Setpoint 11" />
+  <macro id="590" versions="6.000 6.040" description="Enable Port 2 Timeout Timer ONLY for 60 min." />
+  <macro id="591" versions="5.360" description="Resume Scheduler Setpoint 12" />
+  <macro id="591" versions="6.000 6.040" description="Enable Port 3 Timeout Timer ONLY for 60 min." />
+  <macro id="592" versions="5.360" description="Resume Scheduler Setpoint 13" />
+  <macro id="592" versions="6.000 6.040" description="Current wind speed and direction" />
+  <macro id="593" versions="5.360" description="Resume Scheduler Setpoint 14" />
+  <macro id="593" versions="6.000 6.040" description="Current Outdoor temperature" />
+  <macro id="594" versions="5.360" description="Resume Scheduler Setpoint 15" />
+  <macro id="594" versions="6.000 6.040" description="Indoor humidity" />
+  <macro id="595" versions="5.360" description="Resume Scheduler Setpoint 16" />
+  <macro id="595" versions="6.000 6.040" description="Outdoor humidity" />
+  <macro id="596" versions="5.360" description="Resume Scheduler Setpoint 17" />
+  <macro id="596" versions="6.000 6.040" description="Wind Speed high and direction (since Midnight)" />
+  <macro id="597" versions="5.360" description="Resume Scheduler Setpoint 18" />
+  <macro id="597" versions="6.000 6.040" description="Outdoor Temp High (since Midnight)" />
+  <macro id="598" versions="5.360" description="Resume Scheduler Setpoint 19" />
+  <macro id="598" versions="6.000 6.040" description="Outdoor Temp Low (since Midnight)" />
+  <macro id="599" versions="5.360" description="Resume Scheduler Setpoint 20" />
+  <macro id="601" versions="5.360" description="Call Macro 1" />
+  <macro id="602" versions="5.360" description="Call Macro 2" />
+  <macro id="603" versions="5.360" description="Call Macro 3" />
+  <macro id="604" versions="5.360" description="Call Macro 4" />
+  <macro id="605" versions="5.360" description="Call Macro 5" />
+  <macro id="605" versions="6.000 6.040" description="Speak Current Remote Base Freq and Offset" />
+  <macro id="606" versions="5.360" description="Call Macro 6" />
+  <macro id="606" versions="6.040" description="Start General Timer 4" />
+  <macro id="607" versions="5.360" description="Call Macro 7" />
+  <macro id="607" versions="6.040" description="Start General Timer 5" />
+  <macro id="608" versions="5.360" description="Call Macro 8" />
+  <macro id="608" versions="6.040" description="Start General Timer 6" />
+  <macro id="609" versions="5.360" description="Call Macro 9" />
+  <macro id="609" versions="6.040" description="Stop General Timer 4" />
+  <macro id="610" versions="5.360" description="Call Macro 10" />
+  <macro id="610" versions="6.040" description="Stop General Timer 5" />
+  <macro id="611" versions="5.360" description="Call Macro 11" />
+  <macro id="611" versions="6.040" description="Stop General Timer 6" />
+  <macro id="612" versions="5.360" description="Call Macro 12" />
+  <macro id="612" versions="6.040" description="Disable Port 1 Inactivity Timer" />
+  <macro id="613" versions="5.360" description="Call Macro 13" />
+  <macro id="613" versions="6.040" description="Disable Port 2 Inactivity Timer" />
+  <macro id="614" versions="5.360" description="Call Macro 14" />
+  <macro id="614" versions="6.040" description="Disable Port 3 Inactivity Timer" />
+  <macro id="615" versions="5.360" description="Call Macro 15" />
+  <macro id="615" versions="6.040" description="Enable Port 1 Inactivity Timer to Programmed Value" />
+  <macro id="616" versions="5.360" description="Call Macro 16" />
+  <macro id="616" versions="6.040" description="Enable Port 2 Inactivity Timer to Programmed Value" />
+  <macro id="617" versions="5.360" description="Call Macro 17" />
+  <macro id="617" versions="6.040" description="Enable Port 3 Inactivity Timer to Programmed Value" />
+  <macro id="618" versions="5.360" description="Call Macro 18" />
+  <macro id="618" versions="6.040" description="1 Second Execution Delay" />
+  <macro id="619" versions="5.360" description="Call Macro 19" />
+  <macro id="619" versions="6.040" description="2 Second Execution Delay" />
+  <macro id="620" versions="5.360" description="Call Macro 20" />
+  <macro id="620" versions="6.040" description="4 Second Execution Delay" />
+  <macro id="621" versions="5.360" description="Call Macro 21" />
+  <macro id="622" versions="5.360" description="Call Macro 22" />
+  <macro id="623" versions="5.360" description="Call Macro 23" />
+  <macro id="624" versions="5.360" description="Call Macro 24" />
+  <macro id="625" versions="5.360" description="Call Macro 25" />
+  <macro id="626" versions="5.360" description="Call Macro 26" />
+  <macro id="627" versions="5.360" description="Call Macro 27" />
+  <macro id="628" versions="5.360" description="Call Macro 28" />
+  <macro id="629" versions="5.360" description="Call Macro 29" />
+  <macro id="630" versions="5.360" description="Call Macro 30" />
+  <macro id="631" versions="5.360" description="Call Macro 31" />
+  <macro id="632" versions="5.360" description="Call Macro 32" />
+  <macro id="633" versions="5.360" description="Call Macro 33" />
+  <macro id="634" versions="5.360" description="Call Macro 34" />
+  <macro id="635" versions="5.360" description="Call Macro 35" />
+  <macro id="636" versions="5.360" description="Call Macro 36" />
+  <macro id="637" versions="5.360" description="Call Macro 37" />
+  <macro id="638" versions="5.360" description="Call Macro 38" />
+  <macro id="639" versions="5.360" description="Call Macro 39" />
+  <macro id="640" versions="5.360" description="Call Macro 40" />
+  <macro id="641" versions="5.360" description="Call Macro 41" />
+  <macro id="642" versions="5.360" description="Call Macro 42" />
+  <macro id="643" versions="5.360" description="Call Macro 43" />
+  <macro id="644" versions="5.360" description="Call Macro 44" />
+  <macro id="645" versions="5.360" description="Call Macro 45" />
+  <macro id="646" versions="5.360" description="Call Macro 46" />
+  <macro id="647" versions="5.360" description="Call Macro 47" />
+  <macro id="648" versions="5.360" description="Call Macro 48" />
+  <macro id="649" versions="5.360" description="Call Macro 49" />
+  <macro id="650" versions="5.360" description="Call Macro 50" />
+  <macro id="651" versions="5.360" description="Call Macro 51" />
+  <macro id="652" versions="5.360" description="Call Macro 52" />
+  <macro id="653" versions="5.360" description="Call Macro 53" />
+  <macro id="654" versions="5.360" description="Call Macro 54" />
+  <macro id="655" versions="5.360" description="Call Macro 55" />
+  <macro id="656" versions="5.360" description="Call Macro 56" />
+  <macro id="657" versions="5.360" description="Call Macro 57" />
+  <macro id="658" versions="5.360" description="Call Macro 58" />
+  <macro id="659" versions="5.360" description="Call Macro 59" />
+  <macro id="660" versions="5.360" description="Call Macro 60" />
+  <macro id="660" versions="6.000 6.040" description="Suspend Scheduler Setpoint 1" />
+  <macro id="661" versions="5.360" description="Call Macro 61" />
+  <macro id="661" versions="6.000 6.040" description="Suspend Scheduler Setpoint 2" />
+  <macro id="662" versions="5.360" description="Call Macro 62" />
+  <macro id="662" versions="6.000 6.040" description="Suspend Scheduler Setpoint 3" />
+  <macro id="663" versions="5.360" description="Call Macro 63" />
+  <macro id="663" versions="6.000 6.040" description="Suspend Scheduler Setpoint 4" />
+  <macro id="664" versions="5.360" description="Call Macro 64" />
+  <macro id="664" versions="6.000 6.040" description="Suspend Scheduler Setpoint 5" />
+  <macro id="665" versions="5.360" description="Call Macro 65" />
+  <macro id="665" versions="6.000 6.040" description="Suspend Scheduler Setpoint 6" />
+  <macro id="666" versions="5.360" description="Call Macro 66" />
+  <macro id="666" versions="6.000 6.040" description="Suspend Scheduler Setpoint 7" />
+  <macro id="667" versions="5.360" description="Call Macro 67" />
+  <macro id="667" versions="6.000 6.040" description="Suspend Scheduler Setpoint 8" />
+  <macro id="668" versions="5.360" description="Call Macro 68" />
+  <macro id="668" versions="6.000 6.040" description="Suspend Scheduler Setpoint 9" />
+  <macro id="669" versions="5.360" description="Call Macro 69" />
+  <macro id="669" versions="6.000 6.040" description="Suspend Scheduler Setpoint 10" />
+  <macro id="670" versions="5.360" description="Call Macro 70" />
+  <macro id="670" versions="6.000 6.040" description="Suspend Scheduler Setpoint 11" />
+  <macro id="671" versions="5.360" description="Call Macro 71" />
+  <macro id="671" versions="6.000 6.040" description="Suspend Scheduler Setpoint 12" />
+  <macro id="672" versions="5.360" description="Call Macro 72" />
+  <macro id="672" versions="6.000 6.040" description="Suspend Scheduler Setpoint 13" />
+  <macro id="673" versions="5.360" description="Call Macro 73" />
+  <macro id="673" versions="6.000 6.040" description="Suspend Scheduler Setpoint 14" />
+  <macro id="674" versions="5.360" description="Call Macro 74" />
+  <macro id="674" versions="6.000 6.040" description="Suspend Scheduler Setpoint 15" />
+  <macro id="675" versions="5.360" description="Call Macro 75" />
+  <macro id="675" versions="6.000 6.040" description="Suspend Scheduler Setpoint 16" />
+  <macro id="676" versions="5.360" description="Call Macro 76" />
+  <macro id="676" versions="6.000 6.040" description="Suspend Scheduler Setpoint 17" />
+  <macro id="677" versions="5.360" description="Call Macro 77" />
+  <macro id="677" versions="6.000 6.040" description="Suspend Scheduler Setpoint 18" />
+  <macro id="678" versions="5.360" description="Call Macro 78" />
+  <macro id="678" versions="6.000 6.040" description="Suspend Scheduler Setpoint 19" />
+  <macro id="679" versions="5.360" description="Call Macro 79" />
+  <macro id="679" versions="6.000 6.040" description="Suspend Scheduler Setpoint 20" />
+  <macro id="680" versions="5.360" description="Call Macro 80" />
+  <macro id="680" versions="6.000 6.040" description="Resume Scheduler Setpoint 1" />
+  <macro id="681" versions="5.360" description="Call Macro 81" />
+  <macro id="681" versions="6.000 6.040" description="Resume Scheduler Setpoint 2" />
+  <macro id="682" versions="5.360" description="Call Macro 82" />
+  <macro id="682" versions="6.000 6.040" description="Resume Scheduler Setpoint 3" />
+  <macro id="683" versions="5.360" description="Call Macro 83" />
+  <macro id="683" versions="6.000 6.040" description="Resume Scheduler Setpoint 4" />
+  <macro id="684" versions="5.360" description="Call Macro 84" />
+  <macro id="684" versions="6.000 6.040" description="Resume Scheduler Setpoint 5" />
+  <macro id="685" versions="5.360" description="Call Macro 85" />
+  <macro id="685" versions="6.000 6.040" description="Resume Scheduler Setpoint 6" />
+  <macro id="686" versions="5.360" description="Call Macro 86" />
+  <macro id="686" versions="6.000 6.040" description="Resume Scheduler Setpoint 7" />
+  <macro id="687" versions="5.360" description="Call Macro 87" />
+  <macro id="687" versions="6.000 6.040" description="Resume Scheduler Setpoint 8" />
+  <macro id="688" versions="5.360" description="Call Macro 88" />
+  <macro id="688" versions="6.000 6.040" description="Resume Scheduler Setpoint 9" />
+  <macro id="689" versions="5.360" description="Call Macro 89" />
+  <macro id="689" versions="6.000 6.040" description="Resume Scheduler Setpoint 10" />
+  <macro id="690" versions="5.360" description="Call Macro 90" />
+  <macro id="690" versions="6.000 6.040" description="Resume Scheduler Setpoint 11" />
+  <macro id="691" versions="6.000 6.040" description="Resume Scheduler Setpoint 12" />
+  <macro id="692" versions="6.000 6.040" description="Resume Scheduler Setpoint 13" />
+  <macro id="693" versions="6.000 6.040" description="Resume Scheduler Setpoint 14" />
+  <macro id="694" versions="6.000 6.040" description="Resume Scheduler Setpoint 15" />
+  <macro id="695" versions="6.000 6.040" description="Resume Scheduler Setpoint 16" />
+  <macro id="696" versions="6.000 6.040" description="Resume Scheduler Setpoint 17" />
+  <macro id="697" versions="6.000 6.040" description="Resume Scheduler Setpoint 18" />
+  <macro id="698" versions="6.000 6.040" description="Resume Scheduler Setpoint 19" />
+  <macro id="699" versions="6.000 6.040" description="Resume Scheduler Setpoint 20" />
+  <macro id="701" versions="6.000 6.040" description="Call Macro 1" />
+  <macro id="702" versions="6.000 6.040" description="Call Macro 2" />
+  <macro id="703" versions="6.000 6.040" description="Call Macro 3" />
+  <macro id="704" versions="6.000 6.040" description="Call Macro 4" />
+  <macro id="705" versions="6.000 6.040" description="Call Macro 5" />
+  <macro id="706" versions="6.000 6.040" description="Call Macro 6" />
+  <macro id="707" versions="6.000 6.040" description="Call Macro 7" />
+  <macro id="708" versions="6.000 6.040" description="Call Macro 8" />
+  <macro id="709" versions="6.000 6.040" description="Call Macro 9" />
+  <macro id="710" versions="6.000 6.040" description="Call Macro 10" />
+  <macro id="711" versions="6.000 6.040" description="Call Macro 11" />
+  <macro id="712" versions="6.000 6.040" description="Call Macro 12" />
+  <macro id="713" versions="6.000 6.040" description="Call Macro 13" />
+  <macro id="714" versions="6.000 6.040" description="Call Macro 14" />
+  <macro id="715" versions="6.000 6.040" description="Call Macro 15" />
+  <macro id="716" versions="6.000 6.040" description="Call Macro 16" />
+  <macro id="717" versions="6.000 6.040" description="Call Macro 17" />
+  <macro id="718" versions="6.000 6.040" description="Call Macro 18" />
+  <macro id="719" versions="6.000 6.040" description="Call Macro 19" />
+  <macro id="720" versions="6.000 6.040" description="Call Macro 20" />
+  <macro id="721" versions="6.000 6.040" description="Call Macro 21" />
+  <macro id="722" versions="6.000 6.040" description="Call Macro 22" />
+  <macro id="723" versions="6.000 6.040" description="Call Macro 23" />
+  <macro id="724" versions="6.000 6.040" description="Call Macro 24" />
+  <macro id="725" versions="6.000 6.040" description="Call Macro 25" />
+  <macro id="726" versions="6.000 6.040" description="Call Macro 26" />
+  <macro id="727" versions="6.000 6.040" description="Call Macro 27" />
+  <macro id="728" versions="6.000 6.040" description="Call Macro 28" />
+  <macro id="729" versions="6.000 6.040" description="Call Macro 29" />
+  <macro id="730" versions="6.000 6.040" description="Call Macro 30" />
+  <macro id="731" versions="6.000 6.040" description="Call Macro 31" />
+  <macro id="732" versions="6.000 6.040" description="Call Macro 32" />
+  <macro id="733" versions="6.000 6.040" description="Call Macro 33" />
+  <macro id="734" versions="6.000 6.040" description="Call Macro 34" />
+  <macro id="735" versions="6.000 6.040" description="Call Macro 35" />
+  <macro id="736" versions="6.000 6.040" description="Call Macro 36" />
+  <macro id="737" versions="6.000 6.040" description="Call Macro 37" />
+  <macro id="738" versions="6.000 6.040" description="Call Macro 38" />
+  <macro id="739" versions="6.000 6.040" description="Call Macro 39" />
+  <macro id="740" versions="6.000 6.040" description="Call Macro 40" />
+  <macro id="741" versions="6.000 6.040" description="Call Macro 41" />
+  <macro id="742" versions="6.000 6.040" description="Call Macro 42" />
+  <macro id="743" versions="6.000 6.040" description="Call Macro 43" />
+  <macro id="744" versions="6.000 6.040" description="Call Macro 44" />
+  <macro id="745" versions="6.000 6.040" description="Call Macro 45" />
+  <macro id="746" versions="6.000 6.040" description="Call Macro 46" />
+  <macro id="747" versions="6.000 6.040" description="Call Macro 47" />
+  <macro id="748" versions="6.000 6.040" description="Call Macro 48" />
+  <macro id="749" versions="6.000 6.040" description="Call Macro 49" />
+  <macro id="750" versions="6.000 6.040" description="Call Macro 50" />
+  <macro id="751" versions="6.000 6.040" description="Call Macro 51" />
+  <macro id="752" versions="6.000 6.040" description="Call Macro 52" />
+  <macro id="753" versions="6.000 6.040" description="Call Macro 53" />
+  <macro id="754" versions="6.000 6.040" description="Call Macro 54" />
+  <macro id="755" versions="6.000 6.040" description="Call Macro 55" />
+  <macro id="756" versions="6.000 6.040" description="Call Macro 56" />
+  <macro id="757" versions="6.000 6.040" description="Call Macro 57" />
+  <macro id="758" versions="6.000 6.040" description="Call Macro 58" />
+  <macro id="759" versions="6.000 6.040" description="Call Macro 59" />
+  <macro id="760" versions="6.000 6.040" description="Call Macro 60" />
+  <macro id="761" versions="6.000 6.040" description="Call Macro 61" />
+  <macro id="762" versions="6.000 6.040" description="Call Macro 62" />
+  <macro id="763" versions="6.000 6.040" description="Call Macro 63" />
+  <macro id="764" versions="6.000 6.040" description="Call Macro 64" />
+  <macro id="766" versions="6.000 6.040" description="Call Macro 65" />
+  <macro id="767" versions="6.000 6.040" description="Call Macro 66" />
+  <macro id="768" versions="6.000 6.040" description="Call Macro 67" />
+  <macro id="769" versions="6.000 6.040" description="Call Macro 68" />
+  <macro id="770" versions="6.000 6.040" description="Call Macro 69" />
+  <macro id="771" versions="6.000 6.040" description="Call Macro 70" />
+  <macro id="772" versions="6.000 6.040" description="Call Macro 71" />
+  <macro id="773" versions="6.000 6.040" description="Call Macro 72" />
+  <macro id="774" versions="6.000 6.040" description="Call Macro 73" />
+  <macro id="775" versions="6.000 6.040" description="Call Macro 74" />
+  <macro id="776" versions="6.000 6.040" description="Call Macro 75" />
+  <macro id="777" versions="6.000 6.040" description="Call Macro 76" />
+  <macro id="778" versions="6.000 6.040" description="Call Macro 77" />
+  <macro id="779" versions="6.000 6.040" description="Call Macro 78" />
+  <macro id="780" versions="6.000 6.040" description="Call Macro 79" />
+  <macro id="781" versions="6.000 6.040" description="Call Macro 80" />
+  <macro id="782" versions="6.000 6.040" description="Call Macro 81" />
+  <macro id="783" versions="6.000 6.040" description="Call Macro 82" />
+  <macro id="784" versions="6.000 6.040" description="Call Macro 83" />
+  <macro id="785" versions="6.000 6.040" description="Call Macro 84" />
+  <macro id="786" versions="6.000 6.040" description="Call Macro 85" />
+  <macro id="787" versions="6.000 6.040" description="Call Macro 86" />
+  <macro id="788" versions="6.000 6.040" description="Call Macro 87" />
+  <macro id="789" versions="6.000 6.040" description="Call Macro 88" />
+  <macro id="790" versions="6.000 6.040" description="Call Macro 89" />
+  <macro id="791" versions="6.000 6.040" description="Call Macro 90" />
+</macros>


### PR DESCRIPTION
James, the majority of the changes are all in the Form1.cs file. There are now 40 Setpoints possible. Setpoints can have either 7 or 8 column to accommodate Month of Year in the scheduler.

I made a version change in the Assembly.cs file only. The previous version I had changed the copyright. In this one, I only changed the version info and left the copyright at 2015.

Form1.Designer.cs should be the same. The issue with VS2017 is a default style rule which wants 15 items to start with a capital letter. Compiles just fine.